### PR TITLE
feat(core): expose logger config via WalletManagerOptions

### DIFF
--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -24,7 +24,7 @@ const walletManager = new WalletManager(options: WalletManagerOptions)
 | `network`     | `NetworkConfig`   | Default network (a standard id or a custom `NetworkInfo`)  |
 | `autoConnect` | `boolean`         | Auto-reconnect from stored session on initialization       |
 | `storage`     | `StorageAdapter`  | Custom storage adapter (defaults to `LocalStorageAdapter`) |
-| `logger`      | `LoggerOptions`   | `{ level?, prefix? }` to configure logging                 |
+| `logger`      | `LoggerOptions \| LoggerInstance` | `{ level?, prefix? }` to configure the built-in logger, or a custom logger object (`{ debug, info, warn, error }`) that receives all log output |
 
 `NetworkConfig` is either one of the standard keys (`'mainnet' | 'testnet' | 'devnet'`) or a `NetworkInfo` object.
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -18,12 +18,12 @@ const walletManager = new WalletManager(options: WalletManagerOptions)
 
 #### Options
 
-| Property      | Type              | Description                                                |
-| ------------- | ----------------- | ---------------------------------------------------------- |
-| `adapters`    | `WalletAdapter[]` | Array of wallet adapters to register                       |
-| `network`     | `NetworkConfig`   | Default network (a standard id or a custom `NetworkInfo`)  |
-| `autoConnect` | `boolean`         | Auto-reconnect from stored session on initialization       |
-| `storage`     | `StorageAdapter`  | Custom storage adapter (defaults to `LocalStorageAdapter`) |
+| Property      | Type                              | Description                                                                                                                                     |
+| ------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `adapters`    | `WalletAdapter[]`                 | Array of wallet adapters to register                                                                                                            |
+| `network`     | `NetworkConfig`                   | Default network (a standard id or a custom `NetworkInfo`)                                                                                       |
+| `autoConnect` | `boolean`                         | Auto-reconnect from stored session on initialization                                                                                            |
+| `storage`     | `StorageAdapter`                  | Custom storage adapter (defaults to `LocalStorageAdapter`)                                                                                      |
 | `logger`      | `LoggerOptions \| LoggerInstance` | `{ level?, prefix? }` to configure the built-in logger, or a custom logger object (`{ debug, info, warn, error }`) that receives all log output |
 
 `NetworkConfig` is either one of the standard keys (`'mainnet' | 'testnet' | 'devnet'`) or a `NetworkInfo` object.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -45,11 +45,19 @@ interface WalletManagerOptions {
   network?: NetworkConfig | string; // Default network ('mainnet', 'testnet', 'devnet')
   autoConnect?: boolean; // Attempt to reconnect from stored state
   storage?: StorageAdapter; // Custom storage implementation (defaults to LocalStorageAdapter)
-  logger?: LoggerOptions; // Logging configuration
+  logger?: LoggerOptions | LoggerInstance; // Logging configuration — pass options or a custom logger
 }
 
 interface LoggerOptions {
-  level?: 'debug' | 'info' | 'warn' | 'error' | 'none'; // Log level (default: 'info')
+  level?: 'debug' | 'info' | 'warn' | 'error' | 'silent' | 'none'; // 'none' is a deprecated alias for 'silent'
+  prefix?: string;
+}
+
+interface LoggerInstance {
+  debug(message: string, ...args: unknown[]): void;
+  info(message: string, ...args: unknown[]): void;
+  warn(message: string, ...args: unknown[]): void;
+  error(message: string, ...args: unknown[]): void;
 }
 ```
 
@@ -546,18 +554,34 @@ const manager = new WalletManager({
 
 ## Logging
 
-The core includes a configurable logger for debugging.
+The core includes a configurable logger for debugging. The configuration passed to
+`WalletManager` is applied globally, so adapter-level loggers honour the same
+level or routing decisions.
 
 ### Logger Configuration
+
+Set a log level via `LoggerOptions`:
 
 ```typescript
 const manager = new WalletManager({
   adapters: [...],
   logger: {
-    level: 'debug'  // 'debug', 'info', 'warn', 'error', 'none'
-  }
+    level: 'debug', // 'debug' | 'info' | 'warn' | 'error' | 'silent'
+  },
 });
 ```
+
+Silence all output (e.g. in production):
+
+```typescript
+const manager = new WalletManager({
+  adapters: [...],
+  logger: { level: 'silent' },
+});
+```
+
+**Defaults**: when no level is provided, `'debug'` is used in development
+(`NODE_ENV === 'development'` or localhost) and `'warn'` everywhere else.
 
 **Log Levels**:
 
@@ -565,7 +589,32 @@ const manager = new WalletManager({
 - `info`: General information messages
 - `warn`: Warning messages
 - `error`: Error messages only
-- `none`: No logging
+- `silent`: No logging (`'none'` is a deprecated alias)
+
+### Routing logs to a custom logger
+
+Pass any object that implements `LoggerInstance` (matching the `console.*`
+shape) to send all log calls — including those emitted by individual adapters —
+into your own logging pipeline (Sentry, Datadog, pino, etc.):
+
+```typescript
+import type { LoggerInstance } from '@xrpl-connect/core';
+
+const appLogger: LoggerInstance = {
+  debug: (msg, ...args) => myLogger.trace({ msg, args }),
+  info: (msg, ...args) => myLogger.info({ msg, args }),
+  warn: (msg, ...args) => myLogger.warn({ msg, args }),
+  error: (msg, ...args) => myLogger.error({ msg, args }),
+};
+
+const manager = new WalletManager({
+  adapters: [...],
+  logger: appLogger,
+});
+```
+
+The supplied instance receives messages from the manager and every registered
+adapter, each prefixed with its source (e.g. `[Xaman] Connecting…`).
 
 ---
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,8 @@ export type {
   StorageAdapter,
   StoredState,
   LoggerOptions,
+  LoggerInstance,
+  LogLevel,
 } from './types';
 
 export { STANDARD_NETWORKS, WalletErrorCode } from './types';
@@ -34,7 +36,7 @@ export { WalletError, createWalletError, isWalletError, getErrorMessage } from '
 export { Storage, LocalStorageAdapter, MemoryStorageAdapter } from './storage';
 
 // Logger
-export { Logger, createLogger } from './logger';
+export { Logger, createLogger, configureLogger, isLoggerInstance } from './logger';
 
 // Constants
 export { TIME } from './constants';

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,19 +1,24 @@
 /**
  * Logging system for xrpl-connect
- * Supports dev/prod mode with configurable log levels
+ * Supports dev/prod mode with configurable log levels and custom logger instances
  */
 
-import type { LoggerOptions } from './types';
+import type { LoggerOptions, LoggerInstance, LogLevel } from './types';
 
-type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'none';
+type InternalLogLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent';
 
-const LOG_LEVELS: Record<LogLevel, number> = {
+const LOG_LEVELS: Record<InternalLogLevel, number> = {
   debug: 0,
   info: 1,
   warn: 2,
   error: 3,
-  none: 4,
+  silent: 4,
 };
+
+function normalizeLevel(level: LogLevel | undefined): InternalLogLevel | undefined {
+  if (!level) return undefined;
+  return level === 'none' ? 'silent' : level;
+}
 
 /**
  * Detect if running in development mode
@@ -34,31 +39,98 @@ function isDevelopment(): boolean {
 }
 
 /**
- * Logger class for structured logging
- * In development: logs debug, info, warn, error
- * In production: logs only warn and error
+ * Type guard for a user-supplied LoggerInstance.
+ */
+export function isLoggerInstance(value: unknown): value is LoggerInstance {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.debug === 'function' &&
+    typeof candidate.info === 'function' &&
+    typeof candidate.warn === 'function' &&
+    typeof candidate.error === 'function'
+  );
+}
+
+interface GlobalLoggerConfig {
+  instance?: LoggerInstance;
+  level?: InternalLogLevel;
+}
+
+let globalConfig: GlobalLoggerConfig = {};
+
+/**
+ * Configure the global logger used by every `Logger` instance — including the
+ * per-adapter loggers created via `createLogger`. Called by `WalletManager`
+ * when a consumer passes `logger` in `WalletManagerOptions`.
+ *
+ * - A `LoggerInstance` routes every subsequent log call (from the manager and
+ *   all adapters) into the supplied object.
+ * - A `LoggerOptions` value sets a global default level. Per-logger overrides
+ *   still win when explicitly set.
+ * - `undefined` resets the global configuration.
+ */
+export function configureLogger(option: LoggerOptions | LoggerInstance | undefined): void {
+  if (option === undefined) {
+    globalConfig = {};
+    return;
+  }
+  if (isLoggerInstance(option)) {
+    globalConfig = { instance: option };
+    return;
+  }
+  globalConfig = { level: normalizeLevel(option.level) };
+}
+
+/**
+ * Reset the global logger configuration. Exposed primarily for tests.
+ */
+export function resetGlobalLogger(): void {
+  globalConfig = {};
+}
+
+/**
+ * Logger class for structured logging.
+ *
+ * Resolution order for the effective level:
+ *   1. Explicit level passed to the constructor / `setLevel`.
+ *   2. Global level set via `configureLogger`.
+ *   3. `'debug'` in development, `'warn'` in production.
+ *
+ * When a custom `LoggerInstance` is configured globally, all log calls are
+ * routed to that instance instead of `console.*`.
  */
 export class Logger {
-  private level: LogLevel;
+  private localLevel?: InternalLogLevel;
   private prefix: string;
 
   constructor(options: LoggerOptions = {}) {
-    // Auto-detect level based on environment if not explicitly set
-    this.level = options.level || (isDevelopment() ? 'debug' : 'warn');
+    this.localLevel = normalizeLevel(options.level);
     this.prefix = options.prefix || '[xrpl-connect]';
+  }
+
+  /**
+   * Compute the level that should apply to this logger right now.
+   */
+  private effectiveLevel(): InternalLogLevel {
+    if (this.localLevel) return this.localLevel;
+    if (globalConfig.level) return globalConfig.level;
+    return isDevelopment() ? 'debug' : 'warn';
   }
 
   /**
    * Check if a log level should be output
    */
-  private shouldLog(level: LogLevel): boolean {
-    return LOG_LEVELS[level] >= LOG_LEVELS[this.level];
+  private shouldLog(level: Exclude<InternalLogLevel, 'silent'>): boolean {
+    const effective = this.effectiveLevel();
+    if (effective === 'silent') return false;
+    return LOG_LEVELS[level] >= LOG_LEVELS[effective];
   }
 
   /**
    * Format log message with prefix
    */
-  private formatMessage(level: LogLevel, message: string): string {
+  private formatMessage(level: InternalLogLevel, message: string): string {
     const timestamp = new Date().toISOString();
     return `${this.prefix} [${level.toUpperCase()}] ${timestamp} - ${message}`;
   }
@@ -67,50 +139,62 @@ export class Logger {
    * Log debug message
    */
   debug(message: string, ...args: unknown[]): void {
-    if (this.shouldLog('debug')) {
-      console.debug(this.formatMessage('debug', message), ...args);
+    if (!this.shouldLog('debug')) return;
+    if (globalConfig.instance) {
+      globalConfig.instance.debug(`${this.prefix} ${message}`, ...args);
+      return;
     }
+    console.debug(this.formatMessage('debug', message), ...args);
   }
 
   /**
    * Log info message
    */
   info(message: string, ...args: unknown[]): void {
-    if (this.shouldLog('info')) {
-      console.info(this.formatMessage('info', message), ...args);
+    if (!this.shouldLog('info')) return;
+    if (globalConfig.instance) {
+      globalConfig.instance.info(`${this.prefix} ${message}`, ...args);
+      return;
     }
+    console.info(this.formatMessage('info', message), ...args);
   }
 
   /**
    * Log warning message
    */
   warn(message: string, ...args: unknown[]): void {
-    if (this.shouldLog('warn')) {
-      console.warn(this.formatMessage('warn', message), ...args);
+    if (!this.shouldLog('warn')) return;
+    if (globalConfig.instance) {
+      globalConfig.instance.warn(`${this.prefix} ${message}`, ...args);
+      return;
     }
+    console.warn(this.formatMessage('warn', message), ...args);
   }
 
   /**
    * Log error message
    */
   error(message: string, ...args: unknown[]): void {
-    if (this.shouldLog('error')) {
-      console.error(this.formatMessage('error', message), ...args);
+    if (!this.shouldLog('error')) return;
+    if (globalConfig.instance) {
+      globalConfig.instance.error(`${this.prefix} ${message}`, ...args);
+      return;
     }
+    console.error(this.formatMessage('error', message), ...args);
   }
 
   /**
    * Update log level
    */
   setLevel(level: LogLevel): void {
-    this.level = level;
+    this.localLevel = normalizeLevel(level);
   }
 
   /**
-   * Get current log level
+   * Get current effective log level
    */
-  getLevel(): LogLevel {
-    return this.level;
+  getLevel(): InternalLogLevel {
+    return this.effectiveLevel();
   }
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -152,7 +152,7 @@ export interface WalletManagerOptions {
   network?: NetworkConfig; // Default network
   autoConnect?: boolean; // Auto-reconnect on initialization
   storage?: StorageAdapter; // Custom storage (default: localStorage)
-  logger?: LoggerOptions; // Logging configuration
+  logger?: LoggerOptions | LoggerInstance; // Logging configuration (level options or a custom logger instance)
 }
 
 /**
@@ -176,12 +176,31 @@ export interface StoredState {
 }
 
 /**
+ * Supported log levels.
+ * `'silent'` disables all output; `'none'` is a deprecated alias kept for backwards compatibility.
+ */
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent' | 'none';
+
+/**
  * Logger configuration options
  * Level is optional - defaults to 'debug' in development, 'warn' in production
  */
 export interface LoggerOptions {
-  level?: 'debug' | 'info' | 'warn' | 'error' | 'none';
+  level?: LogLevel;
   prefix?: string;
+}
+
+/**
+ * A custom logger object the application can supply to route log output
+ * (e.g. into Sentry, Datadog, or any structured logging stack).
+ *
+ * Method signatures match `console.debug/info/warn/error`.
+ */
+export interface LoggerInstance {
+  debug(message: string, ...args: unknown[]): void;
+  info(message: string, ...args: unknown[]): void;
+  warn(message: string, ...args: unknown[]): void;
+  error(message: string, ...args: unknown[]): void;
 }
 
 /**

--- a/packages/core/src/wallet-manager.ts
+++ b/packages/core/src/wallet-manager.ts
@@ -17,7 +17,7 @@ import type {
   StoredState,
 } from './types';
 import { createWalletError } from './errors';
-import { Logger } from './logger';
+import { Logger, configureLogger, isLoggerInstance } from './logger';
 import { Storage } from './storage';
 import { TIME } from './constants';
 
@@ -36,8 +36,11 @@ export class WalletManager extends EventEmitter<WalletEvent> {
     super();
     this.options = options;
 
-    // Initialize logger
-    this.logger = new Logger(options.logger);
+    // Apply logger configuration globally so adapter-level loggers honour it,
+    // then build the manager's own Logger. A user-supplied LoggerInstance
+    // routes through `configureLogger`; LoggerOptions also drive the local logger.
+    configureLogger(options.logger);
+    this.logger = new Logger(isLoggerInstance(options.logger) ? undefined : options.logger);
 
     // Initialize storage
     this.storage = new Storage(options.storage);


### PR DESCRIPTION
## Summary

- `WalletManager` now accepts either a `LoggerOptions` (with the new `'silent'` level) or a custom `LoggerInstance` via `WalletManagerOptions.logger`.
- A new `configureLogger` global hook makes per-adapter loggers (`createLogger('[Xaman]')`, etc.) honour the manager's configuration, so silencing or rerouting one place propagates everywhere.
- README and API reference updated; `LoggerInstance` and `LogLevel` are exported from `@xrpl-connect/core`.

## Test plan

- [x] `pnpm --filter @xrpl-connect/core lint` (clean)
- [x] `pnpm --filter @xrpl-connect/core build` (clean)
- [x] `pnpm build` at repo root (all 13 turbo tasks succeed)
- [ ] `new WalletManager({ logger: { level: 'silent' } })` produces no console output
- [ ] `new WalletManager({ logger: customLoggerInstance })` routes manager + adapter logs into `customLoggerInstance`

Fixes #65