### PR TITLE
feat(ui): openAndWait() modal promise + most-recently-used ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - xrpl-connect (meta-package): re-export each adapter's full public surface, not just the adapter class. Consumers can now reach adapter-specific exports — including every `*AdapterOptions`/`*ConnectOptions` type — and the complete upstream Xaman, Xaman OAuth, Crossmark, and GemWallet APIs through the collision-safe `XamanSDK`, `XamanOAuth2`, `CrossmarkSDK`, and `GemWalletAPI` namespaces (#35).
+- UI: `<xrpl-wallet-connector>.openAndWait()` opens the modal and returns a `Promise<AccountInfo>` that resolves when a wallet connects and rejects if the user closes the modal first — so callers can `await` a connection in one call instead of wiring up `connected` / `close` listeners.
+- UI: the wallet list now surfaces the most-recently-used wallet first. The connector remembers the last-used wallets (localStorage) and orders the list by usage, keeping the original order for wallets with no history. An explicit `primary-wallet` still takes precedence.
 
 ### Fixed
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -163,6 +163,16 @@ async open(): Promise<void>
 
 Open the wallet selection modal.
 
+#### openAndWait()
+
+```typescript
+openAndWait(): Promise<AccountInfo>
+```
+
+Open the modal and resolve with the connected account. It resolves immediately
+when a wallet is already connected, and rejects when no `WalletManager` is set
+or when the modal closes before a connection completes.
+
 #### close()
 
 ```typescript
@@ -170,6 +180,10 @@ close(): void
 ```
 
 Close any open modals.
