### PR TITLE
refactor: extract shared resolveNetwork helper into core

### DIFF
--- a/packages/adapters/crossmark/src/crossmark-adapter.ts
+++ b/packages/adapters/crossmark/src/crossmark-adapter.ts
@@ -13,7 +13,7 @@ import type {
   SignedMessage,
   SubmittedTransaction,
 } from '@xrpl-connect/core';
-import { createWalletError, STANDARD_NETWORKS } from '@xrpl-connect/core';
+import { createWalletError, resolveNetwork } from '@xrpl-connect/core';
 
 /**
  * Crossmark adapter options
@@ -65,7 +65,7 @@ export class CrossmarkAdapter implements WalletAdapter {
       }
 
       // Determine network
-      const network = this.resolveNetwork(options?.network);
+      const network = resolveNetwork(options?.network);
 
       // Generate a random hash for signing
       const hash = this.generateRandomHash();
@@ -209,25 +209,6 @@ export class CrossmarkAdapter implements WalletAdapter {
     } catch (error) {
       throw createWalletError.signFailed(error as Error);
     }
-  }
-
-  /**
-   * Resolve network configuration
-   */
-  private resolveNetwork(config?: ConnectOptions['network']): NetworkInfo {
-    if (!config) {
-      return STANDARD_NETWORKS.mainnet;
-    }
-
-    if (typeof config === 'string') {
-      const network = STANDARD_NETWORKS[config];
-      if (!network) {
-        throw createWalletError.unknown(`Unknown network: ${config}`);
-      }
-      return network;
-    }
-
-    return config;
   }
 
   /**

--- a/packages/adapters/gemwallet/src/gemwallet-adapter.ts
+++ b/packages/adapters/gemwallet/src/gemwallet-adapter.ts
@@ -214,5 +214,4 @@ export class GemWalletAdapter implements WalletAdapter {
       throw createWalletError.signFailed(error as Error);
     }
   }
-
 }

--- a/packages/adapters/gemwallet/src/gemwallet-adapter.ts
+++ b/packages/adapters/gemwallet/src/gemwallet-adapter.ts
@@ -19,7 +19,7 @@ import type {
   SignedMessage,
   SubmittedTransaction,
 } from '@xrpl-connect/core';
-import { createWalletError, STANDARD_NETWORKS } from '@xrpl-connect/core';
+import { createWalletError, resolveNetwork } from '@xrpl-connect/core';
 
 /**
  * GemWallet adapter options
@@ -69,7 +69,7 @@ export class GemWalletAdapter implements WalletAdapter {
       }
 
       // Determine network
-      const network = this.resolveNetwork(options?.network);
+      const network = resolveNetwork(options?.network);
 
       // Get public key (which also returns the address)
       const publicKeyResponse = await getPublicKey();
@@ -215,22 +215,4 @@ export class GemWalletAdapter implements WalletAdapter {
     }
   }
 
-  /**
-   * Resolve network configuration
-   */
-  private resolveNetwork(config?: ConnectOptions['network']): NetworkInfo {
-    if (!config) {
-      return STANDARD_NETWORKS.mainnet;
-    }
-
-    if (typeof config === 'string') {
-      const network = STANDARD_NETWORKS[config];
-      if (!network) {
-        throw createWalletError.unknown(`Unknown network: ${config}`);
-      }
-      return network;
-    }
-
-    return config;
-  }
 }

--- a/packages/adapters/ledger/src/ledger-adapter.ts
+++ b/packages/adapters/ledger/src/ledger-adapter.ts
@@ -17,7 +17,7 @@ import type {
   SignedMessage,
   SubmittedTransaction,
 } from '@xrpl-connect/core';
-import { createWalletError, STANDARD_NETWORKS } from '@xrpl-connect/core';
+import { createWalletError, resolveNetwork } from '@xrpl-connect/core';
 
 import type { LedgerAdapterOptions, LedgerConnectOptions } from './types';
 import { LedgerDeviceState } from './types';
@@ -99,7 +99,7 @@ export class LedgerAdapter implements WalletAdapter {
         this.derivationPath = `44'/144'/${options.accountIndex}'/0/0`;
       }
 
-      const network = this.resolveNetwork(options?.network);
+      const network = resolveNetwork(options?.network);
       this.transport = await this.createTransport();
       this.xrpApp = new Xrp(this.transport);
 
@@ -444,25 +444,6 @@ export class LedgerAdapter implements WalletAdapter {
       this.transport = null;
     }
     this.xrpApp = null;
