### PR TITLE
fix: isolate per-instance state in WalletConnect and Xaman adapters

### DIFF
--- a/packages/adapters/walletconnect/src/walletconnect-adapter.ts
+++ b/packages/adapters/walletconnect/src/walletconnect-adapter.ts
@@ -82,6 +82,8 @@ export class WalletConnectAdapter implements WalletAdapter {
   private pendingConnection: { uri: string; approval: () => Promise<SessionTypes.Struct> } | null =
     null;
   private modal: WalletConnectModal | null = null;
+  private sessionDeleteHandler: (() => void) | null = null;
+  private sessionExpireHandler: (() => void) | null = null;
 
   constructor(options: WalletConnectAdapterOptions = {}) {
     this.options = options;
@@ -315,11 +317,16 @@ export class WalletConnectAdapter implements WalletAdapter {
         let uri: string;
         let approval: () => Promise<SessionTypes.Struct>;
 
-        // Check if we have a pending connection from pre-initialization
-        if (this.pendingConnection) {
+        // Check if we have a pending connection from pre-initialization.
+        // Consume it immediately so a retry after this connect() fails (or a
+        // concurrent call) does not reuse the same approval promise.
+        const pending = this.pendingConnection;
+        this.pendingConnection = null;
+
+        if (pending) {
           logger.debug('Using pre-generated connection');
-          uri = this.pendingConnection.uri;
-          approval = this.pendingConnection.approval;
+          uri = pending.uri;
+          approval = pending.approval;
 
           if (onQRCode) {
             logger.debug('Calling onQRCode callback with pre-generated URI');
@@ -379,6 +386,8 @@ export class WalletConnectAdapter implements WalletAdapter {
       if (this.modal) {
         this.modal.closeModal();
       }
+      // Drop any stale pending connection so the next connect() starts fresh
+      this.pendingConnection = null;
       throw createWalletError.connectionFailed(this.name, error as Error);
     }
   }
@@ -525,21 +534,36 @@ export class WalletConnectAdapter implements WalletAdapter {
   private setupEventListeners(): void {
     if (!this.client) return;
 
-    // Session delete event
-    this.client.on('session_delete', () => {
-      this.cleanup();
-    });
+    // Tear down any handlers from a previous session before re-binding, so
+    // listeners don't accumulate across connect/disconnect cycles.
+    this.removeEventListeners();
 
-    // Session expire event
-    this.client.on('session_expire', () => {
-      this.cleanup();
-    });
+    this.sessionDeleteHandler = () => this.cleanup();
+    this.sessionExpireHandler = () => this.cleanup();
+
+    this.client.on('session_delete', this.sessionDeleteHandler);
+    this.client.on('session_expire', this.sessionExpireHandler);
+  }
+
+  private removeEventListeners(): void {
+    if (this.client) {
+      if (this.sessionDeleteHandler) {
+        this.client.off('session_delete', this.sessionDeleteHandler);
+      }
+      if (this.sessionExpireHandler) {
+        this.client.off('session_expire', this.sessionExpireHandler);
+      }
+    }
+    this.sessionDeleteHandler = null;
+    this.sessionExpireHandler = null;
   }
 
   /**
    * Cleanup adapter state
    */
   private cleanup(): void {
+    this.removeEventListeners();
+
     // Close and cleanup modal
     if (this.modal) {
       this.modal.closeModal();

--- a/packages/adapters/xaman/src/xaman-adapter.ts
+++ b/packages/adapters/xaman/src/xaman-adapter.ts
@@ -50,6 +50,12 @@ export class XamanAdapter implements WalletAdapter {
   private client: Xumm | null = null;
   private currentAccount: AccountInfo | null = null;
   private options: XamanAdapterOptions;
+  // Per-connection callback overrides. Populated by connect() and cleared by
+  // cleanup(); avoids mutating constructor-supplied options across calls.
+  private activeCallbacks: {
+    onQRCode?: (uri: string) => void;
+    onDeepLink?: (uri: string) => string;
+  } = {};
 
   constructor(options: XamanAdapterOptions = {}) {
     this.options = options;
@@ -129,17 +135,16 @@ export class XamanAdapter implements WalletAdapter {
       );
     }
 
-    // Merge runtime options with constructor options (runtime takes precedence)
-    const onQRCode = options?.onQRCode || this.options.onQRCode;
-    const onDeepLink = options?.onDeepLink || this.options.onDeepLink;
+    // Reset any leftover state from a previous connection attempt so a fast
+    // disconnect → connect cycle doesn't carry stale client/callbacks forward.
+    this.cleanup();
 
-    // Temporarily store callbacks for use in openSignWindow
-    if (onQRCode) {
-      this.options.onQRCode = onQRCode;
-    }
-    if (onDeepLink) {
-      this.options.onDeepLink = onDeepLink;
-    }
+    // Stash per-connection callback overrides without mutating constructor
+    // options — those must remain valid for any future connect() call.
+    this.activeCallbacks = {
+      onQRCode: options?.onQRCode,
+      onDeepLink: options?.onDeepLink,
+    };
 
     try {
       this.client = new Xumm(apiKey);
@@ -170,6 +175,9 @@ export class XamanAdapter implements WalletAdapter {
       return this.currentAccount;
     } catch (error) {
       logger.error('Authorization failed:', error);
+      // Drop the half-initialized client + per-connection callbacks so the
+      // next connect() starts from a clean slate.
+      this.cleanup();
       throw createWalletError.connectionFailed(this.name, error as Error);
     }
   }
@@ -360,12 +368,13 @@ export class XamanAdapter implements WalletAdapter {
    */
   private openSignWindow(url: string): void {
     logger.debug('openSignWindow called with URL:', url.substring(0, 50) + '...');
-    logger.debug('onQRCode callback exists:', !!this.options.onQRCode);
+    const onQRCode = this.activeCallbacks.onQRCode || this.options.onQRCode;
+    logger.debug('onQRCode callback exists:', !!onQRCode);
 
     // If QR code callback is provided, use that instead of popup
-    if (this.options.onQRCode) {
+    if (onQRCode) {
       logger.debug('Calling onQRCode callback');
-      this.options.onQRCode(url);
+      onQRCode(url);
       return;
     }
 
@@ -387,8 +396,9 @@ export class XamanAdapter implements WalletAdapter {
    * Get deep link URI for mobile (Xaman app)
    */
   public getDeepLinkURI(url: string): string {
-    if (this.options.onDeepLink) {
-      return this.options.onDeepLink(url);
+    const onDeepLink = this.activeCallbacks.onDeepLink || this.options.onDeepLink;
+    if (onDeepLink) {
+      return onDeepLink(url);
     }
     // Xaman deep link format
     return `xumm://xumm.app/sign/${url.split('/').pop()}`;
@@ -457,7 +467,7 @@ export class XamanAdapter implements WalletAdapter {
   private cleanup(): void {
     this.client = null;
     this.currentAccount = null;
-    // Don't clear pending payload on disconnect - it might still be needed
+    this.activeCallbacks = {};
   }
 
   /**


### PR DESCRIPTION
## Summary

Adapter connection state was leaking across instances and across rapid connect/disconnect cycles. This patch isolates per-instance lifecycle so two adapters don't collide and a re-connect doesn't see stale state.

- **WalletConnect** (`packages/adapters/walletconnect/src/walletconnect-adapter.ts`)
  - `connect()` now consumes `pendingConnection` once and nulls it before awaiting approval, so a retry can't reuse an already-resolved (or failed) approval promise from `preInitialize()`.
  - `pendingConnection` is also cleared in the `connect()` error path so it never survives a failed attempt.
  - Session `session_delete` / `session_expire` handlers are kept on instance fields and detached in `cleanup()` (via `client.off`) instead of accumulating across connect/disconnect cycles.

- **Xaman** (`packages/adapters/xaman/src/xaman-adapter.ts`)
  - `connect()` no longer mutates `this.options` to stash runtime callbacks — runtime callbacks now live in a separate `activeCallbacks` bag so constructor options remain pristine across successive `connect()` calls with different overrides.
  - `connect()` calls `cleanup()` on entry to drop any leftover client/account from a previous attempt, and also on failure so a half-initialized `Xumm` client isn't left behind.
  - `openSignWindow()` and `getDeepLinkURI()` prefer the per-connection callback over the constructor-supplied one.
  - Removed a stale comment in `cleanup()` referencing a "pending payload" field that no longer exists.

## Test plan

- [x] `pnpm build` — full turbo build (13/13 tasks green)
- [x] `pnpm lint` — no new errors (pre-existing `no-explicit-any` warnings only)
- [x] `pnpm test` — existing UI suite (4 tests) passes; adapter packages have no tests
- [ ] Manual: rapid `connect → disconnect → connect` against a real WalletConnect / Xaman session leaves no leftover URI, listeners, or callback overrides
- [ ] Manual: two `XamanAdapter` instances configured with different `onQRCode` callbacks each receive only their own URI

Fixes #59