### PR TITLE
fix(adapters): drop invalid `;utf8` parameter from icon data URLs

### DIFF
--- a/packages/adapters/crossmark/src/crossmark-adapter.ts
+++ b/packages/adapters/crossmark/src/crossmark-adapter.ts
@@ -16,7 +16,7 @@ import type {
 import { createWalletError, resolveNetwork } from '@xrpl-connect/core';
 import iconSvg from './assets/icon.svg';
 
-const ICON_DATA_URL = `data:image/svg+xml;utf8,${encodeURIComponent(iconSvg)}`;
+const ICON_DATA_URL = `data:image/svg+xml,${encodeURIComponent(iconSvg)}`;
 
 /**
  * Crossmark adapter options

--- a/packages/adapters/gemwallet/src/gemwallet-adapter.ts
+++ b/packages/adapters/gemwallet/src/gemwallet-adapter.ts
@@ -22,7 +22,7 @@ import type {
 import { createWalletError, resolveNetwork } from '@xrpl-connect/core';
 import iconSvg from './assets/icon.svg';
 
-const ICON_DATA_URL = `data:image/svg+xml;utf8,${encodeURIComponent(iconSvg)}`;
+const ICON_DATA_URL = `data:image/svg+xml,${encodeURIComponent(iconSvg)}`;
 
 /**
  * GemWallet adapter options

--- a/packages/adapters/ledger/src/ledger-adapter.ts
+++ b/packages/adapters/ledger/src/ledger-adapter.ts
@@ -24,7 +24,7 @@ import { LedgerDeviceState } from './types';
 import { parseLedgerError, isBrowserSupported, formatLedgerError } from './errors';
 import iconSvg from './assets/icon.svg';
 
-const ICON_DATA_URL = `data:image/svg+xml;utf8,${encodeURIComponent(iconSvg)}`;
+const ICON_DATA_URL = `data:image/svg+xml,${encodeURIComponent(iconSvg)}`;
 
 /**
  * Default timeout for Ledger operations (60 seconds)

--- a/packages/adapters/walletconnect/src/walletconnect-adapter.ts
+++ b/packages/adapters/walletconnect/src/walletconnect-adapter.ts
@@ -28,7 +28,7 @@ import {
   XRPL_NAMESPACE,
 } from './constants';
 
-const ICON_DATA_URL = `data:image/svg+xml;utf8,${encodeURIComponent(iconSvg)}`;
+const ICON_DATA_URL = `data:image/svg+xml,${encodeURIComponent(iconSvg)}`;
 
 /**
  * Utility function to detect if user is on mobile device

--- a/packages/adapters/xaman/src/xaman-adapter.ts
+++ b/packages/adapters/xaman/src/xaman-adapter.ts
@@ -17,7 +17,7 @@ import {
 import { createWalletError, createLogger, resolveNetwork } from '@xrpl-connect/core';
 import iconSvg from './assets/icon.svg';
 
-const ICON_DATA_URL = `data:image/svg+xml;utf8,${encodeURIComponent(iconSvg)}`;
+const ICON_DATA_URL = `data:image/svg+xml,${encodeURIComponent(iconSvg)}`;
 
 /**
  * Logger instance for Xaman adapter

--- a/packages/adapters/xyra/src/xyra-adapter.ts
+++ b/packages/adapters/xyra/src/xyra-adapter.ts
@@ -27,7 +27,7 @@ import type { XyraAdapterOptions, XyraConnectOptions } from './types';
 import { XRPL_CONNECT_TO_XYRA_NETWORK, XYRA_TO_XRPL_CONNECT_NETWORK } from './types';
 import iconSvg from './assets/icon.svg';
 
-const ICON_DATA_URL = `data:image/svg+xml;utf8,${encodeURIComponent(iconSvg)}`;
+const ICON_DATA_URL = `data:image/svg+xml,${encodeURIComponent(iconSvg)}`;
 
 /**
  * Logger instance for Xyra adapter


### PR DESCRIPTION
## Summary

- The icon refactor in #67 (v0.8.0) wraps each SVG adapter's inlined logo as `` `data:image/svg+xml;utf8,${encodeURIComponent(iconSvg)}` ``. `;utf8` is **not** a valid media-type parameter per RFC 2397 — only `;charset=utf-8` is — and some browser / CSP / sanitizer chains reject the URL outright, causing the wallet logo to fail to render silently in consumer apps.
- Switching to the parameterless form `` `data:image/svg+xml,${encodeURIComponent(iconSvg)}` `` is already URL-encoded, universally accepted, and matches the form the MDN docs recommend for inlined SVG data URLs.
- Applied to all six SVG adapters: `xaman`, `crossmark`, `gemwallet`, `ledger`, `walletconnect`, `xyra`. `otsu` is unaffected (ships a PNG via tsup's `dataurl` loader).

## Reported by

A downstream Nuxt app on `xrpl-connect@0.8.0` (vs. `0.7.1` which used a `data:image/svg+xml;base64,…` URL inlined per adapter and rendered fine). They had to ship a runtime `unwrapDoubleEncodedIcon` patch in their wallet plugin to make the modal show the Xaman / Crossmark / GemWallet logos. This change lets them drop the patch on the next bump.

## Test plan

- [x] `pnpm --filter "./packages/adapters/*" build` — all six SVG adapter bundles rebuild; dist now emits `data:image/svg+xml,…` (no `;utf8`).
- [x] `pnpm --filter "./packages/adapters/*" test` — 7 suites / 67 tests pass (no `.icon` assertions, but worth confirming nothing regressed).
- [x] `pnpm --filter "./packages/adapters/*" lint` — clean (only pre-existing warnings).
- [ ] Manual: open the wallet connector modal in an example/consumer app on this branch and confirm each logo renders.