### PR TITLE
refactor(ui): replace pervasive any with typed component context

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,4 +42,12 @@ export default defineConfig([{
           caughtErrors: "none",
         }],
     },
+}, {
+    // The UI package is held to a stricter bar: no `any`. The web component is
+    // the most-exercised public surface, so untyped escape hatches there hide
+    // missing adapter capability declarations.
+    files: ["packages/ui/src/**/*.ts"],
+    rules: {
+        "@typescript-eslint/no-explicit-any": "error",
+    },
 }]);

--- a/packages/adapters/walletconnect/src/walletconnect-adapter.ts
+++ b/packages/adapters/walletconnect/src/walletconnect-adapter.ts
@@ -9,6 +9,7 @@ import type {
   WalletAdapter,
   AccountInfo,
   ConnectOptions,
+  NetworkConfig,
   NetworkInfo,
   Transaction,
   SignedTransaction,
@@ -138,7 +139,7 @@ export class WalletConnectAdapter implements WalletAdapter {
    * This generates the QR code URI before the user clicks WalletConnect
    * Based on ConnectKit's eager initialization pattern
    */
-  async preInitialize(projectId?: string, network?: string): Promise<void> {
+  async preInitialize(projectId?: string, network?: NetworkConfig): Promise<void> {
     const pid = projectId || this.options.projectId;
 
     if (!pid) {

--- a/packages/core/src/wallet-manager.ts
+++ b/packages/core/src/wallet-manager.ts
@@ -13,6 +13,7 @@ import type {
   SubmittedTransaction,
   WalletEvent,
   ConnectOptions,
+  NetworkConfig,
   NetworkInfo,
   StoredState,
 } from './types';
@@ -292,6 +293,13 @@ export class WalletManager extends EventEmitter<WalletEvent> {
    */
   get wallets(): WalletAdapter[] {
     return Array.from(this.adapters.values());
+  }
+
+  /**
+   * Default network configured on the manager, if any.
+   */
+  get defaultNetwork(): NetworkConfig | undefined {
+    return this.options.network;
   }
 
   /**

--- a/packages/ui/src/services/EventHandler.ts
+++ b/packages/ui/src/services/EventHandler.ts
@@ -1,6 +1,7 @@
 import { WalletService } from './WalletService';
 import { TIMINGS } from '../constants';
 import { createLogger } from '@xrpl-connect/core';
+import { isDeepLinkAdapter, type WalletConnectorContext } from '../types';
 import { isMobile } from '../utils';
 
 const logger = createLogger('[EventHandler]');
@@ -15,7 +16,7 @@ export class EventHandler {
   private listeners: TrackedListener[] = [];
 
   constructor(
-    private component: HTMLElement,
+    private component: WalletConnectorContext,
     private walletService: WalletService
   ) {}
 
@@ -37,43 +38,43 @@ export class EventHandler {
     // every render() would stack a new copy on the same (or re-created) elements.
     this.detachEventListeners();
 
-    const shadow = (this.component as any).shadow as ShadowRoot;
-    const overlayRoot: ShadowRoot | null = (this.component as any).getOverlayRoot();
-    const accountRoot: ShadowRoot | null = (this.component as any).getAccountModalRoot();
+    const shadow = this.component.shadow;
+    const overlayRoot = this.component.getOverlayRoot();
+    const accountRoot = this.component.getAccountModalRoot();
 
     // Connect wallet button (in component shadow root)
     this.add(shadow.querySelector('#connect-wallet-button'), 'click', async () => {
-      const isConnected = (this.component as any).walletManager?.connected || false;
+      const isConnected = this.component.walletManager?.connected ?? false;
 
       if (isConnected) {
         // Open account details modal
-        (this.component as any).openAccountModal();
+        this.component.openAccountModal();
       } else {
         // Open connection modal
-        (this.component as any).open();
+        await this.component.open();
       }
     });
 
     // Account modal close button (in account modal portal)
     this.add(accountRoot?.querySelector('#account-modal-close'), 'click', () => {
-      (this.component as any).closeAccountModal();
+      this.component.closeAccountModal();
     });
 
     // Account modal disconnect button (in account modal portal)
     this.add(accountRoot?.querySelector('#account-modal-disconnect'), 'click', () => {
-      (this.component as any).disconnectFromAccountModal();
+      this.component.disconnectFromAccountModal();
     });
 
     // Account modal overlay click (in account modal portal)
     this.add(accountRoot?.querySelector('#account-modal-overlay'), 'click', (e: Event) => {
       if (e.target === e.currentTarget) {
-        (this.component as any).closeAccountModal();
+        this.component.closeAccountModal();
       }
     });
 
     // Copy account address button (in account modal portal)
     this.add(accountRoot?.querySelector('#copy-account-address'), 'click', async () => {
-      const address = (this.component as any).walletManager?.account?.address;
+      const address = this.component.walletManager?.account?.address;
       if (address) {
         try {
           await navigator.clipboard.writeText(address);
@@ -93,13 +94,13 @@ export class EventHandler {
     });
 
     // Close button (in overlay portal)
-    this.add(overlayRoot?.querySelector('.close-button'), 'click', () =>
-      (this.component as any).close()
-    );
+    this.add(overlayRoot?.querySelector('.close-button'), 'click', () => {
+      this.component.close();
+    });
 
     // Overlay click (in overlay portal)
     this.add(overlayRoot?.querySelector('.overlay'), 'click', (e: Event) => {
-      if (e.target === e.currentTarget) (this.component as any).close();
+      if (e.target === e.currentTarget) this.component.close();
     });
 
     // Wallet buttons (in overlay portal)
@@ -112,19 +113,20 @@ export class EventHandler {
 
     // Back button (QR view, in overlay portal)
     this.add(overlayRoot?.querySelector('#back-button'), 'click', () => {
-      (this.component as any).showWalletList();
+      this.component.showWalletList();
     });
 
     // Back button (Loading view, in overlay portal)
     this.add(overlayRoot?.querySelector('#loading-back-button'), 'click', () => {
-      (this.component as any).showWalletList();
+      this.component.showWalletList();
     });
 
     // Copy button (QR view, in overlay portal)
     this.add(overlayRoot?.querySelector('#copy-button'), 'click', async () => {
-      if ((this.component as any).qrCodeData?.uri) {
+      const uri = this.component.qrCodeData?.uri;
+      if (uri) {
         try {
-          await navigator.clipboard.writeText((this.component as any).qrCodeData.uri);
+          await navigator.clipboard.writeText(uri);
           const btn = overlayRoot?.querySelector('#copy-button') as HTMLButtonElement | null;
           if (btn) {
             btn.textContent = 'Copied!';
@@ -141,16 +143,17 @@ export class EventHandler {
 
     // Deeplink button (in overlay portal)
     this.add(overlayRoot?.querySelector('#deeplink-button'), 'click', () => {
-      if ((this.component as any).qrCodeData?.uri && (this.component as any).qrCodeData?.walletId) {
-        const adapter = (this.component as any).walletManager?.wallets.find(
-          (w: any) => w.id === (this.component as any).qrCodeData?.walletId
+      const qrCodeData = this.component.qrCodeData;
+      if (qrCodeData?.uri && qrCodeData.walletId) {
+        const adapter = this.component.walletManager?.wallets.find(
+          (w) => w.id === qrCodeData.walletId
         );
 
-        let deepLink = (this.component as any).qrCodeData.uri;
+        let deepLink = qrCodeData.uri;
 
         // Try to get proper deep link from adapter
-        if (adapter && typeof (adapter as any).getDeepLinkURI === 'function') {
-          deepLink = (adapter as any).getDeepLinkURI((this.component as any).qrCodeData.uri);
+        if (adapter && isDeepLinkAdapter(adapter)) {
+          deepLink = adapter.getDeepLinkURI(qrCodeData.uri);
         }
 
         // Detect mobile and open deep link
@@ -165,19 +168,20 @@ export class EventHandler {
 
     // Error retry button (in overlay portal)
     this.add(overlayRoot?.querySelector('#error-retry-button'), 'click', () => {
-      if ((this.component as any).errorData?.walletId) {
-        this.walletService.connectWallet((this.component as any).errorData.walletId);
+      const errorWalletId = this.component.errorData?.walletId;
+      if (errorWalletId) {
+        this.walletService.connectWallet(errorWalletId);
       }
     });
 
     // Error back button (in overlay portal)
     this.add(overlayRoot?.querySelector('#error-back-button'), 'click', () => {
-      (this.component as any).showWalletList();
+      this.component.showWalletList();
     });
 
     // Account selection back button (in overlay portal)
     this.add(overlayRoot?.querySelector('#account-selection-back-button'), 'click', () => {
-      (this.component as any).showWalletList();
+      this.component.showWalletList();
     });
 
     // Account selection buttons (in overlay portal)

--- a/packages/ui/src/services/WalletService.ts
+++ b/packages/ui/src/services/WalletService.ts
@@ -1,17 +1,39 @@
-import type { WalletManager } from '@xrpl-connect/core';
+import type { ConnectOptions, WalletManager } from '@xrpl-connect/core';
 import { createLogger } from '@xrpl-connect/core';
 import { isSafari, isMobile, delay } from '../utils';
 import { TIMINGS, ERROR_CODES } from '../constants';
+import {
+  isModalConfigurableAdapter,
+  isMultiAccountAdapter,
+  type LedgerConnectOptions,
+  type WalletConnectConnectOptions,
+  type WalletConnectorContext,
+} from '../types';
 
 const logger = createLogger('[WalletService]');
+
+/**
+ * Narrow `unknown` thrown values to the bits we read for error display.
+ */
+interface ErrorLike {
+  code?: string | number;
+  message?: string;
+}
+
+function asErrorLike(value: unknown): ErrorLike {
+  if (value && typeof value === 'object') {
+    return value as ErrorLike;
+  }
+  return {};
+}
 
 export class WalletService {
   constructor(
     private walletManager: WalletManager,
-    private component: HTMLElement
+    private component: WalletConnectorContext
   ) {}
 
-  async connectWallet(walletId: string, options?: any) {
+  async connectWallet(walletId: string, options?: ConnectOptions) {
     if (!this.walletManager) {
       logger.error('WalletManager not set');
       return;
@@ -28,9 +50,12 @@ export class WalletService {
 
       if (walletId === 'walletconnect') {
         // Check if wallet adapter supports modal
-        const wcAdapter = wallet as any;
-        const useModal = wcAdapter.options?.useModal ?? false;
-        const modalMode = wcAdapter.options?.modalMode ?? 'mobile-only';
+        const useModal = isModalConfigurableAdapter(wallet)
+          ? (wallet.options?.useModal ?? false)
+          : false;
+        const modalMode = isModalConfigurableAdapter(wallet)
+          ? (wallet.options?.modalMode ?? 'mobile-only')
+          : 'mobile-only';
 
         const shouldUseModal =
           useModal && (modalMode === 'always' || (modalMode === 'mobile-only' && isMobile()));
@@ -44,7 +69,7 @@ export class WalletService {
           // This gives users the impression they're still in the connection flow
 
           // Show loading state first (with spinning animation like Xaman)
-          (this.component as any).showLoadingView(walletId, wallet.name, wallet.icon);
+          this.component.showLoadingView(walletId, wallet.name, wallet.icon);
 
           this.component.dispatchEvent(new CustomEvent('connecting', { detail: { walletId } }));
 
@@ -56,20 +81,20 @@ export class WalletService {
           this.component.dispatchEvent(new CustomEvent('connected', { detail: { walletId } }));
 
           // Close our modal after successful connection
-          (this.component as any).close();
+          this.component.close();
         } else {
           // ===== USE CUSTOM QR (Desktop mode) =====
           logger.debug('Using custom QR code (desktop mode)');
 
           // Show QR code view first for WalletConnect
-          (this.component as any).showQRCodeView(walletId);
+          this.component.showQRCodeView(walletId);
 
           // Set up QR code callback
-          const connectOptions = {
+          const connectOptions: ConnectOptions<WalletConnectConnectOptions> = {
             ...options,
             onQRCode: (uri: string) => {
               logger.debug('QR code callback received:', uri.substring(0, 50) + '...');
-              (this.component as any).setQRCode(walletId, uri);
+              this.component.setQRCode(walletId, uri);
             },
           };
 
@@ -87,8 +112,12 @@ export class WalletService {
           );
         }
 
+        if (!isMultiAccountAdapter(wallet)) {
+          throw new Error(`${wallet.name} does not support account enumeration`);
+        }
+
         // Show loading while fetching accounts
-        (this.component as any).showLoadingView(walletId, wallet.name, wallet.icon);
+        this.component.showLoadingView(walletId, wallet.name, wallet.icon);
 
         // Small delay for UI
         if (!isSafari()) {
@@ -97,16 +126,11 @@ export class WalletService {
 
         // Fetch accounts from Ledger
         logger.debug('Fetching Ledger accounts...');
-        const accounts = await (wallet as any).getAccounts(5, 0);
+        const accounts = await wallet.getAccounts(5, 0);
         logger.debug('Fetched accounts:', accounts);
 
         // Show account selection view
-        (this.component as any).showAccountSelectionView(
-          walletId,
-          wallet.name,
-          wallet.icon,
-          accounts
-        );
+        this.component.showAccountSelectionView(walletId, wallet.name, wallet.icon, accounts);
       } else {
         // For extension wallets, check availability first
         const isAvailable = await wallet.isAvailable();
@@ -117,7 +141,7 @@ export class WalletService {
         }
 
         // Show loading state
-        (this.component as any).showLoadingView(walletId, wallet.name, wallet.icon);
+        this.component.showLoadingView(walletId, wallet.name, wallet.icon);
 
         this.component.dispatchEvent(new CustomEvent('connecting', { detail: { walletId } }));
 
@@ -130,22 +154,23 @@ export class WalletService {
         await this.walletManager.connect(walletId, options);
         this.component.dispatchEvent(new CustomEvent('connected', { detail: { walletId } }));
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const err = asErrorLike(error);
       const wallet = this.walletManager?.wallets.find((w) => w.id === walletId);
 
       // Detect error type based on error code (ConnectKit pattern)
-      let errorMessage = error.message || 'An unexpected error occurred';
+      let errorMessage = err.message || 'An unexpected error occurred';
       let errorType: 'rejected' | 'unavailable' | 'failed' = 'failed';
 
       // Check for specific error codes
       if (
-        error.code === ERROR_CODES.USER_REJECTED ||
+        err.code === ERROR_CODES.USER_REJECTED ||
         errorMessage.toLowerCase().includes('user rejected')
       ) {
         errorType = 'rejected';
         errorMessage = 'Connection request was cancelled';
       } else if (
-        error.code === ERROR_CODES.POPUP_CLOSED ||
+        err.code === ERROR_CODES.POPUP_CLOSED ||
         errorMessage.toLowerCase().includes('already pending')
       ) {
         errorType = 'unavailable';
@@ -154,13 +179,9 @@ export class WalletService {
         errorType = 'unavailable';
       }
 
-      logger.debug('Connection error type:', errorType, 'Code:', error.code);
+      logger.debug('Connection error type:', errorType, 'Code:', err.code);
 
-      (this.component as any).showErrorView(
-        walletId,
-        wallet?.name || 'Wallet',
-        new Error(errorMessage)
-      );
+      this.component.showErrorView(walletId, wallet?.name || 'Wallet', new Error(errorMessage));
       this.component.dispatchEvent(
         new CustomEvent('error', { detail: { error, walletId, errorType } })
       );
@@ -169,13 +190,13 @@ export class WalletService {
   }
 
   async connectWithLedgerAccount(accountIndex: number) {
-    if (!this.walletManager || !(this.component as any).accountSelectionData) return;
+    if (!this.walletManager || !this.component.accountSelectionData) return;
 
-    const { walletId, walletName, walletIcon } = (this.component as any).accountSelectionData;
+    const { walletId, walletName, walletIcon } = this.component.accountSelectionData;
 
     try {
       // Show loading state
-      (this.component as any).showLoadingView(walletId, walletName, walletIcon);
+      this.component.showLoadingView(walletId, walletName, walletIcon);
 
       // Small delay for UI
       if (!isSafari()) {
@@ -187,27 +208,28 @@ export class WalletService {
         new CustomEvent('connecting', { detail: { walletId, accountIndex } })
       );
 
-      // Connect with selected account index
-      await this.walletManager.connect(walletId, { accountIndex } as any); // Custom options for Ledger
+      const ledgerOptions: ConnectOptions<LedgerConnectOptions> = { accountIndex };
+      await this.walletManager.connect(walletId, ledgerOptions);
 
       this.component.dispatchEvent(
         new CustomEvent('connected', { detail: { walletId, accountIndex } })
       );
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const err = asErrorLike(error);
       // Handle error - show error view
-      let errorMessage = error.message || 'An unexpected error occurred';
+      let errorMessage = err.message || 'An unexpected error occurred';
       let errorType: 'rejected' | 'unavailable' | 'failed' = 'failed';
 
       if (
-        error.code === ERROR_CODES.USER_REJECTED ||
+        err.code === ERROR_CODES.USER_REJECTED ||
         errorMessage.toLowerCase().includes('user rejected')
       ) {
         errorType = 'rejected';
         errorMessage = 'Connection request was cancelled';
       }
 
-      logger.debug('Connection error type:', errorType, 'Code:', error.code);
-      (this.component as any).showErrorView(walletId, walletName, new Error(errorMessage));
+      logger.debug('Connection error type:', errorType, 'Code:', err.code);
+      this.component.showErrorView(walletId, walletName, new Error(errorMessage));
       this.component.dispatchEvent(
         new CustomEvent('error', { detail: { error, walletId, errorType } })
       );
@@ -216,9 +238,9 @@ export class WalletService {
   }
 
   async connectWithCustomDerivationPath(derivationPath: string) {
-    if (!this.walletManager || !(this.component as any).accountSelectionData) return;
+    if (!this.walletManager || !this.component.accountSelectionData) return;
 
-    const { walletId, walletName, walletIcon } = (this.component as any).accountSelectionData;
+    const { walletId, walletName, walletIcon } = this.component.accountSelectionData;
 
     try {
       // Validate derivation path format
@@ -228,7 +250,7 @@ export class WalletService {
       }
 
       // Show loading state
-      (this.component as any).showLoadingView(walletId, walletName, walletIcon);
+      this.component.showLoadingView(walletId, walletName, walletIcon);
 
       // Small delay for UI
       if (!isSafari()) {
@@ -240,27 +262,28 @@ export class WalletService {
         new CustomEvent('connecting', { detail: { walletId, derivationPath } })
       );
 
-      // Connect with custom derivation path
-      await this.walletManager.connect(walletId, { derivationPath } as any); // Custom options for Ledger
+      const ledgerOptions: ConnectOptions<LedgerConnectOptions> = { derivationPath };
+      await this.walletManager.connect(walletId, ledgerOptions);
 
       this.component.dispatchEvent(
         new CustomEvent('connected', { detail: { walletId, derivationPath } })
       );
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const err = asErrorLike(error);
       // Handle error - show error view
-      let errorMessage = error.message || 'An unexpected error occurred';
+      let errorMessage = err.message || 'An unexpected error occurred';
       let errorType: 'rejected' | 'unavailable' | 'failed' = 'failed';
 
       if (
-        error.code === ERROR_CODES.USER_REJECTED ||
+        err.code === ERROR_CODES.USER_REJECTED ||
         errorMessage.toLowerCase().includes('user rejected')
       ) {
         errorType = 'rejected';
         errorMessage = 'Connection request was cancelled';
       }
 
-      logger.debug('Connection error type:', errorType, 'Code:', error.code);
-      (this.component as any).showErrorView(walletId, walletName, new Error(errorMessage));
+      logger.debug('Connection error type:', errorType, 'Code:', err.code);
+      this.component.showErrorView(walletId, walletName, new Error(errorMessage));
       this.component.dispatchEvent(
         new CustomEvent('error', { detail: { error, walletId, errorType } })
       );

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -1,0 +1,184 @@
+/**
+ * Internal types for the UI package.
+ *
+ * Defines a typed surface for the host web component (`WalletConnectorContext`)
+ * so services can depend on a stable interface instead of casting through `any`,
+ * plus capability interfaces for optional adapter methods (`preInitialize`,
+ * `getDeepLinkURI`, `checkXamanState`, `getAccounts`) that aren't part of the
+ * base `WalletAdapter` contract.
+ */
+
+import type { AccountInfo, NetworkConfig, WalletAdapter, WalletManager } from '@xrpl-connect/core';
+
+/**
+ * A single derived account returned by Ledger's `getAccounts`.
+ */
+export interface LedgerAccount {
+  address: string;
+  publicKey: string;
+  path: string;
+  index: number;
+}
+
+/**
+ * Ledger-specific connect options (passed through `ConnectOptions`).
+ *
+ * Carries an index signature so it satisfies the `Record<string, unknown>`
+ * constraint on `ConnectOptions`'s generic parameter.
+ */
+export type LedgerConnectOptions = {
+  accountIndex?: number;
+  derivationPath?: string;
+  [key: string]: unknown;
+};
+
+/**
+ * WalletConnect-specific connect options.
+ */
+export type WalletConnectConnectOptions = {
+  onQRCode?: (uri: string) => void;
+  [key: string]: unknown;
+};
+
+export interface QRCodeData {
+  walletId: string;
+  uri: string;
+}
+
+export interface LoadingData {
+  walletId: string;
+  walletName: string;
+  walletIcon?: string;
+}
+
+export interface ErrorData {
+  walletId: string;
+  walletName: string;
+  error: Error;
+}
+
+export interface AccountSelectionData {
+  walletId: string;
+  walletName: string;
+  walletIcon?: string;
+  accounts: LedgerAccount[];
+}
+
+/**
+ * Public surface of the host `WalletConnector` web component that services
+ * (EventHandler, WalletService) depend on.
+ *
+ * The host class implements this interface, which lets services consume the
+ * component through a typed contract instead of `(component as any)` casts.
+ */
+export interface WalletConnectorContext extends HTMLElement {
+  readonly walletManager: WalletManager | null;
+  readonly shadow: ShadowRoot;
+  readonly qrCodeData: QRCodeData | null;
+  readonly errorData: ErrorData | null;
+  readonly accountSelectionData: AccountSelectionData | null;
+
+  open(): Promise<void> | void;
+  close(): void;
+  openAccountModal(): void;
+  closeAccountModal(): void;
+  disconnectFromAccountModal(): Promise<void> | void;
+
+  showQRCodeView(walletId: string, uri?: string): void;
+  showLoadingView(walletId: string, walletName: string, walletIcon?: string): void;
+  showErrorView(walletId: string, walletName: string, error: Error): void;
+  showWalletList(): void;
+  showAccountSelectionView(
+    walletId: string,
+    walletName: string,
+    walletIcon: string | undefined,
+    accounts: LedgerAccount[]
+  ): void;
+  setQRCode(walletId: string, uri: string): void;
+
+  getOverlayRoot(): ShadowRoot | null;
+  getAccountModalRoot(): ShadowRoot | null;
+}
+
+/**
+ * Options the UI inspects on a WalletConnect-style adapter. These mirror the
+ * adapter's own option shape but are kept loose (all-optional) because the UI
+ * only reads/writes a subset.
+ */
+export interface WalletConnectAdapterLikeOptions {
+  projectId?: string;
+  onQRCode?: (uri: string) => void;
+  useModal?: boolean;
+  modalMode?: 'mobile-only' | 'always' | 'never';
+}
+
+/**
+ * Adapter capability: WalletConnect-style eager initialization with QR pre-gen.
+ */
+export interface PreInitializableAdapter {
+  preInitialize(projectId?: string, network?: NetworkConfig): Promise<void>;
+  options?: WalletConnectAdapterLikeOptions;
+  getDeepLinkURI(uri: string): string;
+}
+
+/**
+ * Adapter capability: Xaman-style session state probe used for silent reconnect.
+ */
+export interface XamanStateAdapter {
+  checkXamanState(): Promise<AccountInfo | null>;
+}
+
+/**
+ * Adapter capability: Ledger-style multi-account enumeration.
+ */
+export interface MultiAccountAdapter {
+  getAccounts(count: number, startIndex: number): Promise<LedgerAccount[]>;
+}
+
+/**
+ * Adapter capability: produces a deep-link URI from a connection URI (mobile).
+ */
+export interface DeepLinkAdapter {
+  getDeepLinkURI(uri: string): string;
+}
+
+/**
+ * Adapter capability: exposes a WalletConnect-style options bag whose
+ * `useModal` / `modalMode` flags drive UI behavior.
+ */
+export interface ModalConfigurableAdapter {
+  options?: WalletConnectAdapterLikeOptions;
+}
+
+export function isPreInitializableAdapter(
+  adapter: WalletAdapter
+): adapter is WalletAdapter & PreInitializableAdapter {
+  const candidate = adapter as Partial<PreInitializableAdapter>;
+  return (
+    typeof candidate.preInitialize === 'function' && typeof candidate.getDeepLinkURI === 'function'
+  );
+}
+
+export function isDeepLinkAdapter(
+  adapter: WalletAdapter
+): adapter is WalletAdapter & DeepLinkAdapter {
+  return typeof (adapter as Partial<DeepLinkAdapter>).getDeepLinkURI === 'function';
+}
+
+export function isXamanStateAdapter(
+  adapter: WalletAdapter
+): adapter is WalletAdapter & XamanStateAdapter {
+  return typeof (adapter as Partial<XamanStateAdapter>).checkXamanState === 'function';
+}
+
+export function isMultiAccountAdapter(
+  adapter: WalletAdapter
+): adapter is WalletAdapter & MultiAccountAdapter {
+  return typeof (adapter as Partial<MultiAccountAdapter>).getAccounts === 'function';
+}
+
+export function isModalConfigurableAdapter(
+  adapter: WalletAdapter
+): adapter is WalletAdapter & ModalConfigurableAdapter {
+  return 'options' in adapter;
+}

--- a/packages/ui/src/views/WalletListView.ts
+++ b/packages/ui/src/views/WalletListView.ts
@@ -1,4 +1,9 @@
-export function renderWalletListView(primaryWallet: any | null, otherWallets: any[]): string {
+import type { WalletAdapter } from '@xrpl-connect/core';
+
+export function renderWalletListView(
+  primaryWallet: WalletAdapter | null,
+  otherWallets: WalletAdapter[]
+): string {
   return `
       <div class="header">
         <h2 class="title">Connect Wallet</h2>

--- a/packages/ui/src/wallet-connector.ts
+++ b/packages/ui/src/wallet-connector.ts
@@ -3,7 +3,7 @@
  * A framework-agnostic web component for connecting to XRPL wallets
  */
 
-import type { WalletManager } from '@xrpl-connect/core';
+import type { WalletAdapter, WalletManager } from '@xrpl-connect/core';
 import { createLogger } from '@xrpl-connect/core';
 import QRCodeStyling from 'qr-code-styling';
 import { mainStyles } from './styles/main';
@@ -17,6 +17,16 @@ import {
   renderAccountModal,
 } from './views';
 import { WalletService, EventHandler } from './services';
+import {
+  isPreInitializableAdapter,
+  isXamanStateAdapter,
+  type AccountSelectionData,
+  type ErrorData,
+  type LedgerAccount,
+  type LoadingData,
+  type QRCodeData,
+  type WalletConnectorContext,
+} from './types';
 import { isXamanQRImage, adjustColorBrightness } from './utils';
 
 /**
@@ -25,7 +35,7 @@ import { isXamanQRImage, adjustColorBrightness } from './utils';
 const logger = createLogger('[WalletConnector]');
 
 // Only define the component in browser (guard against SSR)
-let WalletConnectorElement: any = null;
+let WalletConnectorElement: CustomElementConstructor | null = null;
 
 if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
   const XC_CSS_VARIABLES = [
@@ -67,31 +77,25 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
     '--xc-warning-color',
   ] as const;
 
-  class WalletConnectorElementImpl extends HTMLElement {
-    private walletManager: WalletManager | null = null;
-    private shadow: ShadowRoot;
+  class WalletConnectorElementImpl extends HTMLElement implements WalletConnectorContext {
+    public walletManager: WalletManager | null = null;
+    public readonly shadow: ShadowRoot;
     private isOpen = false;
     private isFirstOpen = true;
     private primaryWalletId: string | null = null;
     private viewState: 'list' | 'qr' | 'loading' | 'error' | 'account-selection' = 'list';
-    private qrCodeData: { walletId: string; uri: string } | null = null;
-    private loadingData: { walletId: string; walletName: string; walletIcon?: string } | null =
-      null;
-    private errorData: { walletId: string; walletName: string; error: Error } | null = null;
-    private accountSelectionData: {
-      walletId: string;
-      walletName: string;
-      walletIcon?: string;
-      accounts: Array<{ address: string; publicKey: string; path: string; index: number }>;
-    } | null = null;
+    public qrCodeData: QRCodeData | null = null;
+    private loadingData: LoadingData | null = null;
+    public errorData: ErrorData | null = null;
+    public accountSelectionData: AccountSelectionData | null = null;
     private previousModalHeight: number = 0;
-    private preGeneratedQRCode: any | null = null; // Store pre-generated QR code
-    private preGeneratedURI: string | null = null; // Store the URI used for pre-generation
-    private specifiedWalletIds: string[] = []; // Wallet IDs specified via 'wallets' attribute
-    private availableWallets: any[] = []; // Cache of available wallets
-    private walletAvailabilityChecked: boolean = false; // Flag to track if availability has been checked
-    private accountModalOpen: boolean = false; // Track if account details modal is open
-    private accountBalance: string | null = null; // Cached account balance
+    private preGeneratedQRCode: QRCodeStyling | null = null;
+    private preGeneratedURI: string | null = null;
+    private specifiedWalletIds: string[] = [];
+    private availableWallets: WalletAdapter[] = [];
+    private walletAvailabilityChecked: boolean = false;
+    private accountModalOpen: boolean = false;
+    private accountBalance: string | null = null;
     private overlayPortal: HTMLDivElement | null = null;
     private accountModalPortal: HTMLDivElement | null = null;
     private styleObserver: MutationObserver | null = null;
@@ -260,19 +264,14 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
      */
     private async checkXamanStateOnInit() {
       try {
-        if (this.listAdapters().includes('xaman')) {
-          const xamanAdapter: any = this.walletManager?.adapters?.get('xaman');
+        const xamanAdapter = this.walletManager?.adapters?.get('xaman');
+        if (!xamanAdapter || !isXamanStateAdapter(xamanAdapter)) {
+          return;
+        }
 
-          if (!xamanAdapter) {
-            return;
-          }
-
-          const account = await xamanAdapter.checkXamanState();
-          if (account) {
-            if (this.walletManager && !this.walletManager.connected) {
-              await this.walletManager.connect('xaman');
-            }
-          }
+        const account = await xamanAdapter.checkXamanState();
+        if (account && this.walletManager && !this.walletManager.connected) {
+          await this.walletManager.connect('xaman');
         }
       } catch (err) {
         console.error('Failed to check Xaman state:', err);
@@ -293,17 +292,6 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
         .split(',')
         .map((id) => id.trim())
         .filter((id) => id.length > 0);
-    }
-
-    private listAdapters(): string[] {
-      const returnArray: string[] = [];
-      if (!this.walletManager?.wallets) return returnArray;
-
-      for (const adapter of Object.values(this.walletManager.wallets)) {
-        returnArray.push(adapter.id);
-      }
-
-      return returnArray;
     }
 
     /**
@@ -346,7 +334,7 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
         this.availableWallets = this.specifiedWalletIds
           .map((id) => availabilityChecks.find((check) => check.wallet.id === id)?.wallet)
           .filter(
-            (wallet): wallet is any =>
+            (wallet): wallet is WalletAdapter =>
               (wallet !== undefined &&
                 availabilityChecks.find((c) => c.wallet.id === wallet.id)?.available) ??
               false
@@ -426,7 +414,7 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
     /**
      * Close the account details modal
      */
-    private closeAccountModal() {
+    public closeAccountModal() {
       this.accountModalOpen = false;
       this.render();
     }
@@ -469,35 +457,25 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
       // Find WalletConnect adapter
       const walletConnectAdapter = this.walletManager.wallets.find((w) => w.id === 'walletconnect');
 
-      if (!walletConnectAdapter) return;
+      if (!walletConnectAdapter || !isPreInitializableAdapter(walletConnectAdapter)) return;
 
-      // Check if adapter has preInitialize method
-      if (typeof (walletConnectAdapter as any).preInitialize === 'function') {
-        try {
-          logger.debug('Pre-initializing WalletConnect...');
+      try {
+        logger.debug('Pre-initializing WalletConnect...');
 
-          // Extract projectId from adapter's stored options
-          const projectId = (walletConnectAdapter as any).options?.projectId;
+        const projectId = walletConnectAdapter.options?.projectId;
+        const network = this.walletManager.defaultNetwork;
 
-          // Pass network information if available
-          const network = (this.walletManager as any).options?.network;
+        // Install the QR-generation callback the adapter will invoke during pre-init.
+        const adapterOptions = (walletConnectAdapter.options ??= {});
+        adapterOptions.onQRCode = (uri: string) => {
+          logger.debug('Pre-generating QR code...');
+          this.preGenerateQRCode(uri);
+        };
 
-          // Store the QR generation callback in the adapter's options
-          // The adapter will call this callback during pre-initialization
-          if (!(walletConnectAdapter as any).options) {
-            (walletConnectAdapter as any).options = {};
-          }
-          (walletConnectAdapter as any).options.onQRCode = (uri: string) => {
-            logger.debug('Pre-generating QR code...');
-            this.preGenerateQRCode(uri);
-          };
-
-          // Pre-initialize with projectId and network
-          await (walletConnectAdapter as any).preInitialize(projectId, network);
-        } catch (error) {
-          logger.warn('Failed to pre-initialize WalletConnect:', error);
-          // Silent failure - connection will initialize on demand if this fails
-        }
+        await walletConnectAdapter.preInitialize(projectId, network);
+      } catch (error) {
+        logger.warn('Failed to pre-initialize WalletConnect:', error);
+        // Silent failure - connection will initialize on demand if this fails
       }
     }
 
@@ -603,7 +581,7 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
       walletId: string,
       walletName: string,
       walletIcon: string | undefined,
-      accounts: Array<{ address: string; publicKey: string; path: string; index: number }>
+      accounts: LedgerAccount[]
     ) {
       this.viewState = 'account-selection';
       this.accountSelectionData = { walletId, walletName, walletIcon, accounts };
@@ -779,7 +757,7 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
           : this.walletManager?.wallets || [];
 
       const primaryWallet = this.primaryWalletId
-        ? wallets.find((w) => w.id === this.primaryWalletId)
+        ? (wallets.find((w) => w.id === this.primaryWalletId) ?? null)
         : null;
       const otherWallets = wallets.filter((w) => w.id !== this.primaryWalletId);
 
@@ -896,7 +874,7 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
 
   // Register the custom element
   if (!customElements.get('xrpl-wallet-connector')) {
-    customElements.define('xrpl-wallet-connector', WalletConnectorElement);
+    customElements.define('xrpl-wallet-connector', WalletConnectorElementImpl);
   }
 }
 


### PR DESCRIPTION
## Summary
- Introduce `WalletConnectorContext` so `EventHandler` / `WalletService` depend on a typed host surface instead of `(component as any)` on every access.
- Add capability interfaces + type guards (`PreInitializableAdapter`, `DeepLinkAdapter`, `XamanStateAdapter`, `MultiAccountAdapter`, `ModalConfigurableAdapter`) for the optional adapter methods the UI invokes (`preInitialize`, `getDeepLinkURI`, `checkXamanState`, `getAccounts`).
- Expose `defaultNetwork` on `WalletManager` and widen `WalletConnectAdapter.preInitialize`'s `network` param to `NetworkConfig` so the UI no longer reaches into private options.
- Promote `@typescript-eslint/no-explicit-any` to `error` for `packages/ui/src/**`; remaining warnings live in adapter packages (tracked under #6).

## Test plan
- [x] `pnpm -F @xrpl-connect/ui type-check`
- [x] `pnpm build` (all 13 packages)
- [x] `pnpm lint` (zero `any` warnings in `packages/ui/src`)
- [x] `pnpm test` (UI EventHandler + WalletService suites green)
- [ ] Smoke-test connect flow with WalletConnect (QR + modal modes) and Xaman session resume in the vanilla example.

Fixes #52