### PR TITLE
feat(core): version persisted session schema with migration path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing to xrpl-connect
+
+Thanks for your interest in contributing! This document covers the conventions
+that aren't already in `README.md` or enforced by tooling.
+
+## Persisted-state migrations
+
+`@xrpl-connect/core` persists wallet-connection state (the `StoredState`
+shape) through the `Storage` class in `packages/core/src/storage.ts`. The
+stored value is always wrapped in a versioned envelope:
+
+```ts
+{ version: number, payload: StoredState }
+```
+
+`Storage.loadState()` reads the envelope, runs any registered migrations to
+bring the payload up to the current version, and **never throws** —
+unrecognized, too-new, or un-migratable entries are cleared so
+`WalletManager.autoConnect` cannot fail because of stale data.
+
+### When you have to bump the version
+
+Bump `STORED_STATE_VERSION` (in `packages/core/src/storage.ts`) whenever you
+change `StoredState` in a way an older runtime cannot safely interpret:
+
+- renaming a field,
+- changing a field's type,
+- adding a field that downstream code assumes is present,
+- changing the semantic meaning of a field (e.g. switching adapter ids).
+
+Additive changes that older code would silently ignore (a new optional field
+that's never read except by new code paths) do **not** require a bump.
+
+### How to add a migration
+
+1. Bump `STORED_STATE_VERSION` to `N + 1`.
+2. Add an entry to `STATE_MIGRATIONS` keyed by `N` (the *source* version)
+   whose function takes the previous payload and returns the new shape:
+   ```ts
+   export const STATE_MIGRATIONS: Record<number, StoredStateMigration> = {
+     1: (payload) => {
+       const p = payload as OldStoredStateV1;
+       return { ...p, newField: defaultValue };
+     },
+   };
+   ```
+3. Add a unit test in `packages/core/src/storage.test.ts` that writes a
+   `version: N` envelope through `MemoryStorageAdapter` and asserts the
+   loaded result matches the new shape.
+4. Avoid throwing inside a migration — `Storage` already treats thrown
+   migrations as "discard and clear." Use that escape hatch sparingly; the
+   point of a migration is to preserve the user's session, not drop it.
+
+### What gets cleared instead of migrated
+
+`Storage.loadState()` will clear the entry and return `null` if:
+
+- the value is not JSON,
+- the value parses but isn't a `{ version, payload }` envelope (data
+  written by a pre-versioning release falls here),
+- `version` is greater than `STORED_STATE_VERSION`,
+- there's no registered migration for some intermediate version,
+- a migration throws.
+
+This is deliberate: a partially-migrated or unknown payload is worse than a
+fresh reconnect prompt.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,7 +31,14 @@ export { STANDARD_NETWORKS, WalletErrorCode } from './types';
 export { WalletError, createWalletError, isWalletError, getErrorMessage } from './errors';
 
 // Storage
-export { Storage, LocalStorageAdapter, MemoryStorageAdapter } from './storage';
+export {
+  Storage,
+  LocalStorageAdapter,
+  MemoryStorageAdapter,
+  STORED_STATE_VERSION,
+  STATE_MIGRATIONS,
+} from './storage';
+export type { StorageOptions, StoredStateEnvelope, StoredStateMigration } from './storage';
 
 // Logger
 export { Logger, createLogger } from './logger';

