### PR TITLE
test(adapters): add vitest coverage for 7 wallet adapters

### DIFF
--- a/packages/adapters/crossmark/tests/crossmark-adapter.test.ts
+++ b/packages/adapters/crossmark/tests/crossmark-adapter.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { WalletErrorCode } from '@xrpl-connect/core';
+
+vi.mock('@crossmarkio/sdk', () => {
+  const sdk = {
+    sync: { isInstalled: vi.fn() },
+    methods: {
+      signInAndWait: vi.fn(),
+      signAndWait: vi.fn(),
+      signAndSubmitAndWait: vi.fn(),
+    },
+  };
+  return { default: sdk };
+});
+
+import sdkDefault from '@crossmarkio/sdk';
+import { CrossmarkAdapter } from '../src/crossmark-adapter';
+
+const sdk = sdkDefault as unknown as {
+  sync: { isInstalled: ReturnType<typeof vi.fn> };
+  methods: {
+    signInAndWait: ReturnType<typeof vi.fn>;
+    signAndWait: ReturnType<typeof vi.fn>;
+    signAndSubmitAndWait: ReturnType<typeof vi.fn>;
+  };
+};
+
+beforeEach(() => {
+  sdk.sync.isInstalled.mockReset();
+  sdk.methods.signInAndWait.mockReset();
+  sdk.methods.signAndWait.mockReset();
+  sdk.methods.signAndSubmitAndWait.mockReset();
+});
+
+describe('CrossmarkAdapter.isAvailable', () => {
+  it('returns true when the extension reports installed', async () => {
+    sdk.sync.isInstalled.mockReturnValue(true);
+    const adapter = new CrossmarkAdapter();
+    await expect(adapter.isAvailable()).resolves.toBe(true);
+  });
+
+  it('returns false when the extension reports not installed', async () => {
+    sdk.sync.isInstalled.mockReturnValue(false);
+    const adapter = new CrossmarkAdapter();
+    await expect(adapter.isAvailable()).resolves.toBe(false);
+  });
+
+  it('returns false when the underlying check throws', async () => {
+    sdk.sync.isInstalled.mockImplementation(() => {
+      throw new Error('boom');
+    });
+    const adapter = new CrossmarkAdapter();
+    await expect(adapter.isAvailable()).resolves.toBe(false);
+  });
+});
+
+describe('CrossmarkAdapter.connect', () => {
+  it('returns account info on success', async () => {
+    sdk.sync.isInstalled.mockReturnValue(true);
+    sdk.methods.signInAndWait.mockResolvedValue({
+      response: { data: { address: 'rUserAddress', publicKey: 'PUBKEY' } },
+    });
+
+    const adapter = new CrossmarkAdapter();
+    const account = await adapter.connect();
+
+    expect(account.address).toBe('rUserAddress');
+    expect(account.publicKey).toBe('PUBKEY');
+    expect(account.network.id).toBe('mainnet');
+  });
+
+  it('wraps "not installed" into a connection error', async () => {
+    sdk.sync.isInstalled.mockReturnValue(false);
+    const adapter = new CrossmarkAdapter();
+
+    await expect(adapter.connect()).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+    });
+  });
+
+  it('wraps user rejection into a connection error', async () => {
+    sdk.sync.isInstalled.mockReturnValue(true);
+    sdk.methods.signInAndWait.mockRejectedValue(new Error('User rejected'));
+    const adapter = new CrossmarkAdapter();
+
+    await expect(adapter.connect()).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+    });
+  });
+});
+
+describe('CrossmarkAdapter.sign', () => {
+  async function connected() {
+    sdk.sync.isInstalled.mockReturnValue(true);
+    sdk.methods.signInAndWait.mockResolvedValue({
+      response: { data: { address: 'rUser', publicKey: 'PK' } },
+    });
+    const adapter = new CrossmarkAdapter();
+    await adapter.connect();
+    return adapter;
+  }
+
+  it('returns tx_blob on success', async () => {
+    const adapter = await connected();
+    sdk.methods.signAndWait.mockResolvedValue({
+      response: { data: { txBlob: 'DEADBEEF' } },
+    });
+
+    const result = await adapter.sign({ TransactionType: 'Payment' } as never);
+
+    expect(result.tx_blob).toBe('DEADBEEF');
+  });
+
+  it('throws notConnected when no account is set', async () => {
+    const adapter = new CrossmarkAdapter();
+    await expect(adapter.sign({ TransactionType: 'Payment' } as never)).rejects.toMatchObject({
+      code: WalletErrorCode.NOT_CONNECTED,
+    });
+  });
+
+  it('maps user rejection to a sign-rejected error', async () => {
+    const adapter = await connected();
+    sdk.methods.signAndWait.mockRejectedValue(new Error('User Rejected the signature'));
+
+    await expect(adapter.sign({ TransactionType: 'Payment' } as never)).rejects.toMatchObject({
+      code: WalletErrorCode.SIGN_REJECTED,
+    });
+  });
+});
+
+describe('CrossmarkAdapter.disconnect', () => {
+  it('clears the connected account', async () => {
+    sdk.sync.isInstalled.mockReturnValue(true);
+    sdk.methods.signInAndWait.mockResolvedValue({
+      response: { data: { address: 'rUser', publicKey: 'PK' } },
+    });
+    const adapter = new CrossmarkAdapter();
+    await adapter.connect();
+    expect(await adapter.getAccount()).not.toBeNull();
+
+    await adapter.disconnect();
+
+    expect(await adapter.getAccount()).toBeNull();
+  });
+});