-  }
-
-  /**
-   * Resolve network configuration
-   */
-  private resolveNetwork(config?: ConnectOptions['network']): NetworkInfo {
-    if (!config) {
-      return STANDARD_NETWORKS.mainnet;
-    }
-
-    if (typeof config === 'string') {
-      const network = STANDARD_NETWORKS[config];
-      if (!network) {
-        throw createWalletError.unknown(`Unknown network: ${config}`);
-      }
-      return network;
-    }
-
-    return config;
   }
 
   /**

--- a/packages/adapters/walletconnect/src/walletconnect-adapter.ts
+++ b/packages/adapters/walletconnect/src/walletconnect-adapter.ts
@@ -15,7 +15,7 @@ import type {
   SignedMessage,
   SubmittedTransaction,
 } from '@xrpl-connect/core';
-import { createWalletError, STANDARD_NETWORKS, createLogger } from '@xrpl-connect/core';
+import { createWalletError, resolveNetwork, createLogger } from '@xrpl-connect/core';
 import {
   DISCONNECT_REASONS,
   DEFAULT_METADATA,
@@ -175,7 +175,7 @@ export class WalletConnectAdapter implements WalletAdapter {
       }
 
       // Determine network for pre-initialization
-      const networkInfo = this.resolveNetwork(network);
+      const networkInfo = resolveNetwork(network);
 
       // Start connection to generate URI (ConnectKit pattern)
       const requiredNamespaces = {
@@ -243,7 +243,7 @@ export class WalletConnectAdapter implements WalletAdapter {
 
     try {
       // Determine network
-      const network = this.resolveNetwork(options?.network);
+      const network = resolveNetwork(options?.network);
 
       // Initialize SignClient if needed
       if (!this.client) {
@@ -498,25 +498,6 @@ export class WalletConnectAdapter implements WalletAdapter {
     throw createWalletError.unsupportedMethod(
       'Message signing is not supported via WalletConnect. Please use Xaman, Crossmark, or GemWallet for signing messages.'
     );
-  }
-
-  /**
-   * Resolve network configuration
-   */
-  private resolveNetwork(config?: ConnectOptions['network']): NetworkInfo {
-    if (!config) {
-      return STANDARD_NETWORKS.mainnet;
-    }
-
-    if (typeof config === 'string') {
-      const network = STANDARD_NETWORKS[config];
-      if (!network) {
-        throw createWalletError.unknown(`Unknown network: ${config}`);
-      }
-      return network;
-    }
-
-    return config;
   }
 
   /**

--- a/packages/adapters/xaman/src/xaman-adapter.ts
+++ b/packages/adapters/xaman/src/xaman-adapter.ts
@@ -12,9 +12,8 @@ import {
   SignedTransaction,
   SignedMessage,
   SubmittedTransaction,
-  STANDARD_NETWORKS,
 } from '@xrpl-connect/core';
-import { createWalletError, createLogger } from '@xrpl-connect/core';
+import { createWalletError, createLogger, resolveNetwork } from '@xrpl-connect/core';
 
 /**
  * Logger instance for Xaman adapter
@@ -91,7 +90,7 @@ export class XamanAdapter implements WalletAdapter {
 
     let resolvedNetwork: NetworkInfo;
     if (network) {
-      resolvedNetwork = this.resolveNetwork(network);
+      resolvedNetwork = resolveNetwork(network);
     } else {
       const xamanNetwork = await this.client.user.networkEndpoint;
       if (!xamanNetwork) {
@@ -159,7 +158,7 @@ export class XamanAdapter implements WalletAdapter {
       logger.debug('Authorization successful', { account: authResult.me?.account });
 
       const account = authResult.me.account;
-      const network: NetworkInfo = this.resolveNetwork(options?.network);
+      const network: NetworkInfo = resolveNetwork(options?.network);
 
       this.currentAccount = {
         address: account,
@@ -460,22 +459,4 @@ export class XamanAdapter implements WalletAdapter {
     // Don't clear pending payload on disconnect - it might still be needed
   }
 
-  /**
-   * Resolve network configuration
-   */
-  private resolveNetwork(config?: ConnectOptions['network']): NetworkInfo {
-    if (!config) {
-      return STANDARD_NETWORKS.mainnet;
-    }
-
-    if (typeof config === 'string') {
-      const network = STANDARD_NETWORKS[config];
-      if (!network) {
-        throw createWalletError.unknown(`Unknown network: ${config}`);
-      }
-      return network;
-    }
-
-    return config;
-  }
 }

--- a/packages/adapters/xaman/src/xaman-adapter.ts
+++ b/packages/adapters/xaman/src/xaman-adapter.ts
@@ -458,5 +458,4 @@ export class XamanAdapter implements WalletAdapter {
     this.currentAccount = null;
     // Don't clear pending payload on disconnect - it might still be needed
   }
-
 }

