### PR TITLE
docs: show error handling and autoConnect in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ import { WalletManager, XamanAdapter, CrossmarkAdapter } from 'xrpl-connect';
 const walletManager = new WalletManager({
   adapters: [new XamanAdapter(), new CrossmarkAdapter()],
   network: 'testnet',
+  // When true, the WalletManager attempts to restore the previous session
+  // from localStorage on page load (the user is not prompted again). Set to
+  // false if you want users to explicitly reconnect every time.
   autoConnect: true,
 });
 
@@ -78,16 +81,37 @@ walletManager.on('connect', (account) => {
   console.log('Connected:', account.address);
 });
 
-// Sign transactions after connection
-const signed = await walletManager.sign({
-  TransactionType: 'Payment',
-  Account: walletManager.account.address,
-  Destination: 'rN7n7otQDd6FczFgLdlqtyMVrn3HMfXoQT',
-  Amount: '1000000',
+// Always handle disconnects so your UI can reset
+walletManager.on('disconnect', () => {
+  console.log('Disconnected');
 });
+
+// Surface connection/adapter errors (wallet not installed, network issues, etc.)
+walletManager.on('error', (error) => {
+  console.error('Wallet error:', error.code, error.message);
+});
+
+// Sign transactions after connection. Always wrap in try/catch — the promise
+// rejects when the user cancels the request in their wallet (SIGN_FAILED).
+try {
+  const signed = await walletManager.sign({
+    TransactionType: 'Payment',
+    Account: walletManager.account.address,
+    Destination: 'rN7n7otQDd6FczFgLdlqtyMVrn3HMfXoQT',
+    Amount: '1000000',
+  });
+} catch (error) {
+  if (error.code === 'SIGN_FAILED') {
+    console.log('User rejected the transaction');
+  } else {
+    console.error('Sign failed:', error);
+  }
+}
 ```
 
 That's it! The web component provides a beautiful, pre-built UI for wallet selection, QR codes, and connection states.
+
+> **Heads up on `autoConnect`:** with `autoConnect: true`, the WalletManager silently restores the previous session from `localStorage` when your page loads and emits a `connect` event before any user interaction. Register your `connect` / `disconnect` / `error` listeners **immediately** after constructing the manager so you don't miss that initial event.
 
 ## 📚 Documentation
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -108,6 +108,75 @@ const ledgerAdapter = new LedgerAdapter({
 
 For more details on Ledger integration, see the [Ledger adapter documentation](https://github.com/XRPL-Commons/xrpl-connect/tree/main/packages/adapters/ledger).
 
+## Quick Start
+
+A minimal, copy-pasteable example covering the patterns you almost always need: wiring the UI component, listening to `connect` / `disconnect` / `error`, and signing a transaction with proper user-rejection handling.
+
+```html
+<button id="connect-btn">Connect Wallet</button>
+<xrpl-wallet-connector id="wallet-connector"></xrpl-wallet-connector>
+```
+
+```javascript
+import { WalletManager, XamanAdapter, CrossmarkAdapter } from 'xrpl-connect';
+
+const walletManager = new WalletManager({
+  adapters: [new XamanAdapter({ apiKey: 'YOUR_API_KEY' }), new CrossmarkAdapter()],
+  network: 'testnet',
+  autoConnect: true,
+});
+
+const connector = document.getElementById('wallet-connector');
+connector.setWalletManager(walletManager);
+
+document.getElementById('connect-btn').addEventListener('click', () => {
+  connector.open();
+});
+
+walletManager.on('connect', (account) => {
+  console.log('Connected:', account.address);
+});
+
+// Reset your UI when the user (or an autoConnect failure) disconnects.
+walletManager.on('disconnect', () => {
+  console.log('Disconnected');
+});
+
+// Surfaces adapter/connection errors (wallet missing, network issues, etc.).
+walletManager.on('error', (error) => {
+  console.error('Wallet error:', error.code, error.message);
+});
+
+// `sign` rejects when the user cancels in their wallet — always wrap it.
+async function sendPayment() {
+  try {
+    const signed = await walletManager.sign({
+      TransactionType: 'Payment',
+      Account: walletManager.account.address,
+      Destination: 'rN7n7otQDd6FczFgLdlqtyMVrn3HMfXoQT',
+      Amount: '1000000',
+    });
+    console.log('Signed:', signed);
+  } catch (error) {
+    if (error.code === 'SIGN_FAILED') {
+      // User rejected the prompt in their wallet — usually a no-op.
+      console.log('User rejected the transaction');
+    } else {
+      console.error('Sign failed:', error);
+    }
+  }
+}
+```
+
+### About `autoConnect`
+
+`autoConnect: true` tells the WalletManager to silently restore the user's previous session from `localStorage` when the page loads. If the previous adapter is still available and the stored session is valid, you'll receive a `connect` event **before** any user interaction; otherwise the manager stays disconnected (and may emit `error` if the adapter explicitly fails).
+
+Two practical consequences:
+
+- **Register listeners first.** Add `on('connect')`, `on('disconnect')`, and `on('error')` immediately after constructing the manager, otherwise the initial reconnect event will fire before your UI is listening.
+- **Set it to `false`** if your app needs the user to explicitly choose a wallet on every visit (e.g., shared kiosks, strict privacy requirements).
+
 ## Framework-Specific Guides
 
 Once you've installed the package and have your API keys, follow the guide for your framework:


### PR DESCRIPTION
## Summary

- README quick-start now shows `on('disconnect')` / `on('error')`, wraps `sign()` in try/catch (with a comment about `SIGN_FAILED` user rejection), and adds an inline + callout explanation of what `autoConnect: true` actually does.
- Adds a mirrored Quick Start section to `docs/guide/getting-started.md` with the same robust example and an "About `autoConnect`" subsection so the docs site quickstart matches.

## Test plan

- [ ] Render the README on GitHub and confirm the new quickstart reads cleanly.
- [ ] `pnpm docs:dev` and verify the Getting Started page shows the Quick Start + autoConnect sections above "Framework-Specific Guides".
- [ ] `pnpm format:check` passes.

Fixes #68