--- a/packages/adapters/gemwallet/tests/gemwallet-adapter.test.ts
+++ b/packages/adapters/gemwallet/tests/gemwallet-adapter.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { WalletErrorCode } from '@xrpl-connect/core';
+
+vi.mock('@gemwallet/api', () => ({
+  isInstalled: vi.fn(),
+  getPublicKey: vi.fn(),
+  signMessage: vi.fn(),
+  signTransaction: vi.fn(),
+  submitTransaction: vi.fn(),
+}));
+
+import * as gemApi from '@gemwallet/api';
+import { GemWalletAdapter } from '../src/gemwallet-adapter';
+
+const api = gemApi as unknown as Record<keyof typeof gemApi, ReturnType<typeof vi.fn>>;
+
+beforeEach(() => {
+  api.isInstalled.mockReset();
+  api.getPublicKey.mockReset();
+  api.signMessage.mockReset();
+  api.signTransaction.mockReset();
+  api.submitTransaction.mockReset();
+});
+
+describe('GemWalletAdapter.isAvailable', () => {
+  it('returns true when extension reports installed', async () => {
+    api.isInstalled.mockResolvedValue({ result: { isInstalled: true } });
+    await expect(new GemWalletAdapter().isAvailable()).resolves.toBe(true);
+  });
+
+  it('returns false when extension reports not installed', async () => {
+    api.isInstalled.mockResolvedValue({ result: { isInstalled: false } });
+    await expect(new GemWalletAdapter().isAvailable()).resolves.toBe(false);
+  });
+
+  it('returns false when the call throws', async () => {
+    api.isInstalled.mockRejectedValue(new Error('boom'));
+    await expect(new GemWalletAdapter().isAvailable()).resolves.toBe(false);
+  });
+});
+
+describe('GemWalletAdapter.connect', () => {
+  it('returns the account on success', async () => {
+    api.isInstalled.mockResolvedValue({ result: { isInstalled: true } });
+    api.getPublicKey.mockResolvedValue({ result: { address: 'rGem', publicKey: 'PK' } });
+
+    const account = await new GemWalletAdapter().connect();
+
+    expect(account.address).toBe('rGem');
+    expect(account.publicKey).toBe('PK');
+    expect(account.network.id).toBe('mainnet');
+  });
+
+  it('throws a wrapped connection error when not installed', async () => {
+    api.isInstalled.mockResolvedValue({ result: { isInstalled: false } });
+    await expect(new GemWalletAdapter().connect()).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+    });
+  });
+
+  it('wraps user rejection into a connection error', async () => {
+    api.isInstalled.mockResolvedValue({ result: { isInstalled: true } });
+    api.getPublicKey.mockRejectedValue(new Error('User rejected request'));
+    await expect(new GemWalletAdapter().connect()).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+    });
+  });
+});
+
+describe('GemWalletAdapter.sign', () => {
+  async function connected() {
+    api.isInstalled.mockResolvedValue({ result: { isInstalled: true } });
+    api.getPublicKey.mockResolvedValue({ result: { address: 'rGem', publicKey: 'PK' } });
+    const adapter = new GemWalletAdapter();
+    await adapter.connect();
+    return adapter;
+  }
+
+  it('returns the signed tx blob on success', async () => {
+    const adapter = await connected();
+    api.signTransaction.mockResolvedValue({ result: { signature: 'SIG' } });
+
+    const result = await adapter.sign({ TransactionType: 'Payment' } as never);
+
+    expect(result.tx_blob).toBe('SIG');
+  });
+
+  it('throws notConnected when no session exists', async () => {
+    const adapter = new GemWalletAdapter();
+    await expect(adapter.sign({ TransactionType: 'Payment' } as never)).rejects.toMatchObject({
+      code: WalletErrorCode.NOT_CONNECTED,
+    });
+  });
+
+  it('maps rejection to sign-rejected', async () => {
+    const adapter = await connected();
+    api.signTransaction.mockRejectedValue(new Error('User Rejected'));
+
+    await expect(adapter.sign({ TransactionType: 'Payment' } as never)).rejects.toMatchObject({
+      code: WalletErrorCode.SIGN_REJECTED,
+    });
+  });
+});
+
+describe('GemWalletAdapter.disconnect', () => {
+  it('clears the current account', async () => {
+    api.isInstalled.mockResolvedValue({ result: { isInstalled: true } });
+    api.getPublicKey.mockResolvedValue({ result: { address: 'rGem', publicKey: 'PK' } });
+    const adapter = new GemWalletAdapter();
+    await adapter.connect();
+    expect(await adapter.getAccount()).not.toBeNull();
+
+    await adapter.disconnect();
+
+    expect(await adapter.getAccount()).toBeNull();
+  });
+});

