### PR TITLE
Copy README.md to dist-publish

### DIFF
--- a/packages/xrpl-connect/vite.config.ts
+++ b/packages/xrpl-connect/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
+import { copyFileSync, existsSync } from 'fs';
 import inject from '@rollup/plugin-inject';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -22,6 +23,20 @@ export default defineConfig({
       '@xrpl-connect/adapter-walletconnect': resolve(__dirname, '../adapters/walletconnect/src/index.ts'),
     },
   },
+  plugins: [
+    {
+      name: 'copy-readme',
+      closeBundle() {
+        const rootReadmePath = resolve(__dirname, '../../README.md');
+        const distReadmePath = resolve(__dirname, 'dist-publish/README.md');
+
+        if (existsSync(rootReadmePath)) {
+          copyFileSync(rootReadmePath, distReadmePath);
+          console.log('✓ Copied README.md to dist-publish/');
+        }
+      },
+    },
+  ],
   build: {
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),


### PR DESCRIPTION
This change will make the README.md at the repository root appear on the npm package page for future versions.

https://www.npmjs.com/package/xrpl-connect