### PR TITLE
fix(adapter-xaman): harden resolved payload validation

### DIFF
--- a/packages/adapters/xaman/src/xaman-adapter.ts
+++ b/packages/adapters/xaman/src/xaman-adapter.ts
@@ -28,7 +28,7 @@ const ICON_DATA_URL = `data:image/svg+xml,${encodeURIComponent(iconSvg)}`;
 const SIGNING_TIMEOUT_MS = 5 * 60 * 1000;
 const RESOLVED_PAYLOAD_RETRY_MAX_MS = 5_000;
 const RESOLVED_PAYLOAD_RETRY_TIMEOUT_MS = 30_000;
-const SIGNING_OUTPUT_FIELDS = new Set(['TxnSignature', 'Signers']);
+const SIGNING_OUTPUT_FIELDS = new Set(['TxnSignature']);
 
 const XAMAN_NETWORKS_BY_ID = new Map<number, XamanNetwork>([
   [0, { forceNetwork: 'MAINNET', networkId: 0, id: 'mainnet', name: 'Mainnet' }],
@@ -901,6 +901,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink {
 
   private containsRequestedValue(expected: unknown, actual: unknown, field?: string): boolean {
     if (field && SIGNING_OUTPUT_FIELDS.has(field)) return true;
+    if (field === 'Signers') return this.containsRequestedSigners(expected, actual);
     if (Array.isArray(expected)) {
       return (
         Array.isArray(actual) &&
@@ -916,6 +917,20 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink {
       );
     }
     return Object.is(expected, actual);
+  }
+
+  private containsRequestedSigners(expected: unknown, actual: unknown): boolean {
+    if (!Array.isArray(expected) || !Array.isArray(actual)) return false;
+    const matchedIndexes = new Set<number>();
+    return expected.every((expectedSigner) => {
+      const matchingIndex = actual.findIndex(
+        (actualSigner, index) =>
+          !matchedIndexes.has(index) && this.containsRequestedValue(expectedSigner, actualSigner)
+      );
+      if (matchingIndex === -1) return false;
+      matchedIndexes.add(matchingIndex);
+      return true;
+    });
   }
 
   private createPayloadOperation(client: Xumm, submit: boolean): ActivePayloadOperation {

--- a/packages/adapters/xaman/src/xaman-adapter.ts
+++ b/packages/adapters/xaman/src/xaman-adapter.ts
@@ -27,6 +27,8 @@ import iconSvg from './assets/icon.svg';
 const ICON_DATA_URL = `data:image/svg+xml,${encodeURIComponent(iconSvg)}`;
 const SIGNING_TIMEOUT_MS = 5 * 60 * 1000;
 const RESOLVED_PAYLOAD_RETRY_MAX_MS = 5_000;
+const RESOLVED_PAYLOAD_RETRY_TIMEOUT_MS = 30_000;
+const SIGNING_OUTPUT_FIELDS = new Set(['TxnSignature', 'Signers']);
 
 const XAMAN_NETWORKS_BY_ID = new Map<number, XamanNetwork>([
   [0, { forceNetwork: 'MAINNET', networkId: 0, id: 'mainnet', name: 'Mainnet' }],
@@ -565,6 +567,8 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink {
         throw new Error('Xaman payload signer did not match the connected account');
       }
 
+      this.validateRequestedTransaction(transaction, resolved.payload?.request_json);
+
       const { response } = resolved;
       if (typeof response.hex !== 'string' || response.hex.length === 0) {
         throw new Error('Xaman did not return a signed transaction blob');
@@ -609,6 +613,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink {
           response.multisign_account,
           xamanNetwork
         );
+        this.validateRequestedTransaction(transaction, tx_json);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         throw new Error(`Xaman returned an invalid signed transaction blob: ${message}`);
@@ -885,6 +890,34 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink {
     }
   }
 
+  private validateRequestedTransaction(
+    requested: Transaction,
+    actual: Record<string, unknown> | undefined
+  ): void {
+    if (!actual || !this.containsRequestedValue(requested, actual)) {
+      throw new Error('Xaman returned a transaction that did not match the signing request');
+    }
+  }
+
+  private containsRequestedValue(expected: unknown, actual: unknown, field?: string): boolean {
+    if (field && SIGNING_OUTPUT_FIELDS.has(field)) return true;
+    if (Array.isArray(expected)) {
+      return (
+        Array.isArray(actual) &&
+        expected.length === actual.length &&
+        expected.every((value, index) => this.containsRequestedValue(value, actual[index]))
+      );
+    }
+    if (expected !== null && typeof expected === 'object') {
+      if (actual === null || typeof actual !== 'object' || Array.isArray(actual)) return false;
+      const actualRecord = actual as Record<string, unknown>;
+      return Object.entries(expected).every(([key, value]) =>
+        this.containsRequestedValue(value, actualRecord[key], key)
+      );
+    }
+    return Object.is(expected, actual);
+  }
+
   private createPayloadOperation(client: Xumm, submit: boolean): ActivePayloadOperation {
     const ready = deferred<void>();
     const stopDecision = deferred<void>();
@@ -918,6 +951,12 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink {
     operation.stopRequested = true;
     await Promise.race([operation.ready, operation.done]);
     if (operation.phase === 'done') return;
+
+    if (operation.phase === 'fetching') {
+      operation.controller.abort();
+      await operation.done;
+      return;
+    }
 
     if (operation.phase !== 'waiting' || !operation.uuid) {
       operation.resolveStopDecision();
@@ -997,19 +1036,49 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink {
     signal: AbortSignal
   ) {
     let retryDelay = 250;
+    const retryDeadline = Date.now() + RESOLVED_PAYLOAD_RETRY_TIMEOUT_MS;
     while (true) {
       try {
         const request = client.payload?.get(uuid, true);
         if (!request) throw new Error('Failed to retrieve the resolved Xaman payload');
-        const resolved = await this.waitForOperation(request, signal);
+        const resolved = await this.waitForOperationUntil(
+          request,
+          signal,
+          retryDeadline,
+          'Timed out retrieving the resolved Xaman payload'
+        );
         if (!resolved) throw new Error('Failed to retrieve the resolved Xaman payload');
         return resolved;
       } catch (error) {
-        if (!retryUntilKnown || signal.aborted) throw error;
+        if (!retryUntilKnown || signal.aborted || Date.now() >= retryDeadline) throw error;
         logger.debug('Unable to retrieve submitted Xaman payload; retrying', error);
-        await new Promise((resolve) => setTimeout(resolve, retryDelay));
+        const delay = Math.min(retryDelay, retryDeadline - Date.now());
+        await this.waitForOperation(
+          new Promise<void>((resolve) => setTimeout(resolve, delay)),
+          signal
+        );
         retryDelay = Math.min(retryDelay * 2, RESOLVED_PAYLOAD_RETRY_MAX_MS);
       }
+    }
+  }
+
+  private async waitForOperationUntil<T>(
+    promise: Promise<T>,
+    signal: AbortSignal,
+    deadline: number,
+    timeoutMessage: string
+  ): Promise<T> {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<never>((_resolve, reject) => {
+      timeout = setTimeout(
+        () => reject(new Error(timeoutMessage)),
+        Math.max(0, deadline - Date.now())
+      );
+    });
+    try {
+      return await this.waitForOperation(Promise.race([promise, timeoutPromise]), signal);
+    } finally {
+      if (timeout) clearTimeout(timeout);
     }
   }
 

--- a/packages/adapters/xaman/tests/xaman-adapter.test.ts
+++ b/packages/adapters/xaman/tests/xaman-adapter.test.ts
@@ -60,6 +60,10 @@ const MULTISIGN_INPUT = {
 const MULTISIGNED_TRANSACTION = SIGNING_WALLET.sign(MULTISIGN_INPUT, true);
 const MULTISIGNED_TX_JSON = decode(MULTISIGNED_TRANSACTION.tx_blob) as Transaction;
 const MULTISIGNED_TX_HASH = hashes.hashSignedTx(MULTISIGNED_TRANSACTION.tx_blob);
+const EXISTING_MULTISIGNER = Wallet.generate();
+const PARTIALLY_SIGNED_INPUT = decode(
+  EXISTING_MULTISIGNER.sign(MULTISIGN_INPUT, true).tx_blob
+) as Transaction;
 
 function signedFixture(networkId = 0) {
   const input = {
@@ -772,6 +776,31 @@ describe('XamanAdapter.sign', () => {
     );
 
     const signPromise = adapter.sign(MULTISIGN_INPUT);
+    const rejection = expect(signPromise).rejects.toMatchObject({
+      code: WalletErrorCode.SIGN_FAILED,
+    });
+    await subscription.emit({ signed: true });
+
+    await rejection;
+  });
+
+  it('rejects a multi-signed result that drops an existing signature', async () => {
+    const { adapter, subscription } = await signedAdapter();
+    mockXummInstance.payload.get.mockResolvedValue(
+      resolvedPayload(
+        false,
+        {
+          hex: MULTISIGNED_TRANSACTION.tx_blob,
+          txid: MULTISIGNED_TX_HASH,
+          account: MULTISIGN_SOURCE.address,
+          multisign_account: CONNECTED_ACCOUNT,
+        },
+        { multisign: true },
+        PARTIALLY_SIGNED_INPUT
+      )
+    );
+
+    const signPromise = adapter.sign(PARTIALLY_SIGNED_INPUT);
     const rejection = expect(signPromise).rejects.toMatchObject({
       code: WalletErrorCode.SIGN_FAILED,
     });

--- a/packages/adapters/xaman/tests/xaman-adapter.test.ts
+++ b/packages/adapters/xaman/tests/xaman-adapter.test.ts
@@ -38,6 +38,15 @@ const SIGNED_TRANSACTION = SIGNING_WALLET.sign({
 const SIGNED_TX_HEX = SIGNED_TRANSACTION.tx_blob;
 const SIGNED_TX_JSON = decode(SIGNED_TX_HEX) as Transaction;
 const SIGNED_TX_HASH = hashes.hashSignedTx(SIGNED_TX_HEX);
+const REQUESTED_TRANSACTION = {
+  TransactionType: 'Payment',
+  Account: CONNECTED_ACCOUNT,
+  Destination: 'rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe',
+  Amount: '1000000',
+  Fee: '10',
+  Sequence: 1,
+  Flags: 0,
+} as Transaction;
 const MULTISIGN_SOURCE = Wallet.generate();
 const MULTISIGN_INPUT = {
   TransactionType: 'Payment',
@@ -117,7 +126,8 @@ function createSubscriptionHarness() {
 function resolvedPayload(
   submit: boolean,
   responseOverrides: Record<string, unknown> = {},
-  metaOverrides: Record<string, unknown> = {}
+  metaOverrides: Record<string, unknown> = {},
+  requestJson: Transaction = REQUESTED_TRANSACTION
 ) {
   return {
     meta: {
@@ -127,6 +137,9 @@ function resolvedPayload(
       multisign: false,
       signers: [CONNECTED_ACCOUNT],
       ...metaOverrides,
+    },
+    payload: {
+      request_json: requestJson,
     },
     response: {
       hex: SIGNED_TX_HEX,
@@ -543,12 +556,17 @@ describe('XamanAdapter.sign', () => {
     const fixture = signedFixture(numericId);
     const { adapter, subscription } = await signedAdapter(network);
     mockXummInstance.payload.get.mockResolvedValue(
-      resolvedPayload(false, {
-        hex: fixture.blob,
-        txid: fixture.hash,
-        environment_networkid: numericId,
-        environment_nodetype: forceNetwork,
-      })
+      resolvedPayload(
+        false,
+        {
+          hex: fixture.blob,
+          txid: fixture.hash,
+          environment_networkid: numericId,
+          environment_nodetype: forceNetwork,
+        },
+        {},
+        fixture.input
+      )
     );
 
     const signPromise = adapter.sign(fixture.input);
@@ -627,6 +645,39 @@ describe('XamanAdapter.sign', () => {
     expect(subscription.close).toHaveBeenCalledTimes(1);
   });
 
+  it('rejects a signed transaction whose requested fields were changed', async () => {
+    const requested = {
+      ...REQUESTED_TRANSACTION,
+      Destination: Wallet.generate().address,
+      Amount: '5000000',
+    } as Transaction;
+    const { adapter, subscription } = await signedAdapter();
+    mockXummInstance.payload.get.mockResolvedValue(resolvedPayload(false, {}, {}, requested));
+
+    const signPromise = adapter.sign(requested);
+    const rejection = expect(signPromise).rejects.toMatchObject({
+      code: WalletErrorCode.SIGN_FAILED,
+    });
+    await subscription.emit({ signed: true });
+
+    await rejection;
+  });
+
+  it('rejects a resolved payload whose request differs from the original transaction', async () => {
+    const { adapter, subscription } = await signedAdapter();
+    mockXummInstance.payload.get.mockResolvedValue(
+      resolvedPayload(false, {}, {}, { ...REQUESTED_TRANSACTION, Amount: '5000000' } as Transaction)
+    );
+
+    const signPromise = adapter.sign(REQUESTED_TRANSACTION);
+    const rejection = expect(signPromise).rejects.toMatchObject({
+      code: WalletErrorCode.SIGN_FAILED,
+    });
+    await subscription.emit({ signed: true });
+
+    await rejection;
+  });
+
   it('rejects a resolved payload signed for a different account', async () => {
     const { adapter, subscription } = await signedAdapter();
     mockXummInstance.payload.get.mockResolvedValue(
@@ -675,7 +726,8 @@ describe('XamanAdapter.sign', () => {
           account: MULTISIGN_SOURCE.address,
           multisign_account: CONNECTED_ACCOUNT,
         },
-        { multisign: true }
+        { multisign: true },
+        MULTISIGN_INPUT
       )
     );
 
@@ -714,7 +766,8 @@ describe('XamanAdapter.sign', () => {
           account: MULTISIGN_SOURCE.address,
           multisign_account: CONNECTED_ACCOUNT,
         },
-        { multisign: true }
+        { multisign: true },
+        MULTISIGN_INPUT
       )
     );
 
@@ -817,6 +870,46 @@ describe('XamanAdapter.signAndSubmit', () => {
     expect(mockXummInstance.payload.get).toHaveBeenCalledTimes(2);
   });
 
+  it('stops retrying authoritative result retrieval after the retry deadline', async () => {
+    vi.useFakeTimers();
+    try {
+      const { adapter, subscription } = await signedAdapter();
+      mockXummInstance.payload.get.mockRejectedValue(new Error('persistent network failure'));
+
+      const submitPromise = adapter.signAndSubmit(REQUESTED_TRANSACTION);
+      const rejection = expect(submitPromise).rejects.toMatchObject({
+        code: WalletErrorCode.SIGN_FAILED,
+      });
+      await subscription.emit({ signed: true });
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      await rejection;
+      expect(mockXummInstance.payload.get.mock.calls.length).toBeGreaterThan(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('times out an authoritative result request that never responds', async () => {
+    vi.useFakeTimers();
+    try {
+      const { adapter, subscription } = await signedAdapter();
+      mockXummInstance.payload.get.mockImplementation(() => new Promise(() => {}));
+
+      const submitPromise = adapter.signAndSubmit(REQUESTED_TRANSACTION);
+      const rejection = expect(submitPromise).rejects.toMatchObject({
+        code: WalletErrorCode.SIGN_FAILED,
+      });
+      await subscription.emit({ signed: true });
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      await rejection;
+      expect(mockXummInstance.payload.get).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('rejects a submission dispatched to a different network', async () => {
     const { adapter, subscription } = await signedAdapter();
     mockXummInstance.payload.get.mockResolvedValue(
@@ -877,6 +970,22 @@ describe('XamanAdapter.signAndSubmit', () => {
 });
 
 describe('XamanAdapter.disconnect', () => {
+  it('aborts authoritative result retrieval before logging out', async () => {
+    const { adapter, subscription } = await signedAdapter();
+    mockXummInstance.payload.get.mockImplementation(() => new Promise(() => {}));
+    mockXummInstance.logout.mockResolvedValue(undefined);
+
+    const submitPromise = adapter.signAndSubmit(REQUESTED_TRANSACTION);
+    await subscription.emit({ signed: true });
+    await vi.waitFor(() => expect(mockXummInstance.payload.get).toHaveBeenCalledTimes(1));
+
+    const disconnectPromise = adapter.disconnect();
+
+    await expect(submitPromise).rejects.toMatchObject({ code: WalletErrorCode.SIGN_FAILED });
+    await disconnectPromise;
+    expect(mockXummInstance.logout).toHaveBeenCalledTimes(1);
+  });
+
   it('authoritatively cancels a payload that finishes creating after disconnect', async () => {
     const { adapter } = await signedAdapter();
     let resolveCreation: ((payload: Record<string, unknown>) => void) | undefined;


### PR DESCRIPTION
Follow-up to #106 based on post-merge review.\n\n## Changes\n\n- bind the resolved Xaman request and signed blob to every caller-supplied transaction field;\n- preserve every pre-existing multisignature while allowing Xaman to append its signer;\n- bound authoritative payload retrieval to 30 seconds, including requests that never settle;\n- make disconnect abort an in-progress authoritative result fetch instead of hanging indefinitely;\n- add regression coverage for altered transactions, persistent and hanging retrieval failures, disconnect during retrieval, and dropped cosignatures.\n\n## Validation\n\n- Xaman type-check and tests: 71/71 passed;\n- Xaman lint and formatting passed;\n- core and Xaman builds passed;\n- full workspace pipeline passed: 22/22 tasks.\n\nFollow-up to #106.