--- a/packages/adapters/ledger/tests/ledger-adapter.test.ts
+++ b/packages/adapters/ledger/tests/ledger-adapter.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WalletErrorCode } from '@xrpl-connect/core';
+
+const mocks = vi.hoisted(() => {
+  const transportWebHID = { create: vi.fn() };
+  const transportWebUSB = { create: vi.fn() };
+  const mockTransport = { close: vi.fn().mockResolvedValue(undefined) };
+  const xrpAppInstance = {
+    getAddress: vi.fn(),
+    signTransaction: vi.fn(),
+  };
+  return { transportWebHID, transportWebUSB, mockTransport, xrpAppInstance };
+});
+
+const { transportWebHID, transportWebUSB, mockTransport, xrpAppInstance } = mocks;
+
+vi.mock('@ledgerhq/hw-transport-webhid', () => ({
+  default: mocks.transportWebHID,
+}));
+
+vi.mock('@ledgerhq/hw-transport-webusb', () => ({
+  default: mocks.transportWebUSB,
+}));
+
+vi.mock('@ledgerhq/hw-app-xrp', () => ({
+  default: vi.fn().mockImplementation(() => mocks.xrpAppInstance),
+}));
+
+vi.mock('xrpl', () => ({
+  encode: vi.fn(() => 'encodedblob'),
+  Client: vi.fn().mockImplementation(() => ({
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    autofill: vi.fn(async (tx) => ({ ...tx, Sequence: 1, Fee: '10' })),
+    submitAndWait: vi.fn().mockResolvedValue({ result: { hash: 'HASH' } }),
+  })),
+}));
+
+import { LedgerAdapter } from '../src/ledger-adapter';
+
+function installNavigator(value: Record<string, unknown> | undefined) {
+  if (value === undefined) {
+    vi.unstubAllGlobals();
+  } else {
+    vi.stubGlobal('navigator', value);
+  }
+}
+
+beforeEach(() => {
+  transportWebHID.create.mockReset();
+  transportWebUSB.create.mockReset();
+  xrpAppInstance.getAddress.mockReset();
+  xrpAppInstance.signTransaction.mockReset();
+  transportWebHID.create.mockResolvedValue(mockTransport);
+  transportWebUSB.create.mockResolvedValue(mockTransport);
+});
+
+afterEach(() => {
+  installNavigator(undefined);
+});
+
+describe('LedgerAdapter.isAvailable', () => {
+  it('returns true when WebHID is supported', async () => {
+    installNavigator({ hid: {} });
+    await expect(new LedgerAdapter().isAvailable()).resolves.toBe(true);
+  });
+
+  it('returns true when only WebUSB is supported', async () => {
+    installNavigator({ usb: {} });
+    await expect(new LedgerAdapter().isAvailable()).resolves.toBe(true);
+  });
+
+  it('returns false when neither WebHID nor WebUSB is available', async () => {
+    installNavigator({});
+    await expect(new LedgerAdapter().isAvailable()).resolves.toBe(false);
+  });
+});
+
+describe('LedgerAdapter.connect', () => {
+  it('returns account info on success', async () => {
+    installNavigator({ hid: {} });
+    xrpAppInstance.getAddress.mockResolvedValue({
+      address: 'rLedger',
+      publicKey: 'aabbcc',
+    });
+
+    const account = await new LedgerAdapter().connect();
+
+    expect(account.address).toBe('rLedger');
+    expect(account.network.id).toBe('mainnet');
+  });
+
+  it('wraps "no device" errors as not-installed', async () => {
+    installNavigator({ hid: {} });
+    xrpAppInstance.getAddress.mockRejectedValue(new Error('No device found'));
+
+    await expect(new LedgerAdapter().connect()).rejects.toMatchObject({
+      code: WalletErrorCode.WALLET_NOT_INSTALLED,
+    });
+  });
+
+  it('wraps user rejection (statusCode 0x6985) as a connection failure', async () => {
+    installNavigator({ hid: {} });
+    const rejected = Object.assign(new Error('rejected'), { statusCode: 0x6985 });
+    xrpAppInstance.getAddress.mockRejectedValue(rejected);
+
+    await expect(new LedgerAdapter().connect()).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+    });
+  });
+});
+
+describe('LedgerAdapter.sign', () => {
+  async function connected() {
+    installNavigator({ hid: {} });
+    xrpAppInstance.getAddress.mockResolvedValue({
+      address: 'rLedger',
+      publicKey: 'aabbcc',
+    });
+    const adapter = new LedgerAdapter();
+    await adapter.connect();
+    return adapter;
+  }
+
+  it('throws notConnected when no account is set', async () => {
+    installNavigator({ hid: {} });
+    const adapter = new LedgerAdapter();
+    await expect(adapter.sign({ TransactionType: 'Payment' } as never)).rejects.toMatchObject({
+      // The adapter wraps the underlying notConnected in signFailed
+      code: WalletErrorCode.SIGN_FAILED,
+    });
+  });
+
+  it('signs successfully when the device returns a signature', async () => {
+    const adapter = await connected();
+    xrpAppInstance.signTransaction.mockResolvedValue('deadbeef');
+
+    const result = await adapter.sign({ TransactionType: 'Payment' } as never);
+
+    expect(typeof result.tx_blob).toBe('string');
+    expect(result.tx_blob!.length).toBeGreaterThan(0);
+  });
+
+  it('maps a user-rejected device signature to sign-rejected', async () => {
+    const adapter = await connected();
+    const rejected = Object.assign(new Error('rejected'), { statusCode: 0x6985 });
+    xrpAppInstance.signTransaction.mockRejectedValue(rejected);
+
+    await expect(adapter.sign({ TransactionType: 'Payment' } as never)).rejects.toMatchObject({
+      code: WalletErrorCode.SIGN_REJECTED,
+    });
+  });
+});
+
+describe('LedgerAdapter.disconnect', () => {
+  it('clears the current account', async () => {
+    installNavigator({ hid: {} });
+    xrpAppInstance.getAddress.mockResolvedValue({
+      address: 'rLedger',
+      publicKey: 'aabbcc',
+    });
+    const adapter = new LedgerAdapter();
+    await adapter.connect();
+    expect(await adapter.getAccount()).not.toBeNull();
+
+    await adapter.disconnect();
+
+    expect(await adapter.getAccount()).toBeNull();
+  });
+});

