### PR TITLE
feat(core,ui): in-app browser (platform wrapper) detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Core / UI: in-app browser detection. `WalletAdapter` gains an optional `isPlatformWrapper()` and `WalletManager.getPlatformWrapper()` returns the adapter whose in-app browser the dApp is running inside (each check bounded by a 500 ms timeout). The `<xrpl-wallet-connector>` promotes that wallet to the top of the list on open unless an explicit `primary-wallet` is set, so a user browsing inside a mobile wallet connects with it directly. Adapters opt in by implementing the method.
+
 ### Fixed
 
 - xrpl-connect (meta-bundle): the published npm package now ships TypeScript types. The self-contained Vite bundle previously emitted no `.d.ts` and the generated `package.json` had no `types`/`exports.types`, so `npm install xrpl-connect` consumers got zero IntelliSense for the re-exported core/UI/adapter API. `publish:build` now rolls a single inlined `dist-publish/index.d.ts` via api-extractor (mirroring the JS bundle, with `@xrpl-connect/*` and `eventemitter3` types inlined) and `prepare-publish.mjs` wires up `types` + `exports.types`. The rolled declarations are verified self-contained: only `xrpl` (peer dependency) and `@walletconnect/types` (dependency, used by `WalletConnectAdapterOptions.metadata`) are left external, and both are now declared in the published manifest so they resolve for consumers. The manifest also drops the erroneous `"type": "module"` so CommonJS `require()` works, and the `publish:build` step is self-sufficient on a clean checkout (#56).

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -8,4 +8,9 @@
 export const TIME = {
   /** Maximum age for stored wallet state before it's considered stale (7 days) */
   STATE_MAX_AGE: 7 * 24 * 60 * 60 * 1000,
+  /**
+   * Max time an adapter's `isPlatformWrapper()` may take before it's treated as
+   * "not the wrapper", so a slow adapter can't delay in-app-browser detection.
+   */
+  PLATFORM_WRAPPER_TIMEOUT: 500,
 } as const;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -121,6 +121,16 @@ export interface WalletAdapter {
   // Availability
   isAvailable(): Promise<boolean>; // Check if wallet is installed/accessible
 
+  /**
+   * Optionally report whether the dApp is currently running *inside* this
+   * wallet's in-app browser (e.g. a mobile wallet's built-in browser). When an
+   * adapter returns `true`, the UI promotes it to the top of the wallet list so
+   * the user connects with the wallet they're already in. Omit when not
+   * applicable. Must resolve quickly — the manager bounds it with a short
+   * timeout ({@link TIME.PLATFORM_WRAPPER_TIMEOUT}).
+   */
+  isPlatformWrapper?(): Promise<boolean>;
+
   // Connection lifecycle
   connect(options?: ConnectOptions): Promise<AccountInfo>;
   disconnect(): Promise<void>;

--- a/packages/core/src/wallet-manager.ts
+++ b/packages/core/src/wallet-manager.ts
@@ -268,6 +268,36 @@ export class WalletManager extends EventEmitter<WalletEvent> {
   }
 
   /**
+   * Detect whether the dApp is running inside a wallet's in-app browser and, if
+   * so, return that adapter — so the UI can promote or auto-select it. Adapters
+   * opt in by implementing `isPlatformWrapper()`. Each check is bounded by a
+   * short timeout so a slow adapter can't delay detection; the first adapter
+   * that reports `true` wins.
+   */
+  async getPlatformWrapper(): Promise<WalletAdapter | null> {
+    const candidates = this.wallets.filter((a) => typeof a.isPlatformWrapper === 'function');
+
+    const results = await Promise.all(
+      candidates.map(async (adapter) => {
+        try {
+          const isWrapper = await Promise.race([
+            adapter.isPlatformWrapper!(),
+            new Promise<boolean>((resolve) =>
+              setTimeout(() => resolve(false), TIME.PLATFORM_WRAPPER_TIMEOUT)
+            ),
+          ]);
+          return isWrapper ? adapter : null;
+        } catch (error) {
+          this.logger.warn(`isPlatformWrapper check failed for ${adapter.name}:`, error);
+          return null;
+        }
+      })
+    );
+
+    return results.find((a): a is WalletAdapter => a !== null) ?? null;
+  }
+
+  /**
    * Get list of available wallets (installed/accessible)
    */
   async getAvailableWallets(): Promise<WalletAdapter[]> {

--- a/packages/core/tests/wallet-manager.test.ts
+++ b/packages/core/tests/wallet-manager.test.ts
@@ -96,3 +96,46 @@ describe('WalletManager.disconnect()', () => {
     expect(adapter.listenerCount('networkChanged')).toBe(0);
   });
 });
+
+describe('WalletManager.getPlatformWrapper()', () => {
+  it('returns the adapter reporting it is the in-app browser', async () => {
+    const other: WalletAdapter = { ...createFakeAdapter(), id: 'other', name: 'Other' };
+    const wrapper: WalletAdapter = {
+      ...createFakeAdapter(),
+      id: 'wrap',
+      name: 'Wrap',
+      isPlatformWrapper: async () => true,
+    };
+    const manager = new WalletManager({ adapters: [other, wrapper] });
+
+    expect(await manager.getPlatformWrapper()).toBe(wrapper);
+  });
+
+  it('returns null when no adapter reports being the in-app browser', async () => {
+    const a: WalletAdapter = {
+      ...createFakeAdapter(),
+      id: 'a',
+      isPlatformWrapper: async () => false,
+    };
+    const b: WalletAdapter = { ...createFakeAdapter(), id: 'b' }; // no method at all
+    const manager = new WalletManager({ adapters: [a, b] });
+
+    expect(await manager.getPlatformWrapper()).toBeNull();
+  });
+
+  it('treats a hung isPlatformWrapper() as "not the wrapper" after the timeout', async () => {
+    vi.useFakeTimers();
+    const hang: WalletAdapter = {
+      ...createFakeAdapter(),
+      id: 'hang',
+      isPlatformWrapper: () => new Promise<boolean>(() => {}),
+    };
+    const manager = new WalletManager({ adapters: [hang] });
+
+    const pending = manager.getPlatformWrapper();
+    await vi.advanceTimersByTimeAsync(500);
+
+    await expect(pending).resolves.toBeNull();
+    vi.useRealTimers();
+  });
+});

--- a/packages/ui/src/wallet-connector.ts
+++ b/packages/ui/src/wallet-connector.ts
@@ -90,6 +90,9 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
     private isOpen = false;
     private isFirstOpen = true;
     private primaryWalletId: string | null = null;
+    // Wallet whose in-app browser we're running inside (detected on open);
+    // promoted to the top of the list unless a primary-wallet attribute is set.
+    private detectedWrapperId: string | null = null;
     private viewState: 'list' | 'qr' | 'loading' | 'error' | 'account-selection' = 'list';
     public qrCodeData: QRCodeData | null = null;
     private loadingData: LoadingData | null = null;
@@ -359,6 +362,20 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
           'Available wallets:',
           this.availableWallets.map((w) => w.id)
         );