+
+Wallet choices are ordered by most recent successful use. The component stores
+that ordering in `localStorage` under `xrpl-connect:mru-wallets`; an explicit
+`primary-wallet` still takes precedence.
 
 ### Events
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -78,7 +78,7 @@ All styling is controlled exclusively via CSS variables (see [Customization](./C
 The web component provides a public API for programmatic control:
 
 ```typescript
-interface WalletConnectorElement extends HTMLElement {
+interface WalletConnectorElementInstance extends HTMLElement {
   setWalletManager(manager: WalletManager): void;
   open(): Promise<void>;
   openAndWait(): Promise<AccountInfo>;

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -80,7 +80,8 @@ The web component provides a public API for programmatic control:
 ```typescript
 interface WalletConnectorElement extends HTMLElement {
   setWalletManager(manager: WalletManager): void;
-  open(): void;
+  open(): Promise<void>;
+  openAndWait(): Promise<AccountInfo>;
   close(): void;
   toggle(): void;
 }
@@ -104,6 +105,21 @@ Opens the wallet connection modal.
 const connector = document.querySelector('xrpl-wallet-connector');
 connector.open();
 ```
+
+#### `openAndWait()`
+
+Opens the modal and resolves with the connected account. It resolves immediately
+if the manager is already connected, and rejects if no manager is configured or
+the user closes the modal first.
+
+```typescript
+const account = await connector.openAndWait();
+console.log(account.address);
+```
+
+Successful connections also update the most-recently-used ordering stored at
+`localStorage["xrpl-connect:mru-wallets"]`. The `primary-wallet` attribute still
+has priority over this ordering.
 
 #### `close()`
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -42,7 +42,8 @@
     "dev": "tsup --watch",
     "lint": "eslint src",
     "type-check": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "pnpm test:types && vitest run",
+    "test:types": "tsc -p tests/tsconfig.types.json",
     "test:watch": "vitest",
     "clean": "rm -rf dist"
   },

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,7 +3,7 @@
  * Web component UI library for XRPL Connect
  */
 
-export { WalletConnectorElement } from './wallet-connector';
+export { WalletConnectorElement, type WalletConnectorElementInstance } from './wallet-connector';
 
 // Export constants and utilities for advanced use cases
 export * from './constants';

--- a/packages/ui/src/utils.ts
+++ b/packages/ui/src/utils.ts
@@ -108,3 +108,23 @@ export function truncateString(str: string, maxLength: number): string {
 export function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+/**
+ * Order wallets by most-recently-used first (`mruIds`, newest first), keeping
+ * the input order for wallets with no usage history. Stable: never reorders two
+ * wallets that are both unused.
+ *
+ * @param wallets - Wallets to order.
+ * @param mruIds - Wallet ids in most-recently-used order (newest first).
+ */
+export function orderWalletsByMru<T extends { id: string }>(wallets: T[], mruIds: string[]): T[] {
+  if (mruIds.length === 0) return wallets;
+  const rank = (id: string): number => {
+    const index = mruIds.indexOf(id);
+    return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+  };
+  return wallets
+    .map((wallet, index) => ({ wallet, index }))
+    .sort((a, b) => rank(a.wallet.id) - rank(b.wallet.id) || a.index - b.index)
+    .map((entry) => entry.wallet);
+}

--- a/packages/ui/src/wallet-connector.ts
+++ b/packages/ui/src/wallet-connector.ts
@@ -42,8 +42,31 @@ import { isXamanQRImage, adjustColorBrightness, orderWalletsByMru } from './util
 const logger = createLogger('[WalletConnector]');
 const AVAILABILITY_TIMED_OUT = Symbol('availability-timed-out');
 
+/** Public API exposed by the `<xrpl-wallet-connector>` custom element. */
+export interface WalletConnectorElementInstance extends HTMLElement {
+  setWalletManager(manager: WalletManager): void;
+  open(): Promise<void>;
+  openAndWait(): Promise<AccountInfo>;
+  close(): void;
+  toggle(): void;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'xrpl-wallet-connector': WalletConnectorElementInstance;
+  }
+}
+
+interface ConnectionWaiter {
+  resolve(account: AccountInfo): void;
+  reject(error: Error): void;
+}
+
 // Only define the component in browser (guard against SSR)
-let WalletConnectorElement: CustomElementConstructor | null = null;
+let WalletConnectorElement: {
+  new (): WalletConnectorElementInstance;
+  readonly prototype: WalletConnectorElementInstance;
+} | null = null;
 
 if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
   const XC_CSS_VARIABLES = [
@@ -85,7 +108,10 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
     '--xc-warning-color',
   ] as const;
 
-  class WalletConnectorElementImpl extends HTMLElement implements WalletConnectorContext {
+  class WalletConnectorElementImpl
+    extends HTMLElement
+    implements WalletConnectorContext, WalletConnectorElementInstance
+  {
     public walletManager: WalletManager | null = null;
     public readonly shadow: ShadowRoot;
     private isOpen = false;
@@ -109,8 +135,9 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
     private overlayPortal: HTMLDivElement | null = null;
     private accountModalPortal: HTMLDivElement | null = null;
     private styleObserver: MutationObserver | null = null;
+    private readonly connectionWaiters = new Set<ConnectionWaiter>();
     private walletManagerHandlers: {
-      connect: () => void;
+      connect: (account: AccountInfo) => void;
       disconnect: () => void;
       accountChanged: () => void;
     } | null = null;
@@ -126,6 +153,7 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
     }
 
     connectedCallback() {
+      this.attachWalletManagerHandlers();
       this.render();
 
       // Update derived colors on initial load
@@ -147,15 +175,12 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
       this.openGeneration += 1;
       this.isOpen = false;
       this.accountModalOpen = false;
+      this.rejectConnectionWaiters(
+        new Error('Wallet connector was disconnected before a wallet was connected.')
+      );
       this.resetWalletAvailability();
       this.eventHandler?.detachEventListeners();
-
-      if (this.walletManager && this.walletManagerHandlers) {
-        this.walletManager.off('connect', this.walletManagerHandlers.connect);
-        this.walletManager.off('disconnect', this.walletManagerHandlers.disconnect);
-        this.walletManager.off('accountChanged', this.walletManagerHandlers.accountChanged);
-        this.walletManagerHandlers = null;
-      }
+      this.detachWalletManagerHandlers();
 
       this.styleObserver?.disconnect();
       this.styleObserver = null;
@@ -256,38 +281,18 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
      * Set the WalletManager instance
      */
     setWalletManager(manager: WalletManager) {
-      // If a previous manager was wired up, drop its subscriptions before swapping.
-      if (this.walletManager && this.walletManagerHandlers) {
-        this.walletManager.off('connect', this.walletManagerHandlers.connect);
-        this.walletManager.off('disconnect', this.walletManagerHandlers.disconnect);
-        this.walletManager.off('accountChanged', this.walletManagerHandlers.accountChanged);
-      }
-
+      this.detachWalletManagerHandlers();
       this.walletManager = manager;
       this.resetWalletAvailability();
       this.walletService = new WalletService(this.walletManager, this);
       this.eventHandler = new EventHandler(this, this.walletService);
+      this.attachWalletManagerHandlers();
 
-      // Listen to wallet manager events — keep refs so we can detach on disconnect.
-      this.walletManagerHandlers = {
-        connect: () => {
-          // Remember the wallet just used so it surfaces first next time.
-          const connectedId = this.walletManager?.wallet?.id;
-          if (connectedId) this.recordMruId(connectedId);
-          this.close();
-          this.render(); // Re-render to update button
-        },
-        disconnect: () => {
-          this.render(); // Re-render to update button
-        },
-        accountChanged: () => {
-          this.render(); // Re-render to update button with new account
-        },
-      };
-
-      this.walletManager.on('connect', this.walletManagerHandlers.connect);
-      this.walletManager.on('disconnect', this.walletManagerHandlers.disconnect);
-      this.walletManager.on('accountChanged', this.walletManagerHandlers.accountChanged);
+      const connectedAccount = manager.connected ? manager.account : null;
+      if (connectedAccount && this.connectionWaiters.size > 0) {
+        this.resolveConnectionWaiters(connectedAccount);
+        if (this.isOpen) this.close();
+      }
 
       if (this.isOpen) {
         // Hide unverified choices until the replacement manager is checked.
@@ -300,6 +305,52 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
 
       // Check for existing Xaman session after a short delay
       this.checkXamanStateOnInit();
+    }
+
+    private attachWalletManagerHandlers(): void {
+      const manager = this.walletManager;
+      if (!manager || this.walletManagerHandlers) return;
+
+      this.walletManagerHandlers = {
+        connect: (account: AccountInfo) => {
+          if (manager !== this.walletManager) return;
+          this.resolveConnectionWaiters(account);
+          const connectedId = manager.wallet?.id;
+          if (connectedId) this.recordMruId(connectedId);
+          this.close();
+          this.render();
+        },
+        disconnect: () => {
+          if (manager === this.walletManager) this.render();
+        },
+        accountChanged: () => {
+          if (manager === this.walletManager) this.render();
+        },
+      };
+
+      manager.on('connect', this.walletManagerHandlers.connect);
+      manager.on('disconnect', this.walletManagerHandlers.disconnect);
+      manager.on('accountChanged', this.walletManagerHandlers.accountChanged);
+    }
+
+    private detachWalletManagerHandlers(): void {
+      if (!this.walletManager || !this.walletManagerHandlers) return;
+      this.walletManager.off('connect', this.walletManagerHandlers.connect);
+      this.walletManager.off('disconnect', this.walletManagerHandlers.disconnect);
+      this.walletManager.off('accountChanged', this.walletManagerHandlers.accountChanged);
+      this.walletManagerHandlers = null;
+    }
+
+    private resolveConnectionWaiters(account: AccountInfo): void {
+      const waiters = Array.from(this.connectionWaiters);
+      this.connectionWaiters.clear();
+      for (const waiter of waiters) waiter.resolve(account);
+    }
+
+    private rejectConnectionWaiters(error: Error): void {
+      const waiters = Array.from(this.connectionWaiters);
+      this.connectionWaiters.clear();
+      for (const waiter of waiters) waiter.reject(error);
     }
 
     /**
@@ -427,10 +478,6 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
               false
           );
 
-        // Surface the most-recently-used wallets first, preserving the original
-        // order for wallets that have never been used.
-        this.availableWallets = this.orderByMru(this.availableWallets);
-
         logger.debug(
           'Available wallets:',
           this.availableWallets.map((w) => w.id)
@@ -530,29 +577,12 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
       }
 
       return new Promise<AccountInfo>((resolve, reject) => {
-        const cleanup = () => {
-          manager.off('connect', onConnect);
-          this.removeEventListener('close', onClose);
-        };
-        // Resolve off the manager's connect event (fires with the account),
-        // not the DOM 'connected' event — a successful connect dispatches
-        // 'close' first, so we must not treat that close as a cancellation.
-        const onConnect = (account: AccountInfo) => {
-          cleanup();
-          resolve(account);
-        };
-        const onClose = () => {
-          if (manager?.connected) return; // close that follows a successful connect
-          cleanup();
-          reject(new Error('Modal closed before a wallet was connected.'));
-        };
-
-        manager.on('connect', onConnect);
-        this.addEventListener('close', onClose);
-        this.open().catch((error) => {
-          cleanup();
-          reject(error instanceof Error ? error : new Error(String(error)));
-        });
+        this.connectionWaiters.add({ resolve, reject });
+        if (!this.isOpen) {
+          void this.open().catch((error) => {
+            this.rejectConnectionWaiters(error instanceof Error ? error : new Error(String(error)));
+          });
+        }
       });
     }
 
@@ -562,6 +592,7 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
     close() {
       this.openGeneration += 1;
       this.isOpen = false;
+      this.rejectConnectionWaiters(new Error('Modal closed before a wallet was connected.'));
 
       // Restore body scroll when modal is closed
       document.body.style.overflow = '';
@@ -933,9 +964,10 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
           : 'Connect Wallet';
 
       // Once checked, an empty list means no wallet is currently available.
-      const wallets = this.walletAvailabilityChecked
+      const baseWallets = this.walletAvailabilityChecked
         ? this.availableWallets
         : this.walletManager?.wallets || [];
+      const wallets = this.orderByMru(baseWallets);
 
       const primaryWallet = this.primaryWalletId
         ? (wallets.find((w) => w.id === this.primaryWalletId) ?? null)

--- a/packages/ui/src/wallet-connector.ts
+++ b/packages/ui/src/wallet-connector.ts
@@ -3,7 +3,7 @@
  * A framework-agnostic web component for connecting to XRPL wallets
  */
 
-import type { WalletAdapter, WalletManager } from '@xrpl-connect/core';
+import type { AccountInfo, WalletAdapter, WalletManager } from '@xrpl-connect/core';
 import { createLogger, supportsPreInitialize, withTimeout, TIME } from '@xrpl-connect/core';
 import QRCodeStyling from 'qr-code-styling';
 import { mainStyles } from './styles/main';
@@ -34,7 +34,7 @@ import {
   type QRCodeData,
   type WalletConnectorContext,
 } from './types';
-import { isXamanQRImage, adjustColorBrightness } from './utils';
+import { isXamanQRImage, adjustColorBrightness, orderWalletsByMru } from './utils';
 
 /**
  * Logger instance for wallet connector
@@ -271,6 +271,9 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
       // Listen to wallet manager events — keep refs so we can detach on disconnect.
       this.walletManagerHandlers = {
         connect: () => {
+          // Remember the wallet just used so it surfaces first next time.
+          const connectedId = this.walletManager?.wallet?.id;
+          if (connectedId) this.recordMruId(connectedId);
           this.close();
           this.render(); // Re-render to update button
         },
@@ -424,6 +427,10 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
               false
           );
 
+        // Surface the most-recently-used wallets first, preserving the original
+        // order for wallets that have never been used.
+        this.availableWallets = this.orderByMru(this.availableWallets);
+
         logger.debug(
           'Available wallets:',
           this.availableWallets.map((w) => w.id)
@@ -438,6 +445,45 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
         this.walletAvailabilityTimedOut = true;
         return true;
       }
+    }
+
+    /** localStorage key holding the most-recently-used wallet ids (newest first). */
+    private static readonly MRU_STORAGE_KEY = 'xrpl-connect:mru-wallets';
+
+    /**
+     * Read the most-recently-used wallet ids (newest first). Never throws —
+     * storage may be unavailable or hold malformed data.
+     */
+    private loadMruIds(): string[] {
+      try {
+        if (typeof localStorage === 'undefined') return [];
+        const raw = localStorage.getItem(WalletConnectorElementImpl.MRU_STORAGE_KEY);
+        const parsed = raw ? JSON.parse(raw) : [];
+        return Array.isArray(parsed)
+          ? parsed.filter((id): id is string => typeof id === 'string')
+          : [];
+      } catch {
+        return [];
+      }
+    }
+
+    /** Move a wallet id to the front of the most-recently-used list. */
+    private recordMruId(id: string): void {
+      try {
+        if (typeof localStorage === 'undefined') return;
+        const next = [id, ...this.loadMruIds().filter((existing) => existing !== id)].slice(0, 10);
+        localStorage.setItem(WalletConnectorElementImpl.MRU_STORAGE_KEY, JSON.stringify(next));
+      } catch {
+        // Ignore storage failures — MRU ordering is a non-critical enhancement.
+      }
+    }
+
+    /**
+     * Return wallets ordered by most-recently-used first, keeping the given
+     * (availability) order for wallets with no usage history.
+     */
+    private orderByMru(wallets: WalletAdapter[]): WalletAdapter[] {
+      return orderWalletsByMru(wallets, this.loadMruIds());
     }
 
     /**
@@ -467,6 +513,40 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
 
       // Pre-initialize WalletConnect to reduce loading time
       this.preInitializeWalletConnect();
+    }
+
+    /**
+     * Open the modal and resolve once a wallet is connected, or reject if the
+     * user closes the modal first. Lets callers `await` a connection in one call
+     * instead of wiring up `connected` / `close` event listeners themselves.
+     */
+    openAndWait(): Promise<AccountInfo> {
+      return new Promise<AccountInfo>((resolve, reject) => {
+        const manager = this.walletManager;
+        const cleanup = () => {
+          manager?.off('connect', onConnect);
+          this.removeEventListener('close', onClose);
+        };
+        // Resolve off the manager's connect event (fires with the account),
+        // not the DOM 'connected' event — a successful connect dispatches
+        // 'close' first, so we must not treat that close as a cancellation.
+        const onConnect = (account: AccountInfo) => {
+          cleanup();
+          resolve(account);
+        };
+        const onClose = () => {
+          if (manager?.connected) return; // close that follows a successful connect
+          cleanup();
+          reject(new Error('Modal closed before a wallet was connected.'));
+        };
+
+        manager?.on('connect', onConnect);
+        this.addEventListener('close', onClose);
+        this.open().catch((error) => {
+          cleanup();
+          reject(error instanceof Error ? error : new Error(String(error)));
+        });
+      });
     }
 
     /**

--- a/packages/ui/src/wallet-connector.ts
+++ b/packages/ui/src/wallet-connector.ts
@@ -521,10 +521,17 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
      * instead of wiring up `connected` / `close` event listeners themselves.
      */
     openAndWait(): Promise<AccountInfo> {
+      const manager = this.walletManager;
+      if (!manager) {
+        return Promise.reject(new Error('WalletManager must be set before opening the modal.'));
+      }
+      if (manager.connected && manager.account) {
+        return Promise.resolve(manager.account);
+      }
+
       return new Promise<AccountInfo>((resolve, reject) => {
-        const manager = this.walletManager;
         const cleanup = () => {
-          manager?.off('connect', onConnect);
+          manager.off('connect', onConnect);
           this.removeEventListener('close', onClose);
         };
         // Resolve off the manager's connect event (fires with the account),
@@ -540,7 +547,7 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
           reject(new Error('Modal closed before a wallet was connected.'));
         };
 
-        manager?.on('connect', onConnect);
+        manager.on('connect', onConnect);
         this.addEventListener('close', onClose);
         this.open().catch((error) => {
           cleanup();

--- a/packages/ui/tests/mru.test.ts
+++ b/packages/ui/tests/mru.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { orderWalletsByMru } from '../src/utils';
+
+const wallets = [{ id: 'xaman' }, { id: 'crossmark' }, { id: 'gemwallet' }, { id: 'ledger' }];
+
+describe('orderWalletsByMru', () => {
+  it('returns the input unchanged when there is no history', () => {
+    expect(orderWalletsByMru(wallets, [])).toEqual(wallets);
+  });
+
+  it('surfaces the most-recently-used wallets first', () => {
+    const ordered = orderWalletsByMru(wallets, ['ledger', 'gemwallet']);
+    expect(ordered.map((w) => w.id)).toEqual(['ledger', 'gemwallet', 'xaman', 'crossmark']);
+  });
+
+  it('keeps the original relative order for wallets with no history (stable)', () => {
+    const ordered = orderWalletsByMru(wallets, ['crossmark']);
+    expect(ordered.map((w) => w.id)).toEqual(['crossmark', 'xaman', 'gemwallet', 'ledger']);
+  });
+
+  it('ignores history entries for wallets that are not present', () => {
+    const ordered = orderWalletsByMru(wallets, ['not-a-wallet', 'ledger']);
+    expect(ordered.map((w) => w.id)).toEqual(['ledger', 'xaman', 'crossmark', 'gemwallet']);
+  });
+});

--- a/packages/ui/tests/mru.test.ts
+++ b/packages/ui/tests/mru.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MemoryStorageAdapter, WalletManager } from '@xrpl-connect/core';
+import type { AccountInfo, NetworkInfo, WalletAdapter } from '@xrpl-connect/core';
+import '../src/wallet-connector';
 import { orderWalletsByMru } from '../src/utils';
 
 const wallets = [{ id: 'xaman' }, { id: 'crossmark' }, { id: 'gemwallet' }, { id: 'ledger' }];
@@ -21,5 +24,94 @@ describe('orderWalletsByMru', () => {
   it('ignores history entries for wallets that are not present', () => {
     const ordered = orderWalletsByMru(wallets, ['not-a-wallet', 'ledger']);
     expect(ordered.map((w) => w.id)).toEqual(['ledger', 'xaman', 'crossmark', 'gemwallet']);
+  });
+});
+
+const NETWORK: NetworkInfo = { id: 'testnet', name: 'Testnet', wss: 'wss://example' };
+
+function createAdapter(id: string): WalletAdapter {
+  const account: AccountInfo = { address: `r-${id}`, network: NETWORK };
+  return {
+    id,
+    name: id,
+    isAvailable: async () => true,
+    connect: async () => account,
+    disconnect: async () => {},
+    getAccount: async () => account,
+    getNetwork: async () => NETWORK,
+    sign: async () => ({ hash: '' }),
+    signAndSubmit: async () => ({ hash: '' }),
+    signMessage: async () => ({ message: '', signature: '', publicKey: '' }),
+  };
+}
+
+function createManager(): WalletManager {
+  return new WalletManager({
+    adapters: [createAdapter('first'), createAdapter('second')],
+    storage: new MemoryStorageAdapter(),
+  });
+}
+
+function mountConnector(manager: WalletManager) {
+  const element = document.createElement('xrpl-wallet-connector');
+  document.body.appendChild(element);
+  element.setWalletManager(manager);
+  return element;
+}
+
+function getRenderedWalletIds(): string[] {
+  const portal = document.querySelector('[data-xrpl-overlay-portal]');
+  return Array.from(
+    portal?.shadowRoot?.querySelectorAll<HTMLElement>('[data-wallet-id]') ?? []
+  ).map((element) => element.dataset.walletId ?? '');
+}
+
+describe('wallet connector MRU integration', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document
+      .querySelectorAll(
+        'xrpl-wallet-connector, [data-xrpl-overlay-portal], [data-xrpl-account-modal-portal]'
+      )
+      .forEach((element) => element.remove());
+  });
+
+  function stubLocalStorage(): void {
+    const values = new Map<string, string>();
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+      removeItem: (key: string) => values.delete(key),
+      clear: () => values.clear(),
+    });
+  }
+
+  it('reorders the cached list after connect, disconnect, and reopen', async () => {
+    stubLocalStorage();
+    const manager = createManager();
+    const element = mountConnector(manager);
+
+    await element.open();
+    expect(getRenderedWalletIds()).toEqual(['first', 'second']);
+    await manager.connect('second');
+    await manager.disconnect();
+    await element.open();
+
+    expect(getRenderedWalletIds()).toEqual(['second', 'first']);
+  });
+
+  it("reads another connector instance's MRU update when reopened", async () => {
+    stubLocalStorage();
+    const cachedElement = mountConnector(createManager());
+    await cachedElement.open();
+    expect(getRenderedWalletIds()).toEqual(['first', 'second']);
+    cachedElement.close();
+
+    const writerManager = createManager();
+    mountConnector(writerManager);
+    await writerManager.connect('second');
+    await cachedElement.open();
+
+    expect(getRenderedWalletIds()).toEqual(['second', 'first']);
   });
 });

--- a/packages/ui/tests/openAndWait.test.ts
+++ b/packages/ui/tests/openAndWait.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import '../src/wallet-connector'; // registers <xrpl-wallet-connector>
+import { WalletManager } from '@xrpl-connect/core';
+import type { AccountInfo, NetworkInfo, WalletAdapter } from '@xrpl-connect/core';
+
+const NETWORK: NetworkInfo = { id: 'testnet', name: 'Testnet', wss: 'wss://example' };
+const ACCOUNT: AccountInfo = { address: 'rTestAddress00000000000000000000000', network: NETWORK };
+
+function fakeAdapter(): WalletAdapter {
+  return {
+    id: 'fake',
+    name: 'Fake Wallet',
+    isAvailable: async () => true,
+    connect: async () => ACCOUNT,
+    disconnect: async () => {},
+    getAccount: async () => ACCOUNT,
+    getNetwork: async () => NETWORK,
+    sign: async () => ({ hash: '' }),
+    signAndSubmit: async () => ({ hash: '' }),
+    signMessage: async () => ({ message: '', signature: '', publicKey: '' }),
+  };
+}
+
+interface ConnectorEl extends HTMLElement {
+  setWalletManager(m: WalletManager): void;
+  openAndWait(): Promise<AccountInfo>;
+  close(): void;
+}
+
+function mountConnector(manager: WalletManager): ConnectorEl {
+  const el = document.createElement('xrpl-wallet-connector') as ConnectorEl;
+  document.body.appendChild(el);
+  el.setWalletManager(manager);
+  return el;
+}
+
+describe('<xrpl-wallet-connector>.openAndWait()', () => {
+  afterEach(() => {
+    // Remove mounted connectors so disconnectedCallback tears down observers /
+    // portals and nothing keeps the test runner alive.
+    document
+      .querySelectorAll(
+        'xrpl-wallet-connector, [data-xrpl-overlay-portal], [data-xrpl-account-modal-portal]'
+      )
+      .forEach((el) => el.remove());
+  });
+
+  it('resolves with the account once a wallet connects', async () => {
+    const manager = new WalletManager({ adapters: [fakeAdapter()] });
+    const el = mountConnector(manager);
+
+    const promise = el.openAndWait();
+    await manager.connect('fake');
+
+    await expect(promise).resolves.toEqual(ACCOUNT);
+  });
+
+  it('rejects when the modal is closed before connecting', async () => {
+    const manager = new WalletManager({ adapters: [fakeAdapter()] });
+    const el = mountConnector(manager);
+
+    const promise = el.openAndWait();
+    el.close();
+
+    await expect(promise).rejects.toThrow(/closed/i);
+  });
+});

--- a/packages/ui/tests/openAndWait.test.ts
+++ b/packages/ui/tests/openAndWait.test.ts
@@ -1,19 +1,31 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import '../src/wallet-connector'; // registers <xrpl-wallet-connector>
-import { WalletManager } from '@xrpl-connect/core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import '../src/wallet-connector';
+import { MemoryStorageAdapter, WalletManager } from '@xrpl-connect/core';
 import type { AccountInfo, NetworkInfo, WalletAdapter } from '@xrpl-connect/core';
 
 const NETWORK: NetworkInfo = { id: 'testnet', name: 'Testnet', wss: 'wss://example' };
 const ACCOUNT: AccountInfo = { address: 'rTestAddress00000000000000000000000', network: NETWORK };
 
-function fakeAdapter(): WalletAdapter {
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function fakeAdapter(
+  id = 'fake',
+  account: AccountInfo = ACCOUNT,
+  isAvailable: WalletAdapter['isAvailable'] = async () => true
+): WalletAdapter {
   return {
-    id: 'fake',
-    name: 'Fake Wallet',
-    isAvailable: async () => true,
-    connect: async () => ACCOUNT,
+    id,
+    name: `Fake Wallet ${id}`,
+    isAvailable,
+    connect: async () => account,
     disconnect: async () => {},
-    getAccount: async () => ACCOUNT,
+    getAccount: async () => account,
     getNetwork: async () => NETWORK,
     sign: async () => ({ hash: '' }),
     signAndSubmit: async () => ({ hash: '' }),
@@ -21,62 +33,161 @@ function fakeAdapter(): WalletAdapter {
   };
 }
 
-interface ConnectorEl extends HTMLElement {
-  setWalletManager(m: WalletManager): void;
-  openAndWait(): Promise<AccountInfo>;
-  close(): void;
+function createManager(adapters: WalletAdapter[]): WalletManager {
+  return new WalletManager({ adapters, storage: new MemoryStorageAdapter() });
 }
 
-function mountConnector(manager: WalletManager): ConnectorEl {
-  const el = document.createElement('xrpl-wallet-connector') as ConnectorEl;
-  document.body.appendChild(el);
-  el.setWalletManager(manager);
-  return el;
+function mountConnector(manager: WalletManager) {
+  const element = document.createElement('xrpl-wallet-connector');
+  document.body.appendChild(element);
+  element.setWalletManager(manager);
+  return element;
+}
+
+async function flushPromises(): Promise<void> {
+  for (let index = 0; index < 10; index += 1) await Promise.resolve();
 }
 
 describe('<xrpl-wallet-connector>.openAndWait()', () => {
   afterEach(() => {
-    // Remove mounted connectors so disconnectedCallback tears down observers /
-    // portals and nothing keeps the test runner alive.
     document
       .querySelectorAll(
         'xrpl-wallet-connector, [data-xrpl-overlay-portal], [data-xrpl-account-modal-portal]'
       )
-      .forEach((el) => el.remove());
+      .forEach((element) => element.remove());
   });
 
   it('resolves with the account once a wallet connects', async () => {
-    const manager = new WalletManager({ adapters: [fakeAdapter()] });
-    const el = mountConnector(manager);
+    const manager = createManager([fakeAdapter()]);
+    const element = mountConnector(manager);
 
-    const promise = el.openAndWait();
+    const pending = element.openAndWait();
     await manager.connect('fake');
 
-    await expect(promise).resolves.toEqual(ACCOUNT);
+    await expect(pending).resolves.toEqual(ACCOUNT);
   });
 
-  it('rejects when the modal is closed before connecting', async () => {
-    const manager = new WalletManager({ adapters: [fakeAdapter()] });
-    const el = mountConnector(manager);
+  it('rejects when the modal closes and does not emit a late open event', async () => {
+    const availability = deferred<boolean>();
+    const isAvailable = vi.fn<WalletAdapter['isAvailable']>(() => availability.promise);
+    const element = mountConnector(createManager([fakeAdapter('fake', ACCOUNT, isAvailable)]));
+    const onOpen = vi.fn();
+    element.addEventListener('open', onOpen);
 
-    const promise = el.openAndWait();
-    el.close();
+    const pending = element.openAndWait();
+    element.close();
+    await expect(pending).rejects.toThrow(/closed/i);
 
-    await expect(promise).rejects.toThrow(/closed/i);
+    availability.resolve(true);
+    await flushPromises();
+    expect(onOpen).not.toHaveBeenCalled();
+    expect(document.body.style.overflow).toBe('');
   });
 
   it('resolves immediately when a wallet is already connected', async () => {
-    const manager = new WalletManager({ adapters: [fakeAdapter()] });
+    const manager = createManager([fakeAdapter()]);
     await manager.connect('fake');
-    const el = mountConnector(manager);
+    const element = mountConnector(manager);
 
-    await expect(el.openAndWait()).resolves.toEqual(ACCOUNT);
+    await expect(element.openAndWait()).resolves.toEqual(ACCOUNT);
   });
 
   it('rejects immediately when no WalletManager has been set', async () => {
-    const el = document.createElement('xrpl-wallet-connector') as ConnectorEl;
-    document.body.appendChild(el);
+    const element = document.createElement('xrpl-wallet-connector');
+    document.body.appendChild(element);
 
-    await expect(el.openAndWait()).rejects.toThrow(/WalletManager/i);
+    await expect(element.openAndWait()).rejects.toThrow(/WalletManager/i);
+  });
+
+  it('follows a replacement manager and ignores the detached manager', async () => {
+    const oldAccount = { ...ACCOUNT, address: 'rOldManager' };
+    const newAccount = { ...ACCOUNT, address: 'rNewManager' };
+    const oldManager = createManager([fakeAdapter('old', oldAccount)]);
+    const newManager = createManager([fakeAdapter('new', newAccount)]);
+    const element = mountConnector(oldManager);
+
+    const pending = element.openAndWait();
+    element.setWalletManager(newManager);
+    expect(oldManager.listenerCount('connect')).toBe(0);
+    await newManager.connect('new');
+
+    await expect(pending).resolves.toEqual(newAccount);
+    await oldManager.connect('old');
+    expect(oldManager.listenerCount('connect')).toBe(0);
+  });
+
+  it('resolves when the replacement manager is already connected', async () => {
+    const replacementAccount = { ...ACCOUNT, address: 'rReplacement' };
+    const oldManager = createManager([fakeAdapter('old')]);
+    const replacement = createManager([fakeAdapter('replacement', replacementAccount)]);
+    await replacement.connect('replacement');
+    const element = mountConnector(oldManager);
+
+    const pending = element.openAndWait();
+    element.setWalletManager(replacement);
+
+    await expect(pending).resolves.toEqual(replacementAccount);
+  });
+
+  it('rejects on unmount, releases handlers, and works after remount', async () => {
+    const manager = createManager([fakeAdapter()]);
+    const element = mountConnector(manager);
+    const pending = element.openAndWait();
+
+    element.remove();
+
+    await expect(pending).rejects.toThrow(/disconnected/i);
+    expect(manager.listenerCount('connect')).toBe(0);
+
+    document.body.appendChild(element);
+    const resumed = element.openAndWait();
+    expect(manager.listenerCount('connect')).toBe(1);
+    await manager.connect('fake');
+    await expect(resumed).resolves.toEqual(ACCOUNT);
+  });
+
+  it('coalesces concurrent waits into one modal open and resolves all callers', async () => {
+    const availability = deferred<boolean>();
+    const isAvailable = vi
+      .fn<WalletAdapter['isAvailable']>()
+      .mockReturnValueOnce(availability.promise)
+      .mockResolvedValue(true);
+    const manager = createManager([fakeAdapter('fake', ACCOUNT, isAvailable)]);
+    const element = mountConnector(manager);
+    const onOpen = vi.fn();
+    element.addEventListener('open', onOpen);
+
+    const first = element.openAndWait();
+    const second = element.openAndWait();
+    expect(isAvailable).toHaveBeenCalledTimes(1);
+
+    availability.resolve(true);
+    await flushPromises();
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    await manager.connect('fake');
+
+    await expect(first).resolves.toEqual(ACCOUNT);
+    await expect(second).resolves.toEqual(ACCOUNT);
+  });
+
+  it('resolves a connection that completes while availability is still pending', async () => {
+    const availability = deferred<boolean>();
+    const isAvailable = vi
+      .fn<WalletAdapter['isAvailable']>()
+      .mockReturnValueOnce(availability.promise)
+      .mockResolvedValue(true);
+    const manager = createManager([fakeAdapter('fake', ACCOUNT, isAvailable)]);
+    const element = mountConnector(manager);
+    const onOpen = vi.fn();
+    element.addEventListener('open', onOpen);
+
+    const pending = element.openAndWait();
+    await manager.connect('fake');
+    await expect(pending).resolves.toEqual(ACCOUNT);
+
+    availability.resolve(true);
+    await flushPromises();
+    expect(onOpen).not.toHaveBeenCalled();
+    expect(document.body.style.overflow).toBe('');
   });
 });

--- a/packages/ui/tests/openAndWait.test.ts
+++ b/packages/ui/tests/openAndWait.test.ts
@@ -64,4 +64,19 @@ describe('<xrpl-wallet-connector>.openAndWait()', () => {
 
     await expect(promise).rejects.toThrow(/closed/i);
   });
+
+  it('resolves immediately when a wallet is already connected', async () => {
+    const manager = new WalletManager({ adapters: [fakeAdapter()] });
+    await manager.connect('fake');
+    const el = mountConnector(manager);
+
+    await expect(el.openAndWait()).resolves.toEqual(ACCOUNT);
+  });
+
+  it('rejects immediately when no WalletManager has been set', async () => {
+    const el = document.createElement('xrpl-wallet-connector') as ConnectorEl;
+    document.body.appendChild(el);
+
+    await expect(el.openAndWait()).rejects.toThrow(/WalletManager/i);
+  });
 });

--- a/packages/ui/tests/public-api.types.ts
+++ b/packages/ui/tests/public-api.types.ts
@@ -1,0 +1,12 @@
+import { WalletConnectorElement, type WalletConnectorElementInstance } from '../dist/index';
+import type { AccountInfo } from '@xrpl-connect/core';
+
+const connector: WalletConnectorElementInstance = document.createElement('xrpl-wallet-connector');
+const pendingAccount: Promise<AccountInfo> = connector.openAndWait();
+
+if (WalletConnectorElement) {
+  const constructed: WalletConnectorElementInstance = new WalletConnectorElement();
+  void constructed;
+}
+
+void pendingAccount;

--- a/packages/ui/tests/tsconfig.types.json
+++ b/packages/ui/tests/tsconfig.types.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "..",
+    "strict": true,
+    "skipLibCheck": false
+  },
+  "files": ["public-api.types.ts", "vendor-types.d.ts"]
+}

--- a/packages/ui/tests/vendor-types.d.ts
+++ b/packages/ui/tests/vendor-types.d.ts
@@ -1,0 +1,12 @@
+declare module 'canvas' {
+  export class Canvas {}
+
+  const canvas: unknown;
+  export default canvas;
+}
+
+declare module 'jsdom' {
+  export interface DOMWindow {}
+
+  export class JSDOM {}
+}

--- a/packages/xrpl-connect/scripts/build-types.mjs
+++ b/packages/xrpl-connect/scripts/build-types.mjs
@@ -118,8 +118,24 @@ let rolled = readFileSync(rolledPath, 'utf-8');
 const chromeTypesReference = '/// <reference types="chrome" />\n';
 if (!rolled.startsWith(chromeTypesReference)) {
   rolled = chromeTypesReference + rolled;
-  writeFileSync(rolledPath, rolled);
 }
+
+// API Extractor inlines the UI package's exported element interface but drops
+// its `declare global` block. Restore the custom-element tag mapping so the
+// packed facade keeps the same `document.createElement()` inference as the
+// standalone UI package.
+const walletConnectorTagDeclaration = `
+declare global {
+    interface HTMLElementTagNameMap {
+        'xrpl-wallet-connector': WalletConnectorElementInstance;
+    }
+}
+`;
+if (!rolled.includes("'xrpl-wallet-connector': WalletConnectorElementInstance")) {
+  rolled += walletConnectorTagDeclaration;
+}
+writeFileSync(rolledPath, rolled);
+
 const importedModules = new Set();
 for (const m of rolled.matchAll(/^\s*(?:import|export)\b[^;]*?\bfrom\s*['"]([^'"]+)['"]/gm)) {
   importedModules.add(m[1]);

--- a/packages/xrpl-connect/tests/publish/types-cjs.cts
+++ b/packages/xrpl-connect/tests/publish/types-cjs.cts
@@ -1,12 +1,15 @@
 import {
   CrossmarkSDK,
   GemWalletAPI,
+  WalletConnectorElement,
   XamanOAuth2,
   XamanSDK,
+  type AccountInfo,
   type ConnectOptions,
   type CrossmarkClient,
   type LedgerConnectOptions,
   type WalletConnectConnectOptions,
+  type WalletConnectorElementInstance,
   type XamanConnectOptions,
   type XyraConnectOptions,
 } from 'xrpl-connect';
@@ -50,6 +53,13 @@ const crossmarkClient: CrossmarkClient = CrossmarkSDK.default;
 const xamanEvent = {} as XamanSDK.UniversalSdkEvent;
 const oauthFlow = {} as XamanOAuth2.ResolvedFlow;
 const gemWalletRequest = {} as GemWalletAPI.SendPaymentRequest;
+const walletConnector: WalletConnectorElementInstance =
+  document.createElement('xrpl-wallet-connector');
+const pendingAccount: Promise<AccountInfo> = walletConnector.openAndWait();
+const walletConnectorConstructor: {
+  new (): WalletConnectorElementInstance;
+  readonly prototype: WalletConnectorElementInstance;
+} | null = WalletConnectorElement;
 
 void [
   connectOptions,
@@ -63,4 +73,7 @@ void [
   xamanEvent,
   oauthFlow,
   gemWalletRequest,
+  walletConnector,
+  pendingAccount,
+  walletConnectorConstructor,
 ];

--- a/packages/xrpl-connect/tests/publish/types-esm.mts
+++ b/packages/xrpl-connect/tests/publish/types-esm.mts
@@ -1,12 +1,15 @@
 import {
   CrossmarkSDK,
   GemWalletAPI,
+  WalletConnectorElement,
   XamanOAuth2,
   XamanSDK,
+  type AccountInfo,
   type ConnectOptions,
   type CrossmarkClient,
   type LedgerConnectOptions,
   type WalletConnectConnectOptions,
+  type WalletConnectorElementInstance,
   type XamanConnectOptions,
   type XyraConnectOptions,
 } from 'xrpl-connect';
@@ -50,6 +53,13 @@ const crossmarkClient: CrossmarkClient = CrossmarkSDK.default;
 const xamanEvent = {} as XamanSDK.UniversalSdkEvent;
 const oauthFlow = {} as XamanOAuth2.ResolvedFlow;
 const gemWalletRequest = {} as GemWalletAPI.SendPaymentRequest;
+const walletConnector: WalletConnectorElementInstance =
+  document.createElement('xrpl-wallet-connector');
+const pendingAccount: Promise<AccountInfo> = walletConnector.openAndWait();
+const walletConnectorConstructor: {
+  new (): WalletConnectorElementInstance;
+  readonly prototype: WalletConnectorElementInstance;
+} | null = WalletConnectorElement;
 
 void [
   connectOptions,
@@ -63,4 +73,7 @@ void [
   xamanEvent,
   oauthFlow,
   gemWalletRequest,
+  walletConnector,
+  pendingAccount,
+  walletConnectorConstructor,
 ];


### PR DESCRIPTION
Part 4/5 of closing the Stellar-Wallets-Kit feature gap. Additive & backward compatible. Both changes are in the `<xrpl-wallet-connector>` web component.

## Gap #5 — modal doesn't return a Promise
SWK's `authModal()` returns `Promise<{ address }>`. xrpl-connect only had imperative `open()`/`close()` + `connected`/`close` events.

**`openAndWait(): Promise<AccountInfo>`** — opens the modal, resolves when a wallet connects, rejects if the user closes it first.

Subtlety handled: a successful connection dispatches the DOM `close` event **before** `connected` (the manager's `connect` fires synchronously inside `manager.connect()`, which closes the modal). So resolution is wired to the manager's `connect` event and the `close` rejection is guarded by `manager.connected` — the close that follows a successful connect is ignored.

## Gap #3 — no most-recently-used ordering
SWK persists `usedWalletsIds` and surfaces the last-used wallet first. We only had a static `primary-wallet`.

The connector now records used wallet ids in `localStorage` (on the manager `connect` event) and orders the list MRU-first via a pure, unit-tested `orderWalletsByMru()` helper — **stable**: wallets with no history keep their availability order. An explicit `primary-wallet` attribute still takes precedence.

## Changes
- `packages/ui/src/wallet-connector.ts` — `openAndWait()`, MRU record/load, apply ordering in `checkWalletAvailability`.
- `packages/ui/src/utils.ts` — pure `orderWalletsByMru()`.
- `packages/ui/tests/mru.test.ts` — 4 tests (pure ordering).
- `packages/ui/tests/openAndWait.test.ts` — 2 jsdom tests (resolve on connect / reject on close), with teardown so the runner exits cleanly.

## Verification
- `pnpm build` (full workspace, 13/13) ✅
- `pnpm test` — ui 10 passed (+6), exit 0 ✅
- `pnpm lint` ✅ · `prettier --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)