--- a/packages/adapters/otsu/tests/otsu-adapter.test.ts
+++ b/packages/adapters/otsu/tests/otsu-adapter.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WalletErrorCode } from '@xrpl-connect/core';
+import { OtsuAdapter } from '../src/otsu-adapter';
+
+function makeProvider(overrides: Record<string, unknown> = {}) {
+  return {
+    isOtsu: true,
+    isConnected: vi.fn(() => false),
+    connect: vi.fn(),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    getAddress: vi.fn(),
+    getNetwork: vi.fn().mockResolvedValue({ network: 'mainnet' }),
+    signTransaction: vi.fn(),
+    signAndSubmit: vi.fn(),
+    signMessage: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+    ...overrides,
+  };
+}
+
+function installProvider(provider: ReturnType<typeof makeProvider> | null) {
+  const w = globalThis as unknown as { window?: unknown };
+  if (provider) {
+    w.window = { xrpl: provider };
+  } else {
+    w.window = {};
+  }
+}
+
+afterEach(() => {
+  delete (globalThis as unknown as { window?: unknown }).window;
+});
+
+describe('OtsuAdapter.isAvailable', () => {
+  beforeEach(() => {
+    delete (globalThis as unknown as { window?: unknown }).window;
+  });
+
+  it('returns false in a non-browser environment', async () => {
+    await expect(new OtsuAdapter().isAvailable()).resolves.toBe(false);
+  });
+
+  it('returns true when window exists', async () => {
+    installProvider(makeProvider());
+    await expect(new OtsuAdapter().isAvailable()).resolves.toBe(true);
+  });
+});
+
+describe('OtsuAdapter.connect', () => {
+  it('returns the account info on success', async () => {
+    const provider = makeProvider({
+      connect: vi.fn().mockResolvedValue({ address: 'rOtsuUser' }),
+    });
+    installProvider(provider);
+
+    const account = await new OtsuAdapter().connect();
+
+    expect(account.address).toBe('rOtsuUser');
+    expect(account.network.id).toBe('mainnet');
+    expect(provider.connect).toHaveBeenCalled();
+  });
+
+  it('throws notInstalled when the provider is not injected', async () => {
+    installProvider(null);
+    await expect(new OtsuAdapter().connect()).rejects.toMatchObject({
+      code: WalletErrorCode.WALLET_NOT_INSTALLED,
+    });
+  });
+
+  it('maps user rejection to a connection-rejected error', async () => {
+    const provider = makeProvider({
+      connect: vi.fn().mockRejectedValue(new Error('User rejected request')),
+    });
+    installProvider(provider);
+
+    await expect(new OtsuAdapter().connect()).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_REJECTED,
+    });
+  });
+});
+
+describe('OtsuAdapter.sign', () => {
+  async function connected() {
+    const provider = makeProvider({
+      connect: vi.fn().mockResolvedValue({ address: 'rOtsuUser' }),
+    });
+    installProvider(provider);
+    const adapter = new OtsuAdapter();
+    await adapter.connect();
+    return { adapter, provider };
+  }
+
+  it('throws notConnected before connect()', async () => {
+    installProvider(makeProvider());
+    const adapter = new OtsuAdapter();
+    await expect(adapter.sign({ TransactionType: 'Payment' } as never)).rejects.toMatchObject({
+      code: WalletErrorCode.NOT_CONNECTED,
+    });
+  });
+
+  it('returns the signed transaction on success', async () => {
+    const { adapter, provider } = await connected();
+    provider.signTransaction.mockResolvedValue({ tx_blob: 'BLOB', hash: 'H' });
+
+    const result = await adapter.sign({ TransactionType: 'Payment' } as never);
+
+    expect(result.tx_blob).toBe('BLOB');
+    expect(result.hash).toBe('H');
+  });
+
+  it('maps a user rejection to a sign-rejected error', async () => {
+    const { adapter, provider } = await connected();
+    provider.signTransaction.mockRejectedValue(new Error('User rejected the signing'));
+
+    await expect(adapter.sign({ TransactionType: 'Payment' } as never)).rejects.toMatchObject({
+      code: WalletErrorCode.SIGN_REJECTED,
+    });
+  });
+});
+
+describe('OtsuAdapter.disconnect', () => {
+  it('calls provider.disconnect and clears state', async () => {
+    const provider = makeProvider({
+      connect: vi.fn().mockResolvedValue({ address: 'rOtsuUser' }),
+    });
+    installProvider(provider);
+    const adapter = new OtsuAdapter();
+    await adapter.connect();
+    expect(await adapter.getAccount()).not.toBeNull();
+
+    await adapter.disconnect();
+
+    expect(provider.disconnect).toHaveBeenCalled();
+    expect(await adapter.getAccount()).toBeNull();
+  });
+});

