### PR TITLE
Release 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-05-21
+
+### Fixed
+
+- xrpl-connect (meta-bundle): load `.svg` imports as raw text in the Vite build so adapter icons aren't double-encoded as `data:image/svg+xml,data%3Aimage%2Fsvg%2Bxml%2C…` and render correctly in consumer apps (#87). The 0.8.1 fix in #85 corrected the per-adapter tsup builds but the published meta-bundle still shipped the broken pattern.
+
 ## [0.8.1] - 2026-05-21
 
 ### Fixed
@@ -129,7 +135,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switch the build to Vite for the meta package.
 - Crossmark adapter: use `signAndSubmitAndWait` and improve `isAvailable`.
 
-[Unreleased]: https://github.com/XRPL-Commons/xrpl-connect/compare/v0.8.1...HEAD
+[Unreleased]: https://github.com/XRPL-Commons/xrpl-connect/compare/v0.8.2...HEAD
+[0.8.2]: https://github.com/XRPL-Commons/xrpl-connect/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/XRPL-Commons/xrpl-connect/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/XRPL-Commons/xrpl-connect/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/XRPL-Commons/xrpl-connect/compare/v0.7.0...v0.7.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xrpl-connect",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "description": "A framework-agnostic wallet connection toolkit for XRPL",
   "keywords": [

--- a/packages/adapters/crossmark/package.json
+++ b/packages/adapters/crossmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrpl-connect/adapter-crossmark",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Crossmark wallet adapter for XRPL Connect - Browser extension wallet support",
   "author": "XRPL Connect Contributors",
   "license": "MIT",

--- a/packages/adapters/gemwallet/package.json
+++ b/packages/adapters/gemwallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrpl-connect/adapter-gemwallet",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "GemWallet adapter for XRPL Connect - Browser extension wallet support",
   "author": "XRPL Connect Contributors",
   "license": "MIT",

--- a/packages/adapters/ledger/package.json
+++ b/packages/adapters/ledger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrpl-connect/adapter-ledger",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Ledger hardware wallet adapter for XRPL Connect",
   "author": "XRPL Connect Contributors",
   "license": "MIT",

--- a/packages/adapters/otsu/package.json
+++ b/packages/adapters/otsu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrpl-connect/adapter-otsu",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Otsu Wallet adapter for XRPL Connect - MV3 browser extension wallet",
   "author": "Otsu Wallet",
   "license": "MIT",

--- a/packages/adapters/walletconnect/package.json
+++ b/packages/adapters/walletconnect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrpl-connect/adapter-walletconnect",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "WalletConnect adapter for XRPL Connect - QR code based wallet connections",
   "author": "XRPL Connect Contributors",
   "license": "MIT",

--- a/packages/adapters/xaman/package.json
+++ b/packages/adapters/xaman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrpl-connect/adapter-xaman",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Xaman (formerly Xumm) wallet adapter for XRPL Connect - Mobile and desktop wallet support",
   "author": "XRPL Connect Contributors",
   "license": "MIT",

--- a/packages/adapters/xyra/package.json
+++ b/packages/adapters/xyra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrpl-connect/adapter-xyra",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Xyra wallet adapter for XRPL Connect - browser-native popup-based wallet",
   "author": "Xyra Wallet",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrpl-connect/core",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Framework-agnostic core SDK for XRPL wallet connections",
   "author": "XRPL Connect Contributors",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrpl-connect/ui",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Web component UI for XRPL Connect wallet connections",
   "author": "XRPL Connect Contributors",
   "license": "MIT",

--- a/packages/xrpl-connect/package.json
+++ b/packages/xrpl-connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xrpl-connect",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The easiest way to connect XRPL wallets to your app - Framework-agnostic toolkit with plug-and-play UI",
   "author": "XRPL Connect Contributors",
   "license": "MIT",

--- a/packages/xrpl-connect/vite.config.ts
+++ b/packages/xrpl-connect/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
-import { copyFileSync, existsSync } from 'fs';
+import { copyFileSync, existsSync, readFileSync } from 'fs';
 import inject from '@rollup/plugin-inject';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -27,6 +27,22 @@ export default defineConfig({
     },
   },
   plugins: [
+    // Match the per-adapter tsup config (`loader: { '.svg': 'text' }`). Without
+    // this, Vite's default asset handler resolves `.svg` imports to a
+    // `data:image/svg+xml,...` URL, and each adapter's
+    // `data:image/svg+xml,${encodeURIComponent(iconSvg)}` wrapper then
+    // double-encodes it into an unrenderable URI.
+    {
+      name: 'svg-as-text',
+      enforce: 'pre',
+      load(id) {
+        const path = id.split('?')[0];
+        if (path.endsWith('.svg')) {
+          const source = readFileSync(path, 'utf-8');
+          return `export default ${JSON.stringify(source)};`;
+        }
+      },
+    },
     {
       name: 'copy-readme',
       closeBundle() {


### PR DESCRIPTION
## Summary

Patch release fixing the broken wallet icons that shipped in **0.8.1** on npm.

### Fixed

- xrpl-connect (meta-bundle): load `.svg` imports as raw text in the Vite build so adapter icons aren't double-encoded as `data:image/svg+xml,data%3Aimage%2Fsvg%2Bxml%2C…` and render correctly in consumer apps (#87).

### Background

The 0.8.1 fix in #85 corrected the per-adapter tsup builds, but the **published meta-bundle** (built with Vite) still shipped the broken pattern because Vite's default `.svg` handler returns a `data:` URL — which the adapter wrapper then encoded a second time. 0.8.2 mirrors the tsup `text` loader in the Vite config so the meta-bundle gets raw `<svg>` markup before single-wrapping.

See [CHANGELOG.md](https://github.com/XRPL-Commons/xrpl-connect/blob/develop/CHANGELOG.md#082---2026-05-21).

## Test plan

- [x] `pnpm --filter xrpl-connect publish:build` produces a bundle with zero pre-encoded `data:image/svg+xml,…` literals; raw `<svg>` constants wrapped exactly once at runtime.
- [x] End-to-end: packed `dist-publish/` into a tarball, installed in the original Nuxt repro app (with `unwrapDoubleEncodedIcon` patch removed), all wallet logos render correctly in the connector modal.
- [x] Runtime probe: instantiating each adapter from the bundle yields `.icon` values whose decoded payload starts with `<svg`/`<?xml` — no nested `data:` prefix.
- [ ] Post-merge: tag `v0.8.2`, run `pnpm publish:build` on `main`, publish to npm.

## Follow-up

Deprecate 0.8.1 on npm once 0.8.2 is published, since 0.8.1 ships with non-rendering wallet icons:

```
npm deprecate xrpl-connect@0.8.1 "Wallet icons fail to render due to double-encoded data URIs; please upgrade to 0.8.2."
```