### PR TITLE
docs: add CHANGELOG.md and CONTRIBUTING.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,110 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- UI: detach event listeners on disconnect and view change to prevent leaks (#54).
+
+### Documentation
+
+- Align all framework guides (Vanilla JS, React, Vue) with the current public API.
+- Fix React import examples to use the meta-package (#48).
+- Add `CHANGELOG.md` and `CONTRIBUTING.md` at the repository root (#60).
+
+## [0.7.1] - 2026-04-10
+
+### Fixed
+
+- Otsu adapter: correct wallet URL.
+- Otsu adapter: fix `isAvailable` detection.
+
+## [0.7.0] - 2026-04-10
+
+### Added
+
+- Otsu Wallet adapter (`@xrpl-connect/adapter-otsu`) and Otsu in the bundled examples.
+
+## [0.6.0] - 2026-03-02
+
+### Added
+
+- Xyra Wallet adapter (`@xrpl-connect/adapter-xyra`), with separate `sign` and `signAndSubmit` methods.
+
+### Changed
+
+- Updated adapters README with directory structure and Xyra integration details.
+- Run formatting across the codebase.
+
+## [0.5.2] - 2026-02-20
+
+### Changed
+
+- UI: render the modal centered in the viewport.
+
+### Added
+
+- CI now runs on the `develop` branch.
+
+## [0.5.1] - 2026-02-17
+
+### Changed
+
+- Maintenance release (version bump only).
+
+## [0.5.0] - 2026-02-17
+
+### Changed
+
+- **Breaking:** split the adapter signing API into separate `sign` and `signAndSubmit` methods. Adapters and consumers calling `sign` need to update accordingly.
+- Refactor the UI web component into smaller pieces and add unit tests.
+- Migrate to ESLint 9.
+
+### Fixed
+
+- Build pipeline fixes and a clean `pnpm` install path.
+- `pnpm audit` vulnerability fixes.
+
+## [0.4.0] - 2025-11-14
+
+### Added
+
+- Ledger hardware wallet adapter (`@xrpl-connect/adapter-ledger`).
+- React example/template.
+- LLM-friendly documentation output (VitePress LLMs plugin) with a "download all documentation" link.
+- Adapter authoring guide.
+
+### Changed
+
+- WalletConnect: use the WalletConnect modal on mobile to ensure proper deep-linking.
+- Logo reworked to use a base64 SVG.
+
+## [0.3.0] - 2025-10-27
+
+### Added
+
+- VitePress-based documentation site published via GitHub Pages.
+- Auto-detection of available wallets.
+- Post-connect modal (replaces the disconnect-on-click flow).
+- "Connect" button shipped inside the web component (component is now button + modal).
+- CSS-based style customization with the `xc-` prefix.
+
+### Changed
+
+- Switch the build to Vite for the meta package.
+- Crossmark adapter: use `signAndSubmitAndWait` and improve `isAvailable`.
+
+[Unreleased]: https://github.com/XRPL-Commons/xrpl-connect/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/XRPL-Commons/xrpl-connect/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/XRPL-Commons/xrpl-connect/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/XRPL-Commons/xrpl-connect/compare/v0.5.2...v0.6.0
+[0.5.2]: https://github.com/XRPL-Commons/xrpl-connect/compare/v0.5.1...v0.5.2
+[0.5.1]: https://github.com/XRPL-Commons/xrpl-connect/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/XRPL-Commons/xrpl-connect/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/XRPL-Commons/xrpl-connect/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/XRPL-Commons/xrpl-connect/releases/tag/v0.3.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,129 @@
+# Contributing to XRPL Connect
+
+Thanks for your interest in contributing! XRPL Connect is an open-source, framework-agnostic wallet-connection toolkit for the XRP Ledger, and contributions of every size are welcome — bug reports, documentation fixes, new adapters, and core improvements.
+
+## Code of Conduct
+
+This project follows the spirit of the [Contributor Covenant](https://www.contributor-covenant.org/). Be kind, be constructive, and assume good intent.
+
+## Ways to Contribute
+
+- **Report bugs** or request features via [GitHub Issues](https://github.com/XRPL-Commons/xrpl-connect/issues).
+- **Improve the docs** under [`docs/`](./docs) — they are published with VitePress.
+- **Add a wallet adapter** — see [Creating Wallet Adapters](./docs/guide/adapter-integration.md).
+- **Fix bugs or implement features** — please open an issue first for non-trivial changes so we can align on the approach.
+
+## Development Setup
+
+### Prerequisites
+
+- **Node.js** ≥ 18
+- **pnpm** ≥ 8 (the repo pins `pnpm@10.18.3` via `packageManager`)
+
+### Install
+
+```bash
+git clone https://github.com/XRPL-Commons/xrpl-connect.git
+cd xrpl-connect
+pnpm install
+```
+
+### Common Commands
+
+All commands run from the repository root via Turborepo:
+
+```bash
+pnpm build         # Build all packages
+pnpm dev           # Watch mode across packages
+pnpm test          # Run all tests (passes when a package has none)
+pnpm lint          # Lint all packages
+pnpm format        # Format with Prettier
+pnpm format:check  # Verify formatting in CI
+pnpm docs:dev      # Run the VitePress docs site locally
+pnpm docs:build    # Build the docs site
+```
+
+### Repository Layout
+
+```
+xrpl-connect/
+├── packages/
+│   ├── core/                  # WalletManager, events, storage
+│   ├── ui/                    # Web component
+│   ├── adapters/              # All wallet adapters (xaman, crossmark, gemwallet,
+│   │                          # walletconnect, ledger, xyra, otsu, …)
+│   └── xrpl-connect/          # Meta-package that re-exports everything
+├── examples/                  # vanilla-js and react integration examples
+└── docs/                      # VitePress documentation site
+```
+
+## Branching & Workflow
+
+- The default branch is **`develop`** — open all pull requests against it.
+- **`main`** tracks released versions; releases are merged from `develop` to `main` and tagged.
+- Use short, descriptive branch names. Suggested prefixes:
+  - `feat/<short-slug>` — new functionality
+  - `fix/<short-slug>` — bug fixes
+  - `docs/<short-slug>` — documentation only
+  - `refactor/<short-slug>` — internal refactors
+  - `chore/<short-slug>` — tooling, deps, CI
+- If your work resolves an issue, including the issue number in the branch name (e.g. `fix/issue-42-…`) helps reviewers.
+
+## Commit Messages
+
+Aim for [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <short summary>
+
+<optional body>
+
+Fixes #<issue>
+```
+
+Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `build`, `ci`. Optional scopes match the package (`core`, `ui`, `adapter-xaman`, …). Keep the subject line under ~72 characters.
+
+## Pull Requests
+
+Before opening a PR:
+
+1. Rebase or merge from the latest `develop`.
+2. Run `pnpm build`, `pnpm lint`, `pnpm test`, and `pnpm format:check` locally.
+3. Add or update tests for behavior changes.
+4. Update the relevant docs under `docs/` if you change public API.
+5. Add a `CHANGELOG.md` entry under the `[Unreleased]` section describing user-visible changes (see [`CHANGELOG.md`](./CHANGELOG.md)).
+
+In the PR description:
+
+- State **what** changed and **why** (link the issue with `Fixes #<num>` to auto-close it on merge).
+- List manual test steps reviewers can follow.
+- Call out breaking changes explicitly, including any required migration.
+
+CI runs build, lint, and tests on every PR and on `develop`. Please keep it green.
+
+## Adding a New Adapter
+
+XRPL Connect's adapter architecture is intentionally small. Follow the dedicated guide — it covers the `WalletAdapter` interface, package layout, registration in the meta-package, and the bundled examples:
+
+➡️ [Creating Wallet Adapters](./docs/guide/adapter-integration.md)
+
+A good reference adapter to copy from is [`@xrpl-connect/adapter-crossmark`](./packages/adapters/crossmark).
+
+## Release Process
+
+Maintainers cut releases as follows:
+
+1. Make sure `develop` is green and the `CHANGELOG.md` `[Unreleased]` section is up to date.
+2. Bump the version in the relevant `package.json` files and move the `[Unreleased]` entries into a new dated version section.
+3. Merge `develop` → `main` via PR.
+4. Tag the merge commit (e.g. `v0.8.0`) and push the tag. The publish workflow takes it from there.
+
+If you are not a maintainer, you do not need to bump versions or update `main` in your PR — leave that to the release process.
+
+## Reporting Security Issues
+
+Please **do not** open public issues for security vulnerabilities. Email the maintainers via the contact details in the [`xrpl-connect` GitHub organization page](https://github.com/XRPL-Commons) instead.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the project's [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ pnpm dev
 
 ## 🤝 Contributing
 
-Contributions are welcome! Please read our [Contributing Guide](./docs/guide/adapter-integration.md) for details on our code of conduct and the process for submitting pull requests.
+Contributions are welcome! Please read our [Contributing Guide](./CONTRIBUTING.md) for development setup, branch/PR conventions, and the release process. To author a new wallet adapter specifically, see the [Adapter Integration Guide](./docs/guide/adapter-integration.md).
+
+A summary of notable changes in each release lives in [`CHANGELOG.md`](./CHANGELOG.md).
 
 ## 📄 License
 


### PR DESCRIPTION
## Summary

- Add `CHANGELOG.md` at the repo root, following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Backfilled entries for releases v0.3.0 → v0.7.1 by walking `git log` and tags, plus an `[Unreleased]` section for what is currently on `develop` (event-handler leak fix, docs alignment, this PR).
- Add `CONTRIBUTING.md` at the repo root covering: prerequisites, install, common `pnpm` scripts, repo layout, branching workflow (PRs target `develop`), commit/PR conventions, a pointer to the existing adapter-authoring guide, and the release process.
- Update the README's "Contributing Guide" link — it previously pointed at `docs/guide/adapter-integration.md` (an adapter authoring guide, not a contribution guide) — to point at `CONTRIBUTING.md`, and add a link to the changelog. The adapter guide is still referenced from the contributing doc.

A `changesets`-style tool was considered (per the issue's optional item) but deferred — it's a separate setup decision that touches CI and publishing. The new `CONTRIBUTING.md` documents adding entries under `[Unreleased]` manually for now.

## Test plan

- [ ] CHANGELOG.md and CONTRIBUTING.md render correctly on the GitHub PR view.
- [ ] README "Contributing Guide" link resolves to `CONTRIBUTING.md`.
- [ ] `pnpm format:check` is green.

Fixes #60