### PR TITLE
fix(xrpl-connect): load `.svg` imports as raw text in meta-bundle build

### DIFF
--- a/packages/xrpl-connect/vite.config.ts
+++ b/packages/xrpl-connect/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
-import { copyFileSync, existsSync } from 'fs';
+import { copyFileSync, existsSync, readFileSync } from 'fs';
 import inject from '@rollup/plugin-inject';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -27,6 +27,22 @@ export default defineConfig({
     },
   },
   plugins: [
+    // Match the per-adapter tsup config (`loader: { '.svg': 'text' }`). Without
+    // this, Vite's default asset handler resolves `.svg` imports to a
+    // `data:image/svg+xml,...` URL, and each adapter's
+    // `data:image/svg+xml,${encodeURIComponent(iconSvg)}` wrapper then
+    // double-encodes it into an unrenderable URI.
+    {
+      name: 'svg-as-text',
+      enforce: 'pre',
+      load(id) {
+        const path = id.split('?')[0];
+        if (path.endsWith('.svg')) {
+          const source = readFileSync(path, 'utf-8');
+          return `export default ${JSON.stringify(source)};`;
+        }
+      },
+    },
     {
       name: 'copy-readme',
       closeBundle() {


### PR DESCRIPTION
## Summary

The fix in #85 resolved the `;utf8` issue in each adapter's tsup dist, but the **published npm package** (`xrpl-connect` meta-bundle, built with Vite) still ships broken wallet icons. Reason: Vite's default asset handler converts `import iconSvg from './assets/icon.svg'` into a full `data:image/svg+xml,…` URL string. The adapter source then wraps that URL again:

```js
const ICON_DATA_URL = `data:image/svg+xml,${encodeURIComponent(iconSvg)}`;
// → data:image/svg+xml,data%3Aimage%2Fsvg%2Bxml%2C%253csvg…
```

The browser decodes the outer wrapper and tries to render the result as SVG, but the payload starts with the literal string `data:image/svg+xml,` rather than `<svg`, so parsing fails and `<img>` shows blank. Reproduced in `xrpl-connect@0.8.1` installed from npm — Xaman, Crossmark, GemWallet (and walletconnect) logos all missing.

Each adapter's own `dist/` (built with tsup, where we configured `loader: { '.svg': 'text' }`) is unaffected, but consumers install the meta-bundle, not those.

## Fix

Add a small Vite plugin (`enforce: 'pre'`) that reads `.svg` files and emits a JS module default-exporting their raw text — matching the tsup loader behavior. After this, the adapter wrapper produces a single, correct `data:image/svg+xml,%3csvg…` URL.

Verified post-build:

```
$ grep -c '"data:image/svg+xml,' dist-publish/*.{mjs,umd.js}
0  (was 7 in 0.8.1)
$ grep -oE "= '<svg" dist-publish/index-*.mjs | wc -l
6  (one per SVG adapter — raw markup, wrapped once at runtime)
```

## Test plan

- [x] `pnpm --filter xrpl-connect publish:build` produces a fresh `dist-publish/` with zero pre-encoded `data:image/svg+xml,…` literals.
- [x] Sample icon construction in the bundle: `O2 = \`data:image/svg+xml,${encodeURIComponent(A2)}\`` where `A2` is now the raw `<svg…>` markup.
- [ ] Post-merge: cut `0.8.2`, publish, verify logos render in a consumer app.

## Follow-up

A `0.8.2` release commit + `develop → main` PR will follow once this lands, since `0.8.1` is already public and unfixable in place.