--- a/packages/adapters/walletconnect/tests/walletconnect-adapter.test.ts
+++ b/packages/adapters/walletconnect/tests/walletconnect-adapter.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { WalletErrorCode } from '@xrpl-connect/core';
+
+const mockClient = {
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  request: vi.fn(),
+  on: vi.fn(),
+};
+
+vi.mock('@walletconnect/sign-client', () => ({
+  default: { init: vi.fn() },
+}));
+
+vi.mock('@walletconnect/modal', () => ({
+  WalletConnectModal: vi.fn(),
+}));
+
+import SignClient from '@walletconnect/sign-client';
+import { WalletConnectAdapter } from '../src/walletconnect-adapter';
+
+const SignClientMock = SignClient as unknown as { init: ReturnType<typeof vi.fn> };
+
+beforeEach(() => {
+  SignClientMock.init.mockReset();
+  mockClient.connect.mockReset();
+  mockClient.disconnect.mockReset();
+  mockClient.request.mockReset();
+  mockClient.on.mockReset();
+  SignClientMock.init.mockResolvedValue(mockClient);
+});
+
+describe('WalletConnectAdapter.isAvailable', () => {
+  it('is always available because it uses a QR code', async () => {
+    await expect(new WalletConnectAdapter().isAvailable()).resolves.toBe(true);
+  });
+
+  it('remains available even without a project ID configured', async () => {
+    // Demonstrates the "false branch is unreachable" — isAvailable is decoupled
+    // from credential validity; the only failure surfaces at connect()
+    const adapter = new WalletConnectAdapter({ projectId: undefined });
+    await expect(adapter.isAvailable()).resolves.toBe(true);
+  });
+});
+
+describe('WalletConnectAdapter.connect', () => {
+  it('returns account info after a successful session approval', async () => {
+    mockClient.connect.mockResolvedValue({
+      uri: 'wc:example',
+      approval: vi.fn().mockResolvedValue({
+        topic: 'topic-1',
+        namespaces: { xrpl: { accounts: ['xrpl:0:rWCAddress'] } },
+      }),
+    });
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    const account = await adapter.connect();
+
+    expect(account.address).toBe('rWCAddress');
+    expect(account.network.id).toBe('mainnet');
+  });
+
+  it('throws a wrapped error when no project ID is provided', async () => {
+    const adapter = new WalletConnectAdapter();
+    await expect(adapter.connect()).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+    });
+  });
+
+  it('wraps user rejection into a connection error', async () => {
+    mockClient.connect.mockResolvedValue({
+      uri: 'wc:example',
+      approval: vi.fn().mockRejectedValue(new Error('User rejected')),
+    });
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    await expect(adapter.connect()).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+    });
+  });
+});
+
+describe('WalletConnectAdapter.sign', () => {
+  async function connected() {
+    mockClient.connect.mockResolvedValue({
+      uri: 'wc:example',
+      approval: vi.fn().mockResolvedValue({
+        topic: 'topic-1',
+        namespaces: { xrpl: { accounts: ['xrpl:0:rWCAddress'] } },
+      }),
+    });
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    await adapter.connect();
+    return adapter;
+  }
+
+  it('returns a signed tx blob on success', async () => {
+    const adapter = await connected();
+    mockClient.request.mockResolvedValue({ tx_json: { TxnSignature: 'SIG' } });
+
+    const result = await adapter.sign({ TransactionType: 'Payment' } as never);
+
+    expect(result.tx_blob).toBe('SIG');
+  });
+
+  it('maps a rejected request to sign-rejected', async () => {
+    const adapter = await connected();
+    mockClient.request.mockRejectedValue(new Error('User rejected the request'));
+
+    await expect(adapter.sign({ TransactionType: 'Payment' } as never)).rejects.toMatchObject({
+      code: WalletErrorCode.SIGN_REJECTED,
+    });
+  });
+
+  it('throws notConnected before any session is established', async () => {
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    await expect(adapter.sign({ TransactionType: 'Payment' } as never)).rejects.toMatchObject({
+      code: WalletErrorCode.SIGN_FAILED,
+    });
+  });
+});
+
+describe('WalletConnectAdapter.disconnect', () => {
+  it('clears the session and account after a successful disconnect', async () => {
+    mockClient.connect.mockResolvedValue({
+      uri: 'wc:example',
+      approval: vi.fn().mockResolvedValue({
+        topic: 'topic-1',
+        namespaces: { xrpl: { accounts: ['xrpl:0:rWCAddress'] } },
+      }),
+    });
+    mockClient.disconnect.mockResolvedValue(undefined);
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    await adapter.connect();
+    expect(await adapter.getAccount()).not.toBeNull();
+
+    await adapter.disconnect();
+
+    expect(mockClient.disconnect).toHaveBeenCalledWith(
+      expect.objectContaining({ topic: 'topic-1' })
+    );
+    expect(await adapter.getAccount()).toBeNull();
+  });
+
+  it('is a no-op when no session exists', async () => {
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    await expect(adapter.disconnect()).resolves.toBeUndefined();
+    expect(mockClient.disconnect).not.toHaveBeenCalled();
+  });
+});