--- a/packages/core/src/storage.test.ts
+++ b/packages/core/src/storage.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MemoryStorageAdapter,
+  Storage,
+  STORED_STATE_VERSION,
+  type StoredStateEnvelope,
+  type StoredStateMigration,
+} from './storage';
+import type { StoredState } from './types';
+
+const STATE_KEY = 'wallet-state';
+
+const NETWORK = {
+  id: 'mainnet',
+  name: 'Mainnet',
+  wss: 'wss://example',
+};
+
+function makeState(overrides: Partial<StoredState> = {}): StoredState {
+  return {
+    walletId: 'crossmark',
+    account: {
+      address: 'rExampleAddress',
+      network: NETWORK,
+    },
+    network: NETWORK,
+    timestamp: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+describe('Storage versioning', () => {
+  it('writes a versioned envelope and reads it back', async () => {
+    const adapter = new MemoryStorageAdapter();
+    const storage = new Storage(adapter);
+    const state = makeState();
+
+    await storage.saveState(state);
+
+    const raw = await adapter.get(STATE_KEY);
+    expect(raw).not.toBeNull();
+    const envelope = JSON.parse(raw!) as StoredStateEnvelope<StoredState>;
+    expect(envelope.version).toBe(STORED_STATE_VERSION);
+    expect(envelope.payload).toEqual(state);
+
+    const loaded = await storage.loadState();
+    expect(loaded).toEqual(state);
+  });
+
+  it('migrates a v1 payload to v2 via a registered migration', async () => {
+    const adapter = new MemoryStorageAdapter();
+    const v1State = makeState({ walletId: 'legacy-id' });
+    await adapter.set(STATE_KEY, JSON.stringify({ version: 1, payload: v1State }));
+
+    const renameWalletId: StoredStateMigration = (payload) => {
+      const p = payload as StoredState & { walletId: string };
+      return { ...p, walletId: `migrated:${p.walletId}` };
+    };
+
+    const storage = new Storage({
+      adapter,
+      version: 2,
+      migrations: { 1: renameWalletId },
+    });
+
+    const loaded = await storage.loadState();
+    expect(loaded?.walletId).toBe('migrated:legacy-id');
+    expect(loaded?.account).toEqual(v1State.account);
+  });
+
+  it('discards a stored state without an envelope (pre-versioning data)', async () => {
+    const adapter = new MemoryStorageAdapter();
+    // Simulate data written by an older release: raw StoredState, no envelope.
+    await adapter.set(STATE_KEY, JSON.stringify(makeState()));
+
+    const storage = new Storage(adapter);
+    const loaded = await storage.loadState();
+
+    expect(loaded).toBeNull();
+    expect(await adapter.get(STATE_KEY)).toBeNull();
+  });
+
+  it('discards a stored state with a version newer than supported', async () => {
+    const adapter = new MemoryStorageAdapter();
+    await adapter.set(
+      STATE_KEY,
+      JSON.stringify({ version: STORED_STATE_VERSION + 1, payload: makeState() }),
+    );
+
+    const storage = new Storage(adapter);
+    const loaded = await storage.loadState();
+
+    expect(loaded).toBeNull();
+    expect(await adapter.get(STATE_KEY)).toBeNull();
+  });
+
+  it('discards a stored state when no migration path is registered', async () => {
+    const adapter = new MemoryStorageAdapter();
+    await adapter.set(STATE_KEY, JSON.stringify({ version: 1, payload: makeState() }));
+
+    // Bump to v3 with no migrations: load must clear, not throw.
+    const storage = new Storage({ adapter, version: 3, migrations: {} });
+    const loaded = await storage.loadState();
+
+    expect(loaded).toBeNull();
+    expect(await adapter.get(STATE_KEY)).toBeNull();
+  });
+
+  it('discards a stored state when migration throws', async () => {
+    const adapter = new MemoryStorageAdapter();
+    await adapter.set(STATE_KEY, JSON.stringify({ version: 1, payload: makeState() }));
+
+    const storage = new Storage({
+      adapter,
+      version: 2,
+      migrations: {
+        1: () => {
+          throw new Error('boom');
+        },
+      },
+    });
+
+    const loaded = await storage.loadState();
+    expect(loaded).toBeNull();
+    expect(await adapter.get(STATE_KEY)).toBeNull();
+  });
+
+  it('returns null and clears storage when the value is malformed JSON', async () => {
+    const adapter = new MemoryStorageAdapter();
+    await adapter.set(STATE_KEY, 'not-json{');
+
+    const storage = new Storage(adapter);
+    const loaded = await storage.loadState();
+
+    expect(loaded).toBeNull();
+    expect(await adapter.get(STATE_KEY)).toBeNull();
+  });
+});

--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -11,6 +11,42 @@ import { createLogger } from './logger';
 const logger = createLogger('[Storage]');
 
 /**
+ * Current persisted-state schema version. Bump this whenever the shape of
+ * `StoredState` changes in a way that's not safely readable by older code,
+ * and add a matching entry to `STATE_MIGRATIONS` that maps the previous
+ * version's payload to the new shape.
+ */
+export const STORED_STATE_VERSION = 1;
+
+/**
+ * Versioned envelope written to storage. Older callers that read the raw
+ * value will see `{ version, payload }` rather than a `StoredState`, and
+ * the load path uses `version` to drive migrations.
+ */
+export interface StoredStateEnvelope<T = unknown> {
+  version: number;
+  payload: T;
+}
+
+/**
+ * Migration function for upgrading a stored payload from version `N` to
+ * version `N + 1`. Receives the previous payload as `unknown` so each
+ * migration is responsible for reshaping it.
+ */
+export type StoredStateMigration = (payload: unknown) => unknown;
+
+/**
+ * Registered migrations keyed by the source version. The entry at key `N`
+ * upgrades a payload from version `N` to version `N + 1`. Migrations run
+ * sequentially until the payload reaches the current version.
+ *
+ * v1 is the first versioned schema, so there are no upgrades yet. Anything
+ * written before versioning was introduced is treated as unrecognized and
+ * cleared rather than silently coerced.
+ */
+export const STATE_MIGRATIONS: Record<number, StoredStateMigration> = {};
+
+/**
  * LocalStorage-based storage adapter
  */
 export class LocalStorageAdapter implements StorageAdapter {
@@ -94,19 +130,36 @@ export class MemoryStorageAdapter implements StorageAdapter {
 }
 
 /**
+ * Optional configuration for {@link Storage}. The `version` and `migrations`
+ * fields are overridable primarily to allow unit-testing the migration
+ * pipeline without mutating module-level state.
+ */
+export interface StorageOptions {
+  adapter?: StorageAdapter;
+  version?: number;
+  migrations?: Record<number, StoredStateMigration>;
+}
+
+/**
  * Storage manager for wallet state
  */
 export class Storage {
   private static readonly STATE_KEY = 'wallet-state';
   private adapter: StorageAdapter;
+  private version: number;
+  private migrations: Record<number, StoredStateMigration>;
 
-  constructor(adapter?: StorageAdapter) {
+  constructor(adapterOrOptions?: StorageAdapter | StorageOptions) {
+    const options = normalizeOptions(adapterOrOptions);
+
     // Default to localStorage if available, otherwise use memory storage
     this.adapter =
-      adapter ||
+      options.adapter ||
       (typeof window !== 'undefined' && window.localStorage
         ? new LocalStorageAdapter()
         : new MemoryStorageAdapter());
+    this.version = options.version ?? STORED_STATE_VERSION;
+    this.migrations = options.migrations ?? STATE_MIGRATIONS;
   }
 
   /**
@@ -114,25 +167,50 @@ export class Storage {
    */
   async saveState(state: StoredState): Promise<void> {
     try {
-      const serialized = JSON.stringify(state);
-      await this.adapter.set(Storage.STATE_KEY, serialized);
+      const envelope: StoredStateEnvelope<StoredState> = {
+        version: this.version,
+        payload: state,
+      };
+      await this.adapter.set(Storage.STATE_KEY, JSON.stringify(envelope));
     } catch (error) {
       logger.warn('Failed to save state:', error);
     }
   }
 
   /**
-   * Load wallet connection state
+   * Load wallet connection state.
+   *
+   * Reads the stored envelope, runs any registered migrations to bring the
+   * payload up to {@link STORED_STATE_VERSION}, and clears the entry instead
+   * of throwing when the data is unrecognized, too new, or un-migratable.
+   * Callers (notably `WalletManager.autoConnect`) must never see an
+   * exception from this method.
    */
   async loadState(): Promise<StoredState | null> {
+    let serialized: string | null = null;
     try {
-      const serialized = await this.adapter.get(Storage.STATE_KEY);
+      serialized = await this.adapter.get(Storage.STATE_KEY);
       if (!serialized) {
         return null;
       }
-      return JSON.parse(serialized) as StoredState;
+
+      const raw = JSON.parse(serialized) as unknown;
+      const envelope = parseEnvelope(raw);
+      if (!envelope) {
+        logger.warn('Stored state is not versioned; discarding');
+        await this.safeRemove();
+        return null;
+      }
+
+      const migrated = this.migrate(envelope);
+      if (!migrated) {
+        await this.safeRemove();
+        return null;
+      }
+      return migrated;
     } catch (error) {
       logger.warn('Failed to load state:', error);
+      await this.safeRemove();
       return null;
     }
   }
@@ -158,4 +236,64 @@ export class Storage {
       logger.warn('Failed to clear storage:', error);
     }
   }
+
+  private migrate(envelope: StoredStateEnvelope): StoredState | null {
+    let { version, payload } = envelope;
+
+    if (version > this.version) {
+      logger.warn(
+        `Stored state version ${version} is newer than supported (${this.version}); discarding`,
+      );
+      return null;
+    }
+
+    while (version < this.version) {
+      const step = this.migrations[version];
+      if (!step) {
+        logger.warn(`No migration from version ${version}; discarding stored state`);
+        return null;
+      }
+      try {
+        payload = step(payload);
+      } catch (error) {
+        logger.warn(`Migration from version ${version} failed; discarding stored state`, error);
+        return null;
+      }
+      version += 1;
+    }
+
+    return payload as StoredState;
+  }
+
+  private async safeRemove(): Promise<void> {
+    try {
+      await this.adapter.remove(Storage.STATE_KEY);
+    } catch (error) {
+      logger.warn('Failed to remove invalid stored state:', error);
+    }
+  }
+}
+
+function normalizeOptions(input?: StorageAdapter | StorageOptions): StorageOptions {
+  if (!input) {
+    return {};
+  }
+  // A StorageAdapter exposes `get`/`set`/`remove`/`clear` as functions;
+  // a StorageOptions object does not.
+  if (typeof (input as StorageAdapter).get === 'function') {
+    return { adapter: input as StorageAdapter };
+  }
+  return input as StorageOptions;
+}
+
+function parseEnvelope(raw: unknown): StoredStateEnvelope | null {
+  if (
+    raw !== null &&
+    typeof raw === 'object' &&
+    typeof (raw as { version?: unknown }).version === 'number' &&
+    'payload' in (raw as Record<string, unknown>)
+  ) {
+    return raw as StoredStateEnvelope;
+  }
+  return null;
 }


### PR DESCRIPTION
## Summary

- Wraps the persisted `StoredState` in a `{ version, payload }` envelope so the schema can evolve without crashing `autoConnect` on stale `localStorage` data.
- Adds a migration pipeline (`STATE_MIGRATIONS`, `STORED_STATE_VERSION`) that runs sequentially per source version; un-migratable / too-new / non-envelope / malformed entries are cleared and `loadState()` returns `null` instead of throwing.
- Documents the bump-and-migrate policy in a new `CONTRIBUTING.md`.

## Test plan

- [x] `pnpm test` in `packages/core` (7 new tests in `storage.test.ts`, including v1→v2 migration via a fake bump, discard-on-newer-version, discard-on-unrecognized-envelope, discard-on-throw, malformed JSON).
- [x] `pnpm lint` in `packages/core` — clean.
- [x] `pnpm build` in `packages/core` — emits updated `dist/index.d.ts` with the new exports.

Fixes #61