+
+        // If we're running inside a wallet's in-app browser, remember it so the
+        // list can promote it to the top (unless a primary-wallet is set).
+        try {
+          const wrapper = await this.walletManager.getPlatformWrapper();
+          this.detectedWrapperId =
+            wrapper && this.availableWallets.some((w) => w.id === wrapper.id) ? wrapper.id : null;
+          if (this.detectedWrapperId) {
+            logger.debug('Detected in-app browser wallet:', this.detectedWrapperId);
+          }
+        } catch (error) {
+          logger.warn('Platform wrapper detection failed:', error);
+          this.detectedWrapperId = null;
+        }
       } catch (error) {
         logger.error('Error checking wallet availability:', error);
         this.availableWallets = [];
@@ -753,7 +770,9 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
         this.previousModalHeight = existingModal.offsetHeight;
       }
 
-      this.primaryWalletId = this.getAttribute('primary-wallet');
+      // An explicit primary-wallet attribute wins; otherwise promote the
+      // detected in-app-browser wallet, if any.
+      this.primaryWalletId = this.getAttribute('primary-wallet') ?? this.detectedWrapperId;
 
       // Check connection state
       const isConnected = this.walletManager?.connected || false;


### PR DESCRIPTION
Part 3/4 of closing the Stellar-Wallets-Kit feature gap. Additive & backward compatible.

## Gap #1 — no in-app browser detection
When a user opens a dApp from *inside* a mobile wallet's built-in browser, xrpl-connect had no way to know, so it couldn't surface that wallet first. SWK exposes an optional per-module `isPlatformWrapper()` for exactly this.

## Fix (faithful port of SWK's optional-method design)
- **`WalletAdapter.isPlatformWrapper?()`** — optional; an adapter returns `true` when the dApp is running inside its in-app browser.
- **`WalletManager.getPlatformWrapper()`** — returns the first adapter reporting `true`. Each check is bounded by `TIME.PLATFORM_WRAPPER_TIMEOUT` (500 ms, matching SWK) so a slow adapter can't delay detection; adapters without the method are skipped.
- **`<xrpl-wallet-connector>`** — on open, detects the wrapper and promotes it to the top of the list, **unless** an explicit `primary-wallet` attribute is set (that still wins).

As in SWK, `isPlatformWrapper` is an **optional per-wallet** method — this PR lands the mechanism + manager/UI wiring; individual wallets opt in by implementing it (no bundled adapter ships a verifiable in-app-browser signal today, so none is fabricated here).

## Changes
- `packages/core/src/types.ts` — optional `isPlatformWrapper()` on `WalletAdapter`.
- `packages/core/src/constants.ts` — `TIME.PLATFORM_WRAPPER_TIMEOUT`.
- `packages/core/src/wallet-manager.ts` — `getPlatformWrapper()`.
- `packages/ui/src/wallet-connector.ts` — detect on open + promote (falls back to `primary-wallet`).
- `packages/core/tests/wallet-manager.test.ts` — +3 tests (detect / none / timeout).

## Verification
- `pnpm build` (full workspace, 13/13) ✅
- `pnpm test` — core 16 passed (+3), ui 4 ✅
- `pnpm lint` ✅ · `prettier --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)