--- a/packages/adapters/xaman/tests/xaman-adapter.test.ts
+++ b/packages/adapters/xaman/tests/xaman-adapter.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { WalletErrorCode } from '@xrpl-connect/core';
+
+const mockXummInstance = {
+  authorize: vi.fn(),
+  logout: vi.fn(),
+  payload: {
+    createAndSubscribe: vi.fn(),
+    create: vi.fn(),
+  },
+};
+
+vi.mock('xumm', () => ({
+  Xumm: vi.fn().mockImplementation(() => mockXummInstance),
+}));
+
+import { XamanAdapter } from '../src/xaman-adapter';
+
+beforeEach(() => {
+  mockXummInstance.authorize.mockReset();
+  mockXummInstance.logout.mockReset();
+  mockXummInstance.payload.createAndSubscribe.mockReset();
+  mockXummInstance.payload.create.mockReset();
+});
+
+describe('XamanAdapter.isAvailable', () => {
+  it('is always available regardless of options', async () => {
+    await expect(new XamanAdapter().isAvailable()).resolves.toBe(true);
+    await expect(new XamanAdapter({ apiKey: 'key' }).isAvailable()).resolves.toBe(true);
+  });
+});
+
+describe('XamanAdapter.connect', () => {
+  it('returns account info on a successful authorize', async () => {
+    mockXummInstance.authorize.mockResolvedValue({ me: { account: 'rXamanUser' } });
+    const adapter = new XamanAdapter({ apiKey: 'test-key' });
+
+    const account = await adapter.connect();
+
+    expect(account.address).toBe('rXamanUser');
+    expect(account.network.id).toBe('mainnet');
+  });
+
+  it('throws a wrapped connection error when no API key is given', async () => {
+    const adapter = new XamanAdapter();
+    await expect(adapter.connect()).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+    });
+    expect(mockXummInstance.authorize).not.toHaveBeenCalled();
+  });
+
+  it('wraps an authorization error returned by the SDK', async () => {
+    mockXummInstance.authorize.mockResolvedValue(new Error('User rejected'));
+    const adapter = new XamanAdapter({ apiKey: 'test-key' });
+    await expect(adapter.connect()).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+    });
+  });
+});
+
+describe('XamanAdapter.sign', () => {
+  it('rejects when called before connect (wrapped as a sign failure)', async () => {
+    const adapter = new XamanAdapter({ apiKey: 'test-key' });
+    await expect(adapter.sign({ TransactionType: 'Payment' } as never)).rejects.toMatchObject({
+      code: WalletErrorCode.SIGN_FAILED,
+    });
+  });
+
+  it('maps a rejected payload to a sign-rejected error', async () => {
+    mockXummInstance.authorize.mockResolvedValue({ me: { account: 'rXamanUser' } });
+    const adapter = new XamanAdapter({ apiKey: 'test-key' });
+    await adapter.connect();
+
+    // Spy on the private waitForSignature step indirectly by faking the payload result
+    mockXummInstance.payload.createAndSubscribe.mockImplementation(async (_tx, _cb) => {
+      // Simulate the SDK invoking the subscription with a rejection.
+      // The adapter then awaits a websocket; we short-circuit by throwing.
+      throw new Error('Sign rejected by user');
+    });
+
+    await expect(adapter.sign({ TransactionType: 'Payment' } as never)).rejects.toMatchObject({
+      code: WalletErrorCode.SIGN_REJECTED,
+    });
+  });
+});
+
+describe('XamanAdapter.disconnect', () => {
+  it('logs out and clears local state', async () => {
+    mockXummInstance.authorize.mockResolvedValue({ me: { account: 'rXamanUser' } });
+    mockXummInstance.logout.mockResolvedValue(undefined);
+    const adapter = new XamanAdapter({ apiKey: 'test-key' });
+    await adapter.connect();
+    expect(await adapter.getAccount()).not.toBeNull();
+
+    await adapter.disconnect();
+
+    expect(mockXummInstance.logout).toHaveBeenCalled();
+    expect(await adapter.getAccount()).toBeNull();
+  });
+
+  it('still clears state when logout throws', async () => {
+    mockXummInstance.authorize.mockResolvedValue({ me: { account: 'rXamanUser' } });
+    mockXummInstance.logout.mockRejectedValue(new Error('already logged out'));
+    const adapter = new XamanAdapter({ apiKey: 'test-key' });
+    await adapter.connect();
+
+    await adapter.disconnect();
+
+    expect(await adapter.getAccount()).toBeNull();
+  });
+});