--- a/packages/adapters/xyra/src/xyra-adapter.ts
+++ b/packages/adapters/xyra/src/xyra-adapter.ts
@@ -136,7 +136,7 @@ export class XyraAdapter implements WalletAdapter {
       this.currentXyraNetwork = response.network;
 
       // Map the response to xrpl-connect AccountInfo
-      const networkInfo = this.resolveNetworkInfo(response.network);
+      const networkInfo = this.xyraNetworkToInfo(response.network);
 
       this.currentAccount = {
         address: response.address,
@@ -436,8 +436,14 @@ export class XyraAdapter implements WalletAdapter {
 
   /**
    * Map a Xyra SDK Network string back to an xrpl-connect NetworkInfo.
+   *
+   * This is not the same as the shared `resolveNetwork` helper from
+   * `@xrpl-connect/core`: that helper resolves a user-supplied
+   * `ConnectOptions['network']` (string id or `NetworkInfo`) to a
+   * `NetworkInfo`, whereas this method translates a Xyra-SDK-native
+   * network identifier returned by the wallet itself.
    */
-  private resolveNetworkInfo(xyraNetwork: Network): NetworkInfo {
+  private xyraNetworkToInfo(xyraNetwork: Network): NetworkInfo {
     const connectNetworkId = XYRA_TO_XRPL_CONNECT_NETWORK[xyraNetwork];
 
     // Check standard networks first

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,3 +38,6 @@ export { Logger, createLogger } from './logger';
 
 // Constants
 export { TIME } from './constants';
+
+// Network helpers
+export { resolveNetwork } from './network';

--- a/packages/core/src/network.test.ts
+++ b/packages/core/src/network.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+
+import { WalletError } from './errors';
+import { resolveNetwork } from './network';
+import type { NetworkInfo } from './types';
+import { STANDARD_NETWORKS, WalletErrorCode } from './types';
+
+describe('resolveNetwork', () => {
+  it('defaults to mainnet when no config is provided', () => {
+    expect(resolveNetwork()).toBe(STANDARD_NETWORKS.mainnet);
+    expect(resolveNetwork(undefined)).toBe(STANDARD_NETWORKS.mainnet);
+  });
+
+  it('resolves standard network ids to their NetworkInfo', () => {
+    expect(resolveNetwork('testnet')).toBe(STANDARD_NETWORKS.testnet);
+    expect(resolveNetwork('devnet')).toBe(STANDARD_NETWORKS.devnet);
+  });
+
+  it('passes a custom NetworkInfo through unchanged', () => {
+    const custom: NetworkInfo = {
+      id: 'custom',
+      name: 'Custom',
+      wss: 'wss://example.com',
+    };
+    expect(resolveNetwork(custom)).toBe(custom);
+  });
+
+  it('throws a WalletError when given an unknown network id', () => {
+    expect(() => resolveNetwork('not-a-network')).toThrow(WalletError);
+    try {
+      resolveNetwork('not-a-network');
+    } catch (err) {
+      expect(err).toBeInstanceOf(WalletError);
+      expect((err as WalletError).code).toBe(WalletErrorCode.UNKNOWN_ERROR);
+      expect((err as WalletError).message).toContain('not-a-network');
+    }
+  });
+});

--- a/packages/core/src/network.ts
+++ b/packages/core/src/network.ts
@@ -1,0 +1,30 @@
+/**
+ * Network resolution helpers shared by all wallet adapters.
+ */
+
+import { createWalletError } from './errors';
+import type { ConnectOptions, NetworkInfo } from './types';
+import { STANDARD_NETWORKS } from './types';
+
+/**
+ * Resolve a `ConnectOptions['network']` value to a concrete `NetworkInfo`.
+ *
+ * - `undefined` → mainnet (default).
+ * - `string` → looked up in `STANDARD_NETWORKS`; throws if unknown.
+ * - `NetworkInfo` → returned as-is.
+ */
+export function resolveNetwork(config?: ConnectOptions['network']): NetworkInfo {
+  if (!config) {
+    return STANDARD_NETWORKS.mainnet;
+  }
+
+  if (typeof config === 'string') {
+    const network = STANDARD_NETWORKS[config];
+    if (!network) {
+      throw createWalletError.unknown(`Unknown network: ${config}`);
+    }
+    return network;
+  }
+
+  return config;
+}


### PR DESCRIPTION
## Summary
- Add `resolveNetwork(config?: ConnectOptions['network']): NetworkInfo` to `@xrpl-connect/core` and re-export it.
- Delete the byte-identical private `resolveNetwork` from each of the 5 adapters (crossmark, gemwallet, ledger, walletconnect, xaman) and switch every call site to the shared helper. Drop the now-unused `STANDARD_NETWORKS` imports.
- Reconcile the Xyra adapter by renaming its `resolveNetworkInfo` → `xyraNetworkToInfo` and documenting why it cannot share the helper: its input is a Xyra-SDK `Network` string returned by the wallet, not a user-supplied `ConnectOptions['network']`.
- Add 4 unit tests for the shared helper in `packages/core/src/network.test.ts` (default, standard id lookup, custom `NetworkInfo` passthrough, unknown-id error).

## Test plan
- [x] `pnpm --filter @xrpl-connect/core test` — 4/4 passing.
- [x] `pnpm build` — all 13 packages build green.
- [x] `pnpm lint` — 0 errors (pre-existing warnings unchanged).

Fixes #53