### PR TITLE
fix(core): detach adapter event listeners on disconnect

### DIFF
--- a/packages/core/src/wallet-manager.ts
+++ b/packages/core/src/wallet-manager.ts
@@ -5,6 +5,7 @@
 import EventEmitter from 'eventemitter3';
 import type {
   WalletAdapter,
+  WalletAdapterEvent,
   WalletManagerOptions,
   AccountInfo,
   Transaction,
@@ -31,6 +32,10 @@ export class WalletManager extends EventEmitter<WalletEvent> {
   private storage: Storage;
   private logger: Logger;
   private options: WalletManagerOptions;
+  private adapterListeners: Array<{
+    event: WalletAdapterEvent;
+    callback: (data: unknown) => void;
+  }> = [];
 
   constructor(options: WalletManagerOptions) {
     super();
@@ -123,12 +128,10 @@ export class WalletManager extends EventEmitter<WalletEvent> {
       };
       await this.storage.saveState(state);
 
-      // Subscribe to adapter events if supported
-      if (adapter.on) {
-        adapter.on('disconnect', () => this.handleAdapterDisconnect());
-        adapter.on('accountChanged', (data) => this.handleAccountChanged(data as AccountInfo));
-        adapter.on('networkChanged', (data) => this.handleNetworkChanged(data as NetworkInfo));
-      }
+      // Subscribe to adapter events if supported. Track every registration so
+      // disconnect() can call the matching off() and stop late callbacks from
+      // mutating manager state after the session is gone.
+      this.subscribeToAdapter(adapter);
 
       this.logger.info(`Connected to ${adapter.name}`, account);
       this.emit('connect', account);
@@ -324,9 +327,44 @@ export class WalletManager extends EventEmitter<WalletEvent> {
   }
 
   /**
+   * Register adapter listeners and remember them so we can detach later.
+   */
+  private subscribeToAdapter(adapter: WalletAdapter): void {
+    if (!adapter.on) return;
+
+    const register = (event: WalletAdapterEvent, callback: (data: unknown) => void): void => {
+      adapter.on!(event, callback);
+      this.adapterListeners.push({ event, callback });
+    };
+
+    register('disconnect', () => this.handleAdapterDisconnect());
+    register('accountChanged', (data) => this.handleAccountChanged(data as AccountInfo));
+    register('networkChanged', (data) => this.handleNetworkChanged(data as NetworkInfo));
+  }
+
+  /**
+   * Detach every listener registered via subscribeToAdapter.
+   */
+  private unsubscribeFromAdapter(adapter: WalletAdapter): void {
+    if (adapter.off) {
+      for (const { event, callback } of this.adapterListeners) {
+        try {
+          adapter.off(event, callback);
+        } catch (error) {
+          this.logger.warn(`Failed to detach adapter listener for ${event}:`, error);
+        }
+      }
+    }
+    this.adapterListeners = [];
+  }
+
+  /**
    * Cleanup connection state
    */
   private async cleanup(): Promise<void> {
+    if (this.currentAdapter) {
+      this.unsubscribeFromAdapter(this.currentAdapter);
+    }
     this.currentAdapter = null;
     this.currentAccount = null;
     await this.storage.clearState();

--- a/packages/core/tests/wallet-manager.test.ts
+++ b/packages/core/tests/wallet-manager.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+import EventEmitter from 'eventemitter3';
+import { WalletManager } from '../src/wallet-manager';
+import type {
+  AccountInfo,
+  NetworkInfo,
+  SignedMessage,
+  SignedTransaction,
+  SubmittedTransaction,
+  Transaction,
+  WalletAdapter,
+  WalletAdapterEvent,
+} from '../src/types';
+
+const NETWORK: NetworkInfo = { id: 'testnet', name: 'Testnet', wss: 'wss://example' };
+const ACCOUNT: AccountInfo = { address: 'rTestAddress00000000000000000000000', network: NETWORK };
+
+function createFakeAdapter(): WalletAdapter & {
+  emitAdapterEvent: (event: WalletAdapterEvent, data?: unknown) => void;
+  listenerCount: (event: WalletAdapterEvent) => number;
+} {
+  const bus = new EventEmitter();
+  return {
+    id: 'fake',
+    name: 'Fake Wallet',
+    isAvailable: vi.fn(async () => true),
+    connect: vi.fn(async () => ACCOUNT),
+    disconnect: vi.fn(async () => {}),
+    getAccount: vi.fn(async () => ACCOUNT),
+    getNetwork: vi.fn(async () => NETWORK),
+    sign: vi.fn(async () => ({ hash: '0xhash' }) as SignedTransaction),
+    signAndSubmit: vi.fn(async () => ({ hash: '0xhash' }) as SubmittedTransaction),
+    signMessage: vi.fn(async () => ({ signature: '0xsig' }) as SignedMessage),
+    on(event, callback) {
+      bus.on(event, callback);
+    },
+    off(event, callback) {
+      bus.off(event, callback);
+    },
+    emitAdapterEvent(event, data) {
+      bus.emit(event, data);
+    },
+    listenerCount(event) {
+      return bus.listenerCount(event);
+    },
+  };
+}
+
+describe('WalletManager.disconnect()', () => {
+  it('removes adapter event listeners so late events do not reach manager subscribers', async () => {
+    const adapter = createFakeAdapter();
+    const manager = new WalletManager({ adapters: [adapter] });
+
+    await manager.connect('fake');
+    expect(adapter.listenerCount('disconnect')).toBe(1);
+    expect(adapter.listenerCount('accountChanged')).toBe(1);
+    expect(adapter.listenerCount('networkChanged')).toBe(1);
+
+    const onAccountChanged = vi.fn();
+    const onNetworkChanged = vi.fn();
+    const onDisconnect = vi.fn();
+    manager.on('accountChanged', onAccountChanged);
+    manager.on('networkChanged', onNetworkChanged);
+    manager.on('disconnect', onDisconnect);
+
+    await manager.disconnect();
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+
+    expect(adapter.listenerCount('disconnect')).toBe(0);
+    expect(adapter.listenerCount('accountChanged')).toBe(0);
+    expect(adapter.listenerCount('networkChanged')).toBe(0);
+
+    adapter.emitAdapterEvent('disconnect');
+    adapter.emitAdapterEvent('accountChanged', {
+      address: 'rOther00000000000000000000000000000',
+      network: NETWORK,
+    } satisfies AccountInfo);
+    adapter.emitAdapterEvent('networkChanged', NETWORK);
+
+    expect(onAccountChanged).not.toHaveBeenCalled();
+    expect(onNetworkChanged).not.toHaveBeenCalled();
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not leak listeners across reconnect cycles', async () => {
+    const adapter = createFakeAdapter();
+    const manager = new WalletManager({ adapters: [adapter] });
+
+    for (let i = 0; i < 3; i++) {
+      await manager.connect('fake');
+      await manager.disconnect();
+    }
+
+    expect(adapter.listenerCount('disconnect')).toBe(0);
+    expect(adapter.listenerCount('accountChanged')).toBe(0);
+    expect(adapter.listenerCount('networkChanged')).toBe(0);
+  });
+});

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,9 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- `WalletManager.connect()` subscribed to `adapter.on('disconnect' | 'accountChanged' | 'networkChanged', ...)` but `disconnect()` never called the matching `off()`, so late adapter callbacks could mutate manager state (or fire `'disconnect'` again) for a session that was already torn down.
- Track every registration in a `adapterListeners` list and release them in `cleanup()` before clearing `currentAdapter` / `currentAccount`.
- Add vitest coverage in `packages/core` (new package-local `vitest.config.ts`) for the new behavior.

This is the manager-side counterpart to #54.

## Test plan
- [x] `pnpm --filter @xrpl-connect/core test`
- [x] `pnpm --filter @xrpl-connect/core lint`
- [x] `pnpm --filter @xrpl-connect/core build`
- [x] `pnpm --filter @xrpl-connect/ui exec vitest run` (sanity check; unaffected)
- [ ] Manual: connect → disconnect → fire a delayed adapter event → confirm no manager-level event fires

Fixes #64