--- a/packages/adapters/xyra/tests/xyra-adapter.test.ts
+++ b/packages/adapters/xyra/tests/xyra-adapter.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WalletErrorCode } from '@xrpl-connect/core';
+
+const mockSdk = {
+  connect: vi.fn(),
+  sign: vi.fn(),
+  signAndSubmit: vi.fn(),
+  signMessage: vi.fn(),
+  destroy: vi.fn(),
+};
+
+vi.mock('@xyrawallet/sdk', () => ({
+  XyraSDK: vi.fn().mockImplementation(() => mockSdk),
+}));
+
+import { XyraAdapter } from '../src/xyra-adapter';
+
+beforeEach(() => {
+  mockSdk.connect.mockReset();
+  mockSdk.sign.mockReset();
+  mockSdk.signAndSubmit.mockReset();
+  mockSdk.signMessage.mockReset();
+  mockSdk.destroy.mockReset();
+});
+
+function installWindow(value: unknown) {
+  const w = globalThis as unknown as { window?: unknown };
+  if (value === undefined) {
+    delete w.window;
+  } else {
+    w.window = value;
+  }
+}
+
+afterEach(() => {
+  installWindow(undefined);
+});
+
+describe('XyraAdapter.isAvailable', () => {
+  it('returns false in a non-browser environment', async () => {
+    installWindow(undefined);
+    await expect(new XyraAdapter().isAvailable()).resolves.toBe(false);
+  });
+
+  it('returns true when window.open is available', async () => {
+    installWindow({ open: vi.fn() });
+    await expect(new XyraAdapter().isAvailable()).resolves.toBe(true);
+  });
+
+  it('returns false when window.open is not a function', async () => {
+    installWindow({});
+    await expect(new XyraAdapter().isAvailable()).resolves.toBe(false);
+  });
+});
+
+describe('XyraAdapter.connect', () => {
+  it('returns account info on success', async () => {
+    mockSdk.connect.mockResolvedValue({
+      address: 'rXyraUser',
+      publicKey: 'PK',
+      network: 'xrpl-mainnet',
+    });
+
+    const account = await new XyraAdapter().connect({ network: 'mainnet' });
+
+    expect(account.address).toBe('rXyraUser');
+    expect(account.publicKey).toBe('PK');
+    expect(account.network.id).toBe('mainnet');
+  });
+
+  it('maps a closed-popup error to connection-rejected', async () => {
+    mockSdk.connect.mockRejectedValue(new Error('User closed popup'));
+
+    await expect(new XyraAdapter().connect()).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_REJECTED,
+    });
+  });
+
+  it('falls back to a generic connection error for other failures', async () => {
+    mockSdk.connect.mockRejectedValue(new Error('something exploded'));
+
+    await expect(new XyraAdapter().connect()).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+    });
+  });
+});
+
+describe('XyraAdapter.sign', () => {
+  async function connected() {
+    mockSdk.connect.mockResolvedValue({
+      address: 'rXyraUser',
+      publicKey: 'PK',
+      network: 'xrpl-mainnet',
+    });
+    const adapter = new XyraAdapter();
+    await adapter.connect();
+    return adapter;
+  }
+
+  it('throws notConnected before any session is open', async () => {
+    const adapter = new XyraAdapter();
+    await expect(adapter.sign({ TransactionType: 'Payment' } as never)).rejects.toMatchObject({
+      code: WalletErrorCode.NOT_CONNECTED,
+    });
+  });
+
+  it('returns the signed payload on success', async () => {
+    const adapter = await connected();
+    mockSdk.sign.mockResolvedValue({ tx_blob: 'BLOB', hash: 'HASH' });
+
+    const result = await adapter.sign({ TransactionType: 'Payment' } as never);
+
+    expect(result.tx_blob).toBe('BLOB');
+    expect(result.hash).toBe('HASH');
+  });
+
+  it('maps a closed-popup error to sign-rejected', async () => {
+    const adapter = await connected();
+    mockSdk.sign.mockRejectedValue(new Error('Popup closed by user'));
+
+    await expect(adapter.sign({ TransactionType: 'Payment' } as never)).rejects.toMatchObject({
+      code: WalletErrorCode.SIGN_REJECTED,
+    });
+  });
+});
+
+describe('XyraAdapter.disconnect', () => {
+  it('clears local state', async () => {
+    mockSdk.connect.mockResolvedValue({
+      address: 'rXyraUser',
+      publicKey: 'PK',
+      network: 'xrpl-mainnet',
+    });
+    const adapter = new XyraAdapter();
+    await adapter.connect();
+    expect(await adapter.getAccount()).not.toBeNull();
+
+    await adapter.disconnect();
+
+    expect(await adapter.getAccount()).toBeNull();
+  });
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,7 +43,8 @@
     "dev": "tsup --watch",
     "lint": "eslint src",
     "type-check": "tsc --noEmit",
-    "test": "vitest"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "peerDependencies": {
     "@xrpl-connect/core": "^0.1.0"


### PR DESCRIPTION
## Summary

- Adds a `tests/<adapter>-adapter.test.ts` file for each of the 7 wallet adapters (crossmark, gemwallet, ledger, otsu, walletconnect, xaman, xyra). Each suite covers the four cases from the issue: `isAvailable()` true/false branches, `connect()` happy path + error path, `sign()` happy path + rejection, and `disconnect()` clearing internal state.
- External SDKs are mocked via `vi.mock` (and `vi.hoisted` for ledger so transports/xrpl can be referenced from the mock factories). The `window.xrpl` provider for Otsu and `navigator.hid`/`navigator.usb` for Ledger are stubbed at the global scope so no browser, extension, or device is needed.
- Standardizes `@xrpl-connect/ui` on `vitest run` (with a `test:watch` alias for the previous behavior) so `pnpm test` exits cleanly under turbo / CI.

Note: the issue listed 8 adapters and mentioned `metamask-snap`, but no `metamask-snap` package exists in `packages/adapters/`. All 7 existing adapters are covered.

## Test plan

- [x] `pnpm test` from the repo root (turbo) — 22/22 tasks green
- [x] Per-package: `pnpm --filter @xrpl-connect/adapter-<name> exec vitest run` passes for every adapter
- [x] `pnpm format:check` clean
- [x] `pnpm lint` produces no new warnings/errors

Fixes #55