### PR TITLE
Release 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-05-21
+
+### Fixed
+
+- Adapters: drop the invalid `;utf8` media-type parameter from inlined SVG icon data URLs so wallet logos render in browsers / CSP / sanitizer setups that strict-parse `data:` URIs (#85).
+
 ## [0.8.0] - 2026-05-21
 
 ### Added
@@ -123,7 +129,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switch the build to Vite for the meta package.
 - Crossmark adapter: use `signAndSubmitAndWait` and improve `isAvailable`.
 
-[Unreleased]: https://github.com/XRPL-Commons/xrpl-connect/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/XRPL-Commons/xrpl-connect/compare/v0.8.1...HEAD
+[0.8.1]: https://github.com/XRPL-Commons/xrpl-connect/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/XRPL-Commons/xrpl-connect/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/XRPL-Commons/xrpl-connect/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/XRPL-Commons/xrpl-connect/compare/v0.6.0...v0.7.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xrpl-connect",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "description": "A framework-agnostic wallet connection toolkit for XRPL",
   "keywords": [

--- a/packages/adapters/crossmark/package.json
+++ b/packages/adapters/crossmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrpl-connect/adapter-crossmark",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Crossmark wallet adapter for XRPL Connect - Browser extension wallet support",
   "author": "XRPL Connect Contributors",
   "license": "MIT",

--- a/packages/adapters/crossmark/src/crossmark-adapter.ts
+++ b/packages/adapters/crossmark/src/crossmark-adapter.ts
@@ -16,7 +16,7 @@ import type {
 import { createWalletError, resolveNetwork } from '@xrpl-connect/core';
 import iconSvg from './assets/icon.svg';
 
-const ICON_DATA_URL = `data:image/svg+xml;utf8,${encodeURIComponent(iconSvg)}`;
+const ICON_DATA_URL = `data:image/svg+xml,${encodeURIComponent(iconSvg)}`;
 
 /**
  * Crossmark adapter options

--- a/packages/adapters/gemwallet/package.json
+++ b/packages/adapters/gemwallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrpl-connect/adapter-gemwallet",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "GemWallet adapter for XRPL Connect - Browser extension wallet support",
   "author": "XRPL Connect Contributors",
   "license": "MIT",

--- a/packages/adapters/gemwallet/src/gemwallet-adapter.ts
+++ b/packages/adapters/gemwallet/src/gemwallet-adapter.ts
@@ -22,7 +22,7 @@ import type {
 import { createWalletError, resolveNetwork } from '@xrpl-connect/core';
 import iconSvg from './assets/icon.svg';
 
-const ICON_DATA_URL = `data:image/svg+xml;utf8,${encodeURIComponent(iconSvg)}`;
+const ICON_DATA_URL = `data:image/svg+xml,${encodeURIComponent(iconSvg)}`;
 
 /**
  * GemWallet adapter options

--- a/packages/adapters/ledger/package.json
+++ b/packages/adapters/ledger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrpl-connect/adapter-ledger",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Ledger hardware wallet adapter for XRPL Connect",
   "author": "XRPL Connect Contributors",
   "license": "MIT",

--- a/packages/adapters/ledger/src/ledger-adapter.ts
+++ b/packages/adapters/ledger/src/ledger-adapter.ts
@@ -24,7 +24,7 @@ import { LedgerDeviceState } from './types';
 import { parseLedgerError, isBrowserSupported, formatLedgerError } from './errors';
 import iconSvg from './assets/icon.svg';
 
-const ICON_DATA_URL = `data:image/svg+xml;utf8,${encodeURIComponent(iconSvg)}`;
+const ICON_DATA_URL = `data:image/svg+xml,${encodeURIComponent(iconSvg)}`;
 
 /**
  * Default timeout for Ledger operations (60 seconds)

--- a/packages/adapters/otsu/package.json
+++ b/packages/adapters/otsu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrpl-connect/adapter-otsu",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Otsu Wallet adapter for XRPL Connect - MV3 browser extension wallet",
   "author": "Otsu Wallet",
   "license": "MIT",

--- a/packages/adapters/walletconnect/package.json
+++ b/packages/adapters/walletconnect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrpl-connect/adapter-walletconnect",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "WalletConnect adapter for XRPL Connect - QR code based wallet connections",
   "author": "XRPL Connect Contributors",
   "license": "MIT",

--- a/packages/adapters/walletconnect/src/walletconnect-adapter.ts
+++ b/packages/adapters/walletconnect/src/walletconnect-adapter.ts
@@ -28,7 +28,7 @@ import {
   XRPL_NAMESPACE,
 } from './constants';
 
-const ICON_DATA_URL = `data:image/svg+xml;utf8,${encodeURIComponent(iconSvg)}`;
+const ICON_DATA_URL = `data:image/svg+xml,${encodeURIComponent(iconSvg)}`;
 
 /**
  * Utility function to detect if user is on mobile device

--- a/packages/adapters/xaman/package.json
+++ b/packages/adapters/xaman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrpl-connect/adapter-xaman",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Xaman (formerly Xumm) wallet adapter for XRPL Connect - Mobile and desktop wallet support",
   "author": "XRPL Connect Contributors",
   "license": "MIT",

--- a/packages/adapters/xaman/src/xaman-adapter.ts
+++ b/packages/adapters/xaman/src/xaman-adapter.ts
@@ -17,7 +17,7 @@ import {
 import { createWalletError, createLogger, resolveNetwork } from '@xrpl-connect/core';
 import iconSvg from './assets/icon.svg';
 
-const ICON_DATA_URL = `data:image/svg+xml;utf8,${encodeURIComponent(iconSvg)}`;
+const ICON_DATA_URL = `data:image/svg+xml,${encodeURIComponent(iconSvg)}`;
 
 /**
  * Logger instance for Xaman adapter

--- a/packages/adapters/xyra/package.json
+++ b/packages/adapters/xyra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrpl-connect/adapter-xyra",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Xyra wallet adapter for XRPL Connect - browser-native popup-based wallet",
   "author": "Xyra Wallet",
   "license": "MIT",

--- a/packages/adapters/xyra/src/xyra-adapter.ts
+++ b/packages/adapters/xyra/src/xyra-adapter.ts
@@ -27,7 +27,7 @@ import type { XyraAdapterOptions, XyraConnectOptions } from './types';
 import { XRPL_CONNECT_TO_XYRA_NETWORK, XYRA_TO_XRPL_CONNECT_NETWORK } from './types';
 import iconSvg from './assets/icon.svg';
 
-const ICON_DATA_URL = `data:image/svg+xml;utf8,${encodeURIComponent(iconSvg)}`;
+const ICON_DATA_URL = `data:image/svg+xml,${encodeURIComponent(iconSvg)}`;
 
 /**
  * Logger instance for Xyra adapter

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrpl-connect/core",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Framework-agnostic core SDK for XRPL wallet connections",
   "author": "XRPL Connect Contributors",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrpl-connect/ui",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Web component UI for XRPL Connect wallet connections",
   "author": "XRPL Connect Contributors",
   "license": "MIT",

--- a/packages/xrpl-connect/package.json
+++ b/packages/xrpl-connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xrpl-connect",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "The easiest way to connect XRPL wallets to your app - Framework-agnostic toolkit with plug-and-play UI",
   "author": "XRPL Connect Contributors",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Patch release covering the wallet-icon rendering regression introduced in 0.8.0.

### Fixed

- Adapters: drop the invalid `;utf8` media-type parameter from inlined SVG icon data URLs so wallet logos render in browsers / CSP / sanitizer setups that strict-parse `data:` URIs (#85).

See [CHANGELOG.md](https://github.com/XRPL-Commons/xrpl-connect/blob/develop/CHANGELOG.md#081---2026-05-21) for details.

## Test plan

- [x] All adapter packages rebuild (`pnpm --filter "./packages/adapters/*" build`); built dists emit `data:image/svg+xml,…` (no `;utf8`).
- [x] Adapter test suites pass (`pnpm --filter "./packages/adapters/*" test`): 7 suites, 67 tests.
- [x] Lint clean (`pnpm --filter "./packages/adapters/*" lint`).
- [ ] Post-merge: tag `v0.8.1` and publish to npm.