### PR TITLE
fix(ui): detach event listeners on disconnect and view change

### DIFF
--- a/packages/ui/src/services/EventHandler.ts
+++ b/packages/ui/src/services/EventHandler.ts
@@ -5,19 +5,44 @@ import { isMobile } from '../utils';
 
 const logger = createLogger('[EventHandler]');
 
+interface TrackedListener {
+  target: EventTarget;
+  type: string;
+  handler: EventListener;
+}
+
 export class EventHandler {
+  private listeners: TrackedListener[] = [];
+
   constructor(
     private component: HTMLElement,
     private walletService: WalletService
   ) {}
 
+  private add(target: EventTarget | null | undefined, type: string, handler: EventListener) {
+    if (!target) return;
+    target.addEventListener(type, handler);
+    this.listeners.push({ target, type, handler });
+  }
+
+  public detachEventListeners() {
+    for (const { target, type, handler } of this.listeners) {
+      target.removeEventListener(type, handler);
+    }
+    this.listeners = [];
+  }
+
   public attachEventListeners() {
+    // Remove any previously tracked listeners before re-binding, otherwise
+    // every render() would stack a new copy on the same (or re-created) elements.
+    this.detachEventListeners();
+
     const shadow = (this.component as any).shadow as ShadowRoot;
     const overlayRoot: ShadowRoot | null = (this.component as any).getOverlayRoot();
     const accountRoot: ShadowRoot | null = (this.component as any).getAccountModalRoot();
 
     // Connect wallet button (in component shadow root)
-    shadow.querySelector('#connect-wallet-button')?.addEventListener('click', async () => {
+    this.add(shadow.querySelector('#connect-wallet-button'), 'click', async () => {
       const isConnected = (this.component as any).walletManager?.connected || false;
 
       if (isConnected) {
@@ -30,24 +55,24 @@ export class EventHandler {
     });
 
     // Account modal close button (in account modal portal)
-    accountRoot?.querySelector('#account-modal-close')?.addEventListener('click', () => {
+    this.add(accountRoot?.querySelector('#account-modal-close'), 'click', () => {
       (this.component as any).closeAccountModal();
     });
 
     // Account modal disconnect button (in account modal portal)
-    accountRoot?.querySelector('#account-modal-disconnect')?.addEventListener('click', () => {
+    this.add(accountRoot?.querySelector('#account-modal-disconnect'), 'click', () => {
       (this.component as any).disconnectFromAccountModal();
     });
 
     // Account modal overlay click (in account modal portal)
-    accountRoot?.querySelector('#account-modal-overlay')?.addEventListener('click', (e: Event) => {
+    this.add(accountRoot?.querySelector('#account-modal-overlay'), 'click', (e: Event) => {
       if (e.target === e.currentTarget) {
         (this.component as any).closeAccountModal();
       }
     });
 
     // Copy account address button (in account modal portal)
-    accountRoot?.querySelector('#copy-account-address')?.addEventListener('click', async () => {
+    this.add(accountRoot?.querySelector('#copy-account-address'), 'click', async () => {
       const address = (this.component as any).walletManager?.account?.address;
       if (address) {
         try {
@@ -68,35 +93,35 @@ export class EventHandler {
     });
 
     // Close button (in overlay portal)
-    overlayRoot
-      ?.querySelector('.close-button')
-      ?.addEventListener('click', () => (this.component as any).close());
+    this.add(overlayRoot?.querySelector('.close-button'), 'click', () =>
+      (this.component as any).close()
+    );
 
     // Overlay click (in overlay portal)
-    overlayRoot?.querySelector('.overlay')?.addEventListener('click', (e: Event) => {
+    this.add(overlayRoot?.querySelector('.overlay'), 'click', (e: Event) => {
       if (e.target === e.currentTarget) (this.component as any).close();
     });
 
     // Wallet buttons (in overlay portal)
     overlayRoot?.querySelectorAll('[data-wallet-id]').forEach((button: Element) => {
-      button.addEventListener('click', () => {
+      this.add(button, 'click', () => {
         const walletId = (button as HTMLElement).dataset.walletId;
         if (walletId) this.walletService.connectWallet(walletId);
       });
     });
 
     // Back button (QR view, in overlay portal)
-    overlayRoot?.querySelector('#back-button')?.addEventListener('click', () => {
+    this.add(overlayRoot?.querySelector('#back-button'), 'click', () => {
       (this.component as any).showWalletList();
     });
 
     // Back button (Loading view, in overlay portal)
-    overlayRoot?.querySelector('#loading-back-button')?.addEventListener('click', () => {
+    this.add(overlayRoot?.querySelector('#loading-back-button'), 'click', () => {
       (this.component as any).showWalletList();
     });
 
     // Copy button (QR view, in overlay portal)
-    overlayRoot?.querySelector('#copy-button')?.addEventListener('click', async () => {
+    this.add(overlayRoot?.querySelector('#copy-button'), 'click', async () => {
       if ((this.component as any).qrCodeData?.uri) {
         try {
           await navigator.clipboard.writeText((this.component as any).qrCodeData.uri);
@@ -115,7 +140,7 @@ export class EventHandler {
     });
 
     // Deeplink button (in overlay portal)
-    overlayRoot?.querySelector('#deeplink-button')?.addEventListener('click', () => {
+    this.add(overlayRoot?.querySelector('#deeplink-button'), 'click', () => {
       if ((this.component as any).qrCodeData?.uri && (this.component as any).qrCodeData?.walletId) {
         const adapter = (this.component as any).walletManager?.wallets.find(
           (w: any) => w.id === (this.component as any).qrCodeData?.walletId
@@ -139,25 +164,25 @@ export class EventHandler {
     });
 
     // Error retry button (in overlay portal)
-    overlayRoot?.querySelector('#error-retry-button')?.addEventListener('click', () => {
+    this.add(overlayRoot?.querySelector('#error-retry-button'), 'click', () => {
       if ((this.component as any).errorData?.walletId) {
         this.walletService.connectWallet((this.component as any).errorData.walletId);
       }
     });
 
     // Error back button (in overlay portal)
-    overlayRoot?.querySelector('#error-back-button')?.addEventListener('click', () => {
+    this.add(overlayRoot?.querySelector('#error-back-button'), 'click', () => {
       (this.component as any).showWalletList();
     });
 
     // Account selection back button (in overlay portal)
-    overlayRoot?.querySelector('#account-selection-back-button')?.addEventListener('click', () => {
+    this.add(overlayRoot?.querySelector('#account-selection-back-button'), 'click', () => {
       (this.component as any).showWalletList();
     });
 
     // Account selection buttons (in overlay portal)
     overlayRoot?.querySelectorAll('.account-button').forEach((button: Element) => {
-      button.addEventListener('click', () => {
+      this.add(button, 'click', () => {
         const accountIndex = parseInt((button as HTMLElement).dataset.accountIndex || '0', 10);
         logger.debug('Account selected:', accountIndex);
         this.walletService.connectWithLedgerAccount(accountIndex);
@@ -165,7 +190,7 @@ export class EventHandler {
     });
 
     // Custom derivation path button (in overlay portal)
-    overlayRoot?.querySelector('#custom-path-connect-button')?.addEventListener('click', () => {
+    this.add(overlayRoot?.querySelector('#custom-path-connect-button'), 'click', () => {
       const input = overlayRoot?.querySelector(
         '#custom-derivation-path'
       ) as HTMLInputElement | null;

--- a/packages/ui/src/wallet-connector.ts
+++ b/packages/ui/src/wallet-connector.ts
@@ -94,6 +94,12 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
     private accountBalance: string | null = null; // Cached account balance
     private overlayPortal: HTMLDivElement | null = null;
     private accountModalPortal: HTMLDivElement | null = null;
+    private styleObserver: MutationObserver | null = null;
+    private walletManagerHandlers: {
+      connect: () => void;
+      disconnect: () => void;
+      accountChanged: () => void;
+    } | null = null;
 
     // Observed attributes
     static get observedAttributes() {
@@ -112,17 +118,30 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
       requestAnimationFrame(() => this.updateDerivedColors());
 
       // Observe style attribute changes for CSS variable updates
-      const styleObserver = new MutationObserver(() => {
+      this.styleObserver?.disconnect();
+      this.styleObserver = new MutationObserver(() => {
         this.updateDerivedColors();
       });
 
-      styleObserver.observe(this, {
+      this.styleObserver.observe(this, {
         attributes: true,
         attributeFilter: ['style'],
       });
     }
 
     disconnectedCallback() {
+      this.eventHandler?.detachEventListeners();
+
+      if (this.walletManager && this.walletManagerHandlers) {
+        this.walletManager.off('connect', this.walletManagerHandlers.connect);
+        this.walletManager.off('disconnect', this.walletManagerHandlers.disconnect);
+        this.walletManager.off('accountChanged', this.walletManagerHandlers.accountChanged);
+        this.walletManagerHandlers = null;
+      }
+
+      this.styleObserver?.disconnect();
+      this.styleObserver = null;
+
       this.overlayPortal?.remove();
       this.overlayPortal = null;
       this.accountModalPortal?.remove();
@@ -201,23 +220,34 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
      * Set the WalletManager instance
      */
     setWalletManager(manager: WalletManager) {
+      // If a previous manager was wired up, drop its subscriptions before swapping.
+      if (this.walletManager && this.walletManagerHandlers) {
+        this.walletManager.off('connect', this.walletManagerHandlers.connect);
+        this.walletManager.off('disconnect', this.walletManagerHandlers.disconnect);
+        this.walletManager.off('accountChanged', this.walletManagerHandlers.accountChanged);
+      }
+
       this.walletManager = manager;
       this.walletService = new WalletService(this.walletManager, this);
       this.eventHandler = new EventHandler(this, this.walletService);
 
-      // Listen to wallet manager events
-      this.walletManager.on('connect', () => {
-        this.close();
-        this.render(); // Re-render to update button
-      });
+      // Listen to wallet manager events — keep refs so we can detach on disconnect.
+      this.walletManagerHandlers = {
+        connect: () => {
+          this.close();
+          this.render(); // Re-render to update button
+        },
+        disconnect: () => {
+          this.render(); // Re-render to update button
+        },
+        accountChanged: () => {
+          this.render(); // Re-render to update button with new account
+        },
+      };
 
-      this.walletManager.on('disconnect', () => {
-        this.render(); // Re-render to update button
-      });
-
-      this.walletManager.on('accountChanged', () => {
-        this.render(); // Re-render to update button with new account
-      });
+      this.walletManager.on('connect', this.walletManagerHandlers.connect);
+      this.walletManager.on('disconnect', this.walletManagerHandlers.disconnect);
+      this.walletManager.on('accountChanged', this.walletManagerHandlers.accountChanged);
 
       this.render();
 

--- a/packages/ui/tests/EventHandler.test.ts
+++ b/packages/ui/tests/EventHandler.test.ts
@@ -1,8 +1,28 @@
 import { describe, it, expect, vi } from 'vitest';
 import { EventHandler } from '../src/services/EventHandler';
 
+/**
+ * Build a minimal mock component whose shadow / overlay / account roots return
+ * the same `host` element for every selector. Counting listeners on a single
+ * real DOM node is enough to detect both the original leak (attach without
+ * detach) and the regression we are guarding against (re-attach without
+ * dropping the previous bindings).
+ */
+function makeComponentBackedBy(host: HTMLElement) {
+  const root = {
+    querySelector: vi.fn(() => host),
+    querySelectorAll: vi.fn(() => [] as Element[]),
+  };
+  return {
+    shadow: root,
+    getOverlayRoot: vi.fn(() => root),
+    getAccountModalRoot: vi.fn(() => root),
+    open: vi.fn(),
+  };
+}
+
 describe('EventHandler', () => {
-  it('should attach event listeners', () => {
+  it('attaches event listeners', () => {
     const mockPortalRoot = {
       querySelector: vi.fn(),
       querySelectorAll: vi.fn(() => []),
@@ -20,6 +40,7 @@ describe('EventHandler', () => {
 
     const mockButton = {
       addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
     };
     mockComponent.shadow.querySelector.mockReturnValue(mockButton);
 
@@ -27,5 +48,58 @@ describe('EventHandler', () => {
 
     expect(mockComponent.shadow.querySelector).toHaveBeenCalledWith('#connect-wallet-button');
     expect(mockButton.addEventListener).toHaveBeenCalledWith('click', expect.any(Function));
+  });
+
+  it('removes every attached listener on detach', () => {
+    const host = document.createElement('div');
+    let net = 0;
+    const origAdd = host.addEventListener.bind(host);
+    const origRemove = host.removeEventListener.bind(host);
+    host.addEventListener = ((type: string, handler: any, opts?: any) => {
+      net++;
+      return origAdd(type, handler, opts);
+    }) as typeof host.addEventListener;
+    host.removeEventListener = ((type: string, handler: any, opts?: any) => {
+      net--;
+      return origRemove(type, handler, opts);
+    }) as typeof host.removeEventListener;
+
+    const eventHandler = new EventHandler(makeComponentBackedBy(host) as any, {} as any);
+
+    eventHandler.attachEventListeners();
+    expect(net).toBeGreaterThan(0);
+
+    eventHandler.detachEventListeners();
+    expect(net).toBe(0);
+  });
+
+  it('does not accumulate listeners across repeated attach calls', () => {
+    const host = document.createElement('div');
+    let net = 0;
+    const origAdd = host.addEventListener.bind(host);
+    const origRemove = host.removeEventListener.bind(host);
+    host.addEventListener = ((type: string, handler: any, opts?: any) => {
+      net++;
+      return origAdd(type, handler, opts);
+    }) as typeof host.addEventListener;
+    host.removeEventListener = ((type: string, handler: any, opts?: any) => {
+      net--;
+      return origRemove(type, handler, opts);
+    }) as typeof host.removeEventListener;
+
+    const eventHandler = new EventHandler(makeComponentBackedBy(host) as any, {} as any);
+
+    eventHandler.attachEventListeners();
+    const afterFirst = net;
+
+    // Re-attach simulates what render() does on every view change. Without the
+    // detach-before-attach guard, listeners would stack on the same element.
+    eventHandler.attachEventListeners();
+    eventHandler.attachEventListeners();
+
+    expect(net).toBe(afterFirst);
+
+    eventHandler.detachEventListeners();
+    expect(net).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- `EventHandler` now tracks every listener it binds and exposes `detachEventListeners()`; each `attachEventListeners()` pass runs detach first so the per-render re-binding in `wallet-connector.ts` no longer stacks duplicates on transient shadow-DOM elements.
- `disconnectedCallback()` cleans up: drops the `EventHandler` listeners, removes the `walletManager` subscriptions via stored handler refs (`connect` / `disconnect` / `accountChanged`), and disconnects the style `MutationObserver`. Nothing survives unmounting the custom element.
- Added unit tests asserting net listener count on a host element across `attach` → `detach`, and across repeated `attach` calls (regression guard for the original leak).

## Test plan
- [x] `pnpm --filter @xrpl-connect/ui test --run` — 4/4 pass, including the new attach/detach and re-attach tests
- [x] `pnpm --filter @xrpl-connect/ui type-check`
- [x] `pnpm --filter @xrpl-connect/ui lint` — 0 errors (pre-existing `any` warnings only)
- [ ] Manual smoke: mount + unmount `<xrpl-wallet-connector>` in an SPA, then open/close/switch views; verify no listener accumulation in DevTools and no leftover modal portals after disconnect

Fixes #54