### PR TITLE
Fix wallet connection lifecycle and add MetaMask examples

### DIFF
--- a/docs/.vitepress/composables/useWallet.ts
+++ b/docs/.vitepress/composables/useWallet.ts
@@ -34,6 +34,7 @@ export const useWallet = () => {
           LedgerAdapter,
           XyraAdapter,
           OtsuAdapter,
+          MetaMaskSnapAdapter,
         } = (await import('xrpl-connect')) as any;
 
         if (!WalletManager) {
@@ -73,6 +74,13 @@ export const useWallet = () => {
           adapters.push(otsu);
         } catch (err) {
           console.warn('Failed to create OtsuAdapter:', err);
+        }
+
+        try {
+          const metaMaskSnap = new MetaMaskSnapAdapter();
+          adapters.push(metaMaskSnap);
+        } catch (err) {
+          console.warn('Failed to create MetaMaskSnapAdapter:', err);
         }
 
         try {

--- a/docs/.vitepress/composables/useWallet.ts
+++ b/docs/.vitepress/composables/useWallet.ts
@@ -35,10 +35,13 @@ export const useWallet = () => {
           XyraAdapter,
           OtsuAdapter,
           MetaMaskSnapAdapter,
-        } = (await import('xrpl-connect')) as any;
+        } = await import('xrpl-connect');
 
         if (!WalletManager) {
           throw new Error('Failed to import WalletManager from xrpl-connect');
+        }
+        if (!MetaMaskSnapAdapter) {
+          throw new Error('Failed to import MetaMaskSnapAdapter from xrpl-connect');
         }
 
         const adapters: any[] = [];

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "xrpl": "^4.4.2",
-    "xrpl-connect": "^0.6.0"
+    "xrpl-connect": "workspace:*"
   },
   "devDependencies": {
     "vitepress": "^1.6.4",

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "xrpl": "^4.4.2",
-    "xrpl-connect": "^0.8.0"
+    "xrpl-connect": "workspace:*"
   },
   "devDependencies": {
     "vitepress": "^1.6.4",

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "xrpl": "^4.4.2",
-    "xrpl-connect": "workspace:*"
+    "xrpl-connect": "^0.8.0"
   },
   "devDependencies": {
     "vitepress": "^1.6.4",

--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -4,7 +4,7 @@ This is a demo application showcasing the XRPL Connect wallet toolkit with a Rea
 
 ## Features
 
-- Connect to multiple XRPL wallets (Xaman, WalletConnect, Crossmark, GemWallet)
+- Connect to multiple XRPL wallets, including Xaman, WalletConnect, Crossmark, GemWallet, and MetaMask Snap
 - React integration with XRPL Connect web component
 - Sign XRPL transactions
 - Sign arbitrary messages

--- a/examples/react/src/main.tsx
+++ b/examples/react/src/main.tsx
@@ -8,6 +8,7 @@ import {
   GemWalletAdapter,
   XyraAdapter,
   OtsuAdapter,
+  MetaMaskSnapAdapter,
 } from 'xrpl-connect';
 import { XrplConnectProvider, type XrplConnectConfig } from '@xrpl-connect/react';
 import App from './App';
@@ -27,6 +28,7 @@ const config: XrplConnectConfig = {
     new GemWalletAdapter(),
     new XyraAdapter(),
     new OtsuAdapter(),
+    new MetaMaskSnapAdapter(),
   ],
   network: 'testnet',
   autoConnect: true,

--- a/examples/vanilla-js/README.md
+++ b/examples/vanilla-js/README.md
@@ -136,6 +136,7 @@ Ensure your WalletConnect Project ID is valid and your internet connection is st
 - **XRPL Connect Core** - Wallet management
 - **Xaman Adapter** - Xaman Wallet integration
 - **WalletConnect Adapter** - WalletConnect protocol
+- **MetaMask Snap Adapter** - XRPL accounts and transactions through MetaMask Snaps
 - **xrpl.js** - XRPL JavaScript library
 
 ## Learn More

--- a/examples/vanilla-js/package.json
+++ b/examples/vanilla-js/package.json
@@ -12,6 +12,7 @@
     "@xrpl-connect/adapter-crossmark": "workspace:*",
     "@xrpl-connect/adapter-gemwallet": "workspace:*",
     "@xrpl-connect/adapter-ledger": "workspace:*",
+    "@xrpl-connect/adapter-metamask-snap": "workspace:*",
     "@xrpl-connect/adapter-walletconnect": "workspace:*",
     "@xrpl-connect/adapter-xaman": "workspace:*",
     "@xrpl-connect/adapter-xyra": "workspace:*",

--- a/examples/vanilla-js/src/main.js
+++ b/examples/vanilla-js/src/main.js
@@ -7,6 +7,8 @@ import { GemWalletAdapter } from '@xrpl-connect/adapter-gemwallet';
 import { LedgerAdapter } from '@xrpl-connect/adapter-ledger';
 import { XyraAdapter } from '@xrpl-connect/adapter-xyra';
 import { OtsuAdapter } from '@xrpl-connect/adapter-otsu';
+import { MetaMaskSnapAdapter } from '@xrpl-connect/adapter-metamask-snap';
+
 import { WalletConnectorElement } from '@xrpl-connect/ui';
 import '@xrpl-connect/ui'; // Register the web component
 
@@ -37,6 +39,7 @@ const walletManager = new WalletManager({
     new LedgerAdapter(),
     new XyraAdapter(),
     new OtsuAdapter(),
+    new MetaMaskSnapAdapter(),
   ],
   network: 'testnet',
   autoConnect: true,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "format:check": "vp fmt --check",
     "clean": "vp run -r clean && vp cache clean",
     "docs:dev": "vp exec vitepress dev docs",
-    "docs:build": "vp exec vitepress build docs",
+    "docs:build": "vp run -F '{./docs}^...' build && vp exec vitepress build docs",
     "docs:preview": "vp exec vitepress preview docs"
   },
   "devDependencies": {

--- a/packages/adapters/walletconnect/src/walletconnect-adapter.ts
+++ b/packages/adapters/walletconnect/src/walletconnect-adapter.ts
@@ -90,6 +90,7 @@ export class WalletConnectAdapter
   private currentAccount: AccountInfo | null = null;
   private options: WalletConnectAdapterOptions;
   private initializationPromise: Promise<SignClient> | null = null;
+  private connectionAttemptGeneration = 0;
   private pendingConnection: { uri: string; approval: () => Promise<SessionTypes.Struct> } | null =
     null;
   private modal: WalletConnectModal | null = null;
@@ -239,6 +240,7 @@ export class WalletConnectAdapter
    * Connect to WalletConnect
    */
   async connect(options?: ConnectOptions<WalletConnectConnectOptions>): Promise<AccountInfo> {
+    const connectionAttempt = ++this.connectionAttemptGeneration;
     const projectId = options?.projectId || this.options.projectId;
 
     if (!projectId) {
@@ -375,6 +377,17 @@ export class WalletConnectAdapter
         session = await approval();
       }
 
+      // Approval cannot be aborted by SignClient. If the UI cancelled this
+      // attempt while approval was pending, immediately close the late session
+      // instead of exposing it as an orphaned WalletConnect connection.
+      if (connectionAttempt !== this.connectionAttemptGeneration) {
+        await this.client.disconnect({
+          topic: session.topic,
+          reason: DISCONNECT_REASONS.USER_DISCONNECTED,
+        });
+        throw new Error('WalletConnect connection was cancelled');
+      }
+
       // Store session
       this.session = session;
 
@@ -412,6 +425,13 @@ export class WalletConnectAdapter
    * Disconnect from WalletConnect
    */
   async disconnect(): Promise<void> {
+    this.connectionAttemptGeneration += 1;
+    this.pendingConnection = null;
+
+    if (this.modal) {
+      this.modal.closeModal();
+    }
+
     if (!this.client || !this.session) {
       return;
     }

--- a/packages/adapters/walletconnect/tests/walletconnect-adapter.test.ts
+++ b/packages/adapters/walletconnect/tests/walletconnect-adapter.test.ts
@@ -188,6 +188,40 @@ describe('WalletConnectAdapter.signAndSubmit', () => {
 });
 
 describe('WalletConnectAdapter.disconnect', () => {
+  it('disconnects a session that is approved after the pending connection was cancelled', async () => {
+    let approve!: (session: {
+      topic: string;
+      namespaces: { xrpl: { accounts: string[] } };
+    }) => void;
+    const approval = new Promise<{
+      topic: string;
+      namespaces: { xrpl: { accounts: string[] } };
+    }>((resolve) => {
+      approve = resolve;
+    });
+    mockClient.connect.mockResolvedValue({
+      uri: 'wc:example',
+      approval: vi.fn(() => approval),
+    });
+    mockClient.disconnect.mockResolvedValue(undefined);
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    const connection = adapter.connect();
+    await vi.waitFor(() => expect(mockClient.connect).toHaveBeenCalledOnce());
+
+    await adapter.disconnect();
+    approve({
+      topic: 'late-topic',
+      namespaces: { xrpl: { accounts: ['xrpl:0:rLateAddress'] } },
+    });
+
+    await expect(connection).rejects.toMatchObject({ code: WalletErrorCode.CONNECTION_FAILED });
+    expect(mockClient.disconnect).toHaveBeenCalledWith(
+      expect.objectContaining({ topic: 'late-topic' })
+    );
+    expect(await adapter.getAccount()).toBeNull();
+  });
+
   it('clears the session and account after a successful disconnect', async () => {
     mockClient.connect.mockResolvedValue({
       uri: 'wc:example',

--- a/packages/adapters/xaman/src/xaman-adapter.ts
+++ b/packages/adapters/xaman/src/xaman-adapter.ts
@@ -149,8 +149,10 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
   private options: XamanAdapterOptions;
   private activePayloadOperations = new Set<ActivePayloadOperation>();
   private connectionGeneration = 0;
+  private supersededRestorationGeneration: number | null = null;
   private accountRefreshRevision = 0;
   private connecting = false;
+  private restoringState = false;
   private disconnecting = false;
   private connectionAttemptDone: Promise<void> | null = null;
   private disconnectPromise: Promise<void> | null = null;
@@ -197,6 +199,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
 
     const generation = ++this.connectionGeneration;
     this.connecting = true;
+    this.restoringState = true;
     const attemptDone = deferred<void>();
     this.connectionAttemptDone = attemptDone.promise;
     let client: Xumm | null = null;
@@ -207,6 +210,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
       this.clientApiKey = apiKey;
       const address = await client.user.account;
       if (generation !== this.connectionGeneration || this.client !== client) {
+        if (this.supersededRestorationGeneration === generation) return null;
         throw new Error('Xaman state restoration was superseded or disconnected');
       }
       if (!address) {
@@ -233,6 +237,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
       }
 
       if (generation !== this.connectionGeneration || this.client !== client) {
+        if (this.supersededRestorationGeneration === generation) return null;
         throw new Error('Xaman state restoration was superseded or disconnected');
       }
 
@@ -244,7 +249,8 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
 
       return this.currentAccount;
     } catch (error) {
-      if (client) {
+      if (this.supersededRestorationGeneration === generation) return null;
+      if (client && generation === this.connectionGeneration && this.client === client) {
         try {
           await client.logout();
         } catch (logoutError) {
@@ -255,8 +261,14 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
       if (isWalletError(error)) throw error;
       throw createWalletError.connectionFailed(this.name, error as Error);
     } finally {
-      this.connecting = false;
-      if (this.connectionAttemptDone === attemptDone.promise) this.connectionAttemptDone = null;
+      if (this.supersededRestorationGeneration === generation) {
+        this.supersededRestorationGeneration = null;
+      }
+      if (this.connectionAttemptDone === attemptDone.promise) {
+        this.connecting = false;
+        this.restoringState = false;
+        this.connectionAttemptDone = null;
+      }
       attemptDone.resolve(undefined);
     }
   }
@@ -267,6 +279,20 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
   async connect(options?: ConnectOptions<XamanConnectOptions>): Promise<AccountInfo> {
     const apiKey = options?.apiKey || this.options.apiKey;
 
+    logger.info('Connection phase: requested', {
+      hasApiKey: Boolean(apiKey),
+      restoringState: this.restoringState,
+      connecting: this.connecting,
+      disconnecting: this.disconnecting,
+      activePayloadOperations: this.activePayloadOperations.size,
+      hasClient: Boolean(this.client),
+      hasAccount: Boolean(this.currentAccount),
+      browserUserActivation:
+        typeof navigator !== 'undefined' && 'userActivation' in navigator
+          ? navigator.userActivation.isActive
+          : undefined,
+    });
+
     if (!apiKey) {
       throw createWalletError.connectionFailed(
         this.name,
@@ -274,6 +300,18 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
           'API key is required for Xaman. Please provide it in connect options or adapter constructor.'
         )
       );
+    }
+
+    if (this.restoringState && this.connectionAttemptDone) {
+      const restorationGeneration = this.connectionGeneration;
+      logger.info('Connection phase: superseding silent session restoration');
+      this.supersededRestorationGeneration = restorationGeneration;
+      this.connectionGeneration += 1;
+      this.client = null;
+      this.clientApiKey = null;
+      this.connecting = false;
+      this.restoringState = false;
+      this.connectionAttemptDone = null;
     }
 
     if (this.connecting || this.disconnecting || this.activePayloadOperations.size > 0) {
@@ -321,10 +359,20 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
       client = new Xumm(apiKey);
       this.client = client;
       this.clientApiKey = apiKey;
-      logger.debug('Starting authorization flow');
+      logger.info('Connection phase: Xaman SDK initialized', {
+        browserUserActivation:
+          typeof navigator !== 'undefined' && 'userActivation' in navigator
+            ? navigator.userActivation.isActive
+            : undefined,
+        documentHasFocus:
+          typeof document !== 'undefined' && typeof document.hasFocus === 'function'
+            ? document.hasFocus()
+            : undefined,
+      });
+      logger.info('Connection phase: calling SDK authorize (popup should open now)');
 
       const authResult = await client.authorize();
-      logger.debug('Authorization result:', {
+      logger.info('Connection phase: SDK authorize settled', {
         hasResult: !!authResult,
         isError: authResult instanceof Error,
         hasMe: authResult && !(authResult instanceof Error) ? !!authResult.me : false,
@@ -337,7 +385,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
         throw new Error('Xaman connection attempt was superseded or disconnected');
       }
 
-      logger.debug('Authorization successful', { account: authResult.me?.account });
+      logger.info('Connection phase: authorization successful');
 
       const account = authResult.me.account;
 
@@ -349,7 +397,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
 
       return this.currentAccount;
     } catch (error) {
-      logger.error('Authorization failed:', error);
+      logger.error('Connection phase: authorization failed', error);
       if (client) {
         try {
           await client.logout();
@@ -363,6 +411,9 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
       if (isWalletError(error)) throw error;
       throw createWalletError.connectionFailed(this.name, error as Error);
     } finally {
+      logger.info('Connection phase: authorization attempt finished', {
+        connected: Boolean(this.currentAccount),
+      });
       this.connecting = false;
       if (this.connectionAttemptDone === attemptDone.promise) this.connectionAttemptDone = null;
       attemptDone.resolve(undefined);

--- a/packages/adapters/xaman/src/xaman-adapter.ts
+++ b/packages/adapters/xaman/src/xaman-adapter.ts
@@ -145,6 +145,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
 
   private client: Xumm | null = null;
   private clientApiKey: string | null = null;
+  private sdkApiKey: string | null = null;
   private currentAccount: AccountInfo | null = null;
   private options: XamanAdapterOptions;
   private activePayloadOperations = new Set<ActivePayloadOperation>();
@@ -188,6 +189,15 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
       );
     }
 
+    if (this.sdkApiKey && this.sdkApiKey !== apiKey) {
+      throw createWalletError.connectionFailed(
+        this.name,
+        new Error(
+          'Cannot change the Xaman API key after the browser SDK has initialized. Reload the page before using a different API key.'
+        )
+      );
+    }
+
     if (this.connecting || this.disconnecting || this.activePayloadOperations.size > 0) {
       throw createWalletError.connectionFailed(
         this.name,
@@ -205,6 +215,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
     let client: Xumm | null = null;
 
     try {
+      this.sdkApiKey = apiKey;
       client = new Xumm(apiKey);
       this.client = client;
       this.clientApiKey = apiKey;
@@ -302,6 +313,15 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
       );
     }
 
+    if (this.sdkApiKey && this.sdkApiKey !== apiKey) {
+      throw createWalletError.connectionFailed(
+        this.name,
+        new Error(
+          'Cannot change the Xaman API key after the browser SDK has initialized. Reload the page before using a different API key.'
+        )
+      );
+    }
+
     if (this.restoringState && this.connectionAttemptDone) {
       const restorationGeneration = this.connectionGeneration;
       logger.info('Connection phase: superseding silent session restoration');
@@ -356,6 +376,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
 
     let client: Xumm | null = null;
     try {
+      this.sdkApiKey = apiKey;
       client = new Xumm(apiKey);
       this.client = client;
       this.clientApiKey = apiKey;

--- a/packages/adapters/xaman/tests/xaman-adapter.test.ts
+++ b/packages/adapters/xaman/tests/xaman-adapter.test.ts
@@ -283,6 +283,94 @@ describe('XamanAdapter.checkXamanState', () => {
 });
 
 describe('XamanAdapter.connect', () => {
+  it('supersedes an in-flight state check and starts authorization immediately', async () => {
+    let resolveRestoredAccount!: (account: undefined) => void;
+    mockXummInstance.user.account = new Promise<undefined>((resolve) => {
+      resolveRestoredAccount = resolve;
+    });
+    mockXummInstance.logout.mockResolvedValue(undefined);
+    mockXummInstance.authorize.mockResolvedValue({ me: { account: CONNECTED_ACCOUNT } });
+    const adapter = new XamanAdapter({ apiKey: 'test-key' });
+
+    const stateCheck = adapter.checkXamanState();
+    const connection = adapter.connect();
+    await Promise.resolve();
+    expect(mockXummInstance.authorize).toHaveBeenCalledTimes(1);
+
+    resolveRestoredAccount(undefined);
+
+    await expect(stateCheck).resolves.toBeNull();
+    await expect(connection).resolves.toMatchObject({ address: CONNECTED_ACCOUNT });
+    expect(mockXummInstance.authorize).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let a superseded restoration overwrite explicit authorization', async () => {
+    let resolveRestoredAccount!: (account: string) => void;
+    mockXummInstance.user.account = new Promise<string>((resolve) => {
+      resolveRestoredAccount = resolve;
+    });
+    mockXummInstance.user.networkEndpoint = Promise.resolve('wss://xrplcluster.com');
+    mockXummInstance.user.networkId = Promise.resolve(0);
+    mockXummInstance.authorize.mockResolvedValue({ me: { account: CONNECTED_ACCOUNT } });
+    const adapter = new XamanAdapter({ apiKey: 'test-key' });
+
+    const stateCheck = adapter.checkXamanState();
+    const connection = adapter.connect();
+    resolveRestoredAccount(CONNECTED_ACCOUNT);
+
+    await expect(stateCheck).resolves.toBeNull();
+    await expect(connection).resolves.toMatchObject({ address: CONNECTED_ACCOUNT });
+    expect(mockXummInstance.authorize).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps explicit authorization busy when the superseded restoration finishes first', async () => {
+    let resolveRestoredAccount!: (account: undefined) => void;
+    let resolveAuthorization!: (result: { me: { account: string } }) => void;
+    mockXummInstance.user.account = new Promise<undefined>((resolve) => {
+      resolveRestoredAccount = resolve;
+    });
+    mockXummInstance.authorize.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveAuthorization = resolve;
+        })
+    );
+    const adapter = new XamanAdapter({ apiKey: 'test-key' });
+
+    const stateCheck = adapter.checkXamanState();
+    const connection = adapter.connect();
+    resolveRestoredAccount(undefined);
+    await expect(stateCheck).resolves.toBeNull();
+
+    await expect(adapter.connect()).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+    });
+    expect(mockXummInstance.authorize).toHaveBeenCalledTimes(1);
+
+    resolveAuthorization({ me: { account: CONNECTED_ACCOUNT } });
+    await expect(connection).resolves.toMatchObject({ address: CONNECTED_ACCOUNT });
+  });
+
+  it('ignores late network data from a superseded restoration', async () => {
+    let resolveNetworkEndpoint!: (endpoint: string) => void;
+    mockXummInstance.user.account = Promise.resolve(CONNECTED_ACCOUNT);
+    mockXummInstance.user.networkEndpoint = new Promise<string>((resolve) => {
+      resolveNetworkEndpoint = resolve;
+    });
+    mockXummInstance.user.networkId = Promise.resolve(0);
+    mockXummInstance.authorize.mockResolvedValue({ me: { account: CONNECTED_ACCOUNT } });
+    const adapter = new XamanAdapter({ apiKey: 'test-key' });
+
+    const stateCheck = adapter.checkXamanState();
+    await Promise.resolve();
+    const connection = adapter.connect();
+    resolveNetworkEndpoint('wss://xrplcluster.com');
+
+    await expect(stateCheck).resolves.toBeNull();
+    await expect(connection).resolves.toMatchObject({ address: CONNECTED_ACCOUNT });
+    expect(mockXummInstance.logout).not.toHaveBeenCalled();
+  });
+
   it('returns account info on a successful authorize', async () => {
     mockXummInstance.authorize.mockResolvedValue({ me: { account: CONNECTED_ACCOUNT } });
     const adapter = new XamanAdapter({ apiKey: 'test-key' });

--- a/packages/adapters/xaman/tests/xaman-adapter.test.ts
+++ b/packages/adapters/xaman/tests/xaman-adapter.test.ts
@@ -304,6 +304,33 @@ describe('XamanAdapter.connect', () => {
     expect(mockXummInstance.authorize).toHaveBeenCalledTimes(1);
   });
 
+  it('rejects a different API key after the browser SDK initializes', async () => {
+    let resolveRestoredAccount!: (account: undefined) => void;
+    mockXummInstance.user.account = new Promise<undefined>((resolve) => {
+      resolveRestoredAccount = resolve;
+    });
+    mockXummInstance.logout.mockResolvedValue(undefined);
+    mockXummInstance.authorize.mockResolvedValue({ me: { account: CONNECTED_ACCOUNT } });
+    const adapter = new XamanAdapter({ apiKey: 'restoration-key' });
+
+    const stateCheck = adapter.checkXamanState();
+
+    await expect(adapter.connect({ apiKey: 'authorization-key' })).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+      message: expect.stringContaining('Reload the page'),
+    });
+    expect(mockXummInstance.authorize).not.toHaveBeenCalled();
+
+    resolveRestoredAccount(undefined);
+    await expect(stateCheck).resolves.toBeNull();
+
+    await expect(adapter.connect({ apiKey: 'authorization-key' })).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+      message: expect.stringContaining('Reload the page'),
+    });
+    expect(mockXummInstance.authorize).not.toHaveBeenCalled();
+  });
+
   it('does not let a superseded restoration overwrite explicit authorization', async () => {
     let resolveRestoredAccount!: (account: string) => void;
     mockXummInstance.user.account = new Promise<string>((resolve) => {

--- a/packages/ui/src/services/WalletService.ts
+++ b/packages/ui/src/services/WalletService.ts
@@ -78,6 +78,17 @@ export class WalletService {
 
       logger.debug('Connecting to wallet:', walletId);
 
+      if (walletId === 'xaman') {
+        logger.info('Xaman UI connection phase: selected', {
+          managerConnected: this.walletManager.connected,
+          activeWalletId: this.walletManager.wallet?.id ?? null,
+          browserUserActivation:
+            typeof navigator !== 'undefined' && 'userActivation' in navigator
+              ? navigator.userActivation.isActive
+              : undefined,
+        });
+      }
+
       if (walletId === 'walletconnect') {
         // Check if wallet adapter supports modal
         const useModal = isModalConfigurableAdapter(wallet)
@@ -168,12 +179,25 @@ export class WalletService {
         this.component.dispatchEvent(new CustomEvent('connecting', { detail: { walletId } }));
 
         // Browser-specific delay (Safari needs immediate connection for user gesture)
-        if (!isSafari()) {
+        if (!isSafari() && walletId !== 'xaman') {
           // Small delay for UI animation on non-Safari browsers
           await delay(TIMINGS.NON_SAFARI_CONNECT_DELAY);
         }
 
+        if (walletId === 'xaman') {
+          logger.info('Xaman UI connection phase: handing off to WalletManager', {
+            browserUserActivation:
+              typeof navigator !== 'undefined' && 'userActivation' in navigator
+                ? navigator.userActivation.isActive
+                : undefined,
+          });
+        }
+
         await this.walletManager.connect(walletId, options);
+
+        if (walletId === 'xaman') {
+          logger.info('Xaman UI connection phase: WalletManager connected');
+        }
         this.component.dispatchEvent(new CustomEvent('connected', { detail: { walletId } }));
       }
     } catch (error: unknown) {

--- a/packages/ui/src/wallet-connector.ts
+++ b/packages/ui/src/wallet-connector.ts
@@ -312,7 +312,7 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
       }
 
       // Check for existing Xaman session after a short delay
-      this.checkXamanStateOnInit();
+      void this.checkXamanStateOnInit();
     }
 
     private attachWalletManagerHandlers(): void {
@@ -616,6 +616,7 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
      * Close the modal
      */
     close() {
+      this.cancelPendingConnection();
       this.openGeneration += 1;
       this.isOpen = false;
       this.rejectConnectionWaiters(new Error('Modal closed before a wallet was connected.'));
@@ -802,12 +803,21 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
      * Show wallet list view
      */
     public showWalletList() {
+      this.cancelPendingConnection();
       this.viewState = 'list';
       this.qrCodeData = null;
       this.loadingData = null;
       this.errorData = null;
       this.accountSelectionData = null;
       this.render();
+    }
+
+    private cancelPendingConnection(): void {
+      if (!this.walletManager || this.walletManager.connected) return;
+
+      void this.walletManager.disconnect().catch((error) => {
+        logger.warn('Failed to cancel pending wallet connection:', error);
+      });
     }
 
     /**

--- a/packages/ui/src/wallet-connector.ts
+++ b/packages/ui/src/wallet-connector.ts
@@ -180,6 +180,7 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
     }
 
     disconnectedCallback() {
+      this.cancelPendingConnection();
       this.openGeneration += 1;
       this.isOpen = false;
       this.accountModalOpen = false;

--- a/packages/ui/tests/WalletConnector.test.ts
+++ b/packages/ui/tests/WalletConnector.test.ts
@@ -40,6 +40,7 @@ function createElement(manager: WalletManager) {
     openAccountModal(): void;
     disconnectedCallback(): void;
     getOverlayRoot(): ShadowRoot | null;
+    showWalletList(): void;
   };
   element.setWalletManager(manager);
   return element;
@@ -57,6 +58,24 @@ describe('WalletConnector wallet availability', () => {
     document.body.replaceChildren();
     vi.clearAllTimers();
     vi.useRealTimers();
+  });
+
+  it('cancels a pending wallet selection before returning to the wallet list', async () => {
+    const walletConnect = createAdapter('walletconnect', 'WalletConnect', vi.fn(async () => true));
+    walletConnect.connect = vi.fn(() => new Promise(() => {}));
+    const xaman = createAdapter('xaman', 'Xaman', vi.fn(async () => true));
+    xaman.connect = vi.fn(async () => ({ address: 'rXaman', network: NETWORK }));
+    const manager = new WalletManager({ adapters: [walletConnect, xaman] });
+    element = createElement(manager);
+
+    void manager.connect('walletconnect');
+    await vi.waitFor(() => expect(walletConnect.connect).toHaveBeenCalledOnce());
+
+    element.showWalletList();
+    await expect(manager.connect('xaman')).resolves.toMatchObject({ address: 'rXaman' });
+
+    expect(walletConnect.disconnect).toHaveBeenCalledOnce();
+    expect(manager.wallet).toBe(xaman);
   });
 
   it('renders an empty state instead of falling back to unavailable wallets', async () => {

--- a/packages/ui/tests/WalletConnector.test.ts
+++ b/packages/ui/tests/WalletConnector.test.ts
@@ -61,9 +61,17 @@ describe('WalletConnector wallet availability', () => {
   });
 
   it('cancels a pending wallet selection before returning to the wallet list', async () => {
-    const walletConnect = createAdapter('walletconnect', 'WalletConnect', vi.fn(async () => true));
+    const walletConnect = createAdapter(
+      'walletconnect',
+      'WalletConnect',
+      vi.fn(async () => true)
+    );
     walletConnect.connect = vi.fn(() => new Promise(() => {}));
-    const xaman = createAdapter('xaman', 'Xaman', vi.fn(async () => true));
+    const xaman = createAdapter(
+      'xaman',
+      'Xaman',
+      vi.fn(async () => true)
+    );
     xaman.connect = vi.fn(async () => ({ address: 'rXaman', network: NETWORK }));
     const manager = new WalletManager({ adapters: [walletConnect, xaman] });
     element = createElement(manager);

--- a/packages/ui/tests/WalletConnector.test.ts
+++ b/packages/ui/tests/WalletConnector.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
-import { TIME, WalletManager } from '@xrpl-connect/core';
+import { MemoryStorageAdapter, TIME, WalletManager } from '@xrpl-connect/core';
 import type { NetworkInfo, WalletAdapter } from '@xrpl-connect/core';
 import '../src/wallet-connector';
 
@@ -84,6 +84,39 @@ describe('WalletConnector wallet availability', () => {
 
     expect(walletConnect.disconnect).toHaveBeenCalledOnce();
     expect(manager.wallet).toBe(xaman);
+  });
+
+  it('cancels a pending wallet connection when detached', async () => {
+    let resolveConnection!: (account: { address: string; network: NetworkInfo }) => void;
+    const walletConnect = createAdapter(
+      'walletconnect',
+      'WalletConnect',
+      vi.fn(async () => true)
+    );
+    walletConnect.connect = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveConnection = resolve;
+        })
+    );
+    const manager = new WalletManager({
+      adapters: [walletConnect],
+      storage: new MemoryStorageAdapter(),
+    });
+    element = createElement(manager);
+    document.body.appendChild(element);
+
+    const connection = manager.connect('walletconnect');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(walletConnect.connect).toHaveBeenCalledOnce();
+    element.remove();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(walletConnect.disconnect).toHaveBeenCalled();
+    resolveConnection({ address: 'rWalletConnect', network: NETWORK });
+
+    await expect(connection).rejects.toMatchObject({ code: 'NOT_CONNECTED' });
+    expect(manager.connected).toBe(false);
+    expect(manager.wallet).toBeNull();
   });
 
   it('renders an empty state instead of falling back to unavailable wallets', async () => {

--- a/packages/ui/tests/WalletService.test.ts
+++ b/packages/ui/tests/WalletService.test.ts
@@ -7,6 +7,30 @@ afterEach(() => {
 });
 
 describe('WalletService', () => {
+  it('starts Xaman connection without deferring beyond the user activation task', async () => {
+    vi.useFakeTimers();
+    const connect = vi.fn(async () => undefined);
+    const mockWalletManager = {
+      wallets: [{ id: 'xaman', name: 'Xaman' }],
+      connect,
+    };
+    const mockComponent = {
+      showLoadingView: vi.fn(),
+      showQRCodeView: vi.fn(),
+      showAccountSelectionView: vi.fn(),
+      showErrorView: vi.fn(),
+      dispatchEvent: vi.fn(),
+      setQRCode: vi.fn(),
+      close: vi.fn(),
+    };
+    const walletService = new WalletService(mockWalletManager as any, mockComponent as any);
+
+    const connection = walletService.connectWallet('xaman');
+
+    expect(connect).toHaveBeenCalledWith('xaman', undefined);
+    await connection;
+  });
+
   it('should connect to a wallet', async () => {
     const isAvailable = vi.fn(async () => true);
     const mockWalletManager = {

--- a/packages/xrpl-connect/tests/publish/runtime-cjs.cjs
+++ b/packages/xrpl-connect/tests/publish/runtime-cjs.cjs
@@ -4,6 +4,7 @@ require('./runtime-env.cjs');
 const api = require('xrpl-connect');
 
 assert.equal(typeof api.XamanAdapter, 'function');
+assert.equal(typeof api.MetaMaskSnapAdapter, 'function');
 assert.equal(typeof api.XamanSDK.Xumm, 'function');
 assert.equal(typeof api.XamanOAuth2.XummPkce, 'function');
 assert.equal(typeof api.CrossmarkSDK.default.methods.signInAndWait, 'function');

--- a/packages/xrpl-connect/tests/publish/runtime-esm.mjs
+++ b/packages/xrpl-connect/tests/publish/runtime-esm.mjs
@@ -5,6 +5,7 @@ createRequire(import.meta.url)('./runtime-env.cjs');
 const api = await import('xrpl-connect');
 
 assert.equal(typeof api.XamanAdapter, 'function');
+assert.equal(typeof api.MetaMaskSnapAdapter, 'function');
 assert.equal(typeof api.XamanSDK.Xumm, 'function');
 assert.equal(typeof api.XamanOAuth2.XummPkce, 'function');
 assert.equal(typeof api.CrossmarkSDK.default.methods.signInAndWait, 'function');

--- a/packages/xrpl-connect/tests/publish/types-cjs.cts
+++ b/packages/xrpl-connect/tests/publish/types-cjs.cts
@@ -1,6 +1,7 @@
 import {
   CrossmarkSDK,
   GemWalletAPI,
+  MetaMaskSnapAdapter,
   WalletConnectorElement,
   XamanOAuth2,
   XamanSDK,
@@ -64,6 +65,7 @@ const walletConnectorConstructor: {
 const metamaskOptions: MetaMaskSnapAdapterOptions = {
   snapId: 'local:http://localhost:8080',
 };
+const metamaskAdapter = new MetaMaskSnapAdapter(metamaskOptions);
 
 void [
   connectOptions,
@@ -81,4 +83,5 @@ void [
   pendingAccount,
   walletConnectorConstructor,
   metamaskOptions,
+  metamaskAdapter,
 ];

--- a/packages/xrpl-connect/tests/publish/types-esm.mts
+++ b/packages/xrpl-connect/tests/publish/types-esm.mts
@@ -1,6 +1,7 @@
 import {
   CrossmarkSDK,
   GemWalletAPI,
+  MetaMaskSnapAdapter,
   WalletConnectorElement,
   XamanOAuth2,
   XamanSDK,
@@ -64,6 +65,7 @@ const walletConnectorConstructor: {
 const metamaskOptions: MetaMaskSnapAdapterOptions = {
   snapId: 'local:http://localhost:8080',
 };
+const metamaskAdapter = new MetaMaskSnapAdapter(metamaskOptions);
 
 void [
   connectOptions,
@@ -81,4 +83,5 @@ void [
   pendingAccount,
   walletConnectorConstructor,
   metamaskOptions,
+  metamaskAdapter,
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^4.4.2
         version: 4.4.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       xrpl-connect:
-        specifier: workspace:*
-        version: link:../packages/xrpl-connect
+        specifier: ^0.8.0
+        version: 0.8.2
     devDependencies:
       vitepress:
         specifier: ^1.6.4
@@ -4145,6 +4145,9 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  xrpl-connect@0.8.2:
+    resolution: {integrity: sha512-te3NDPSJGZhk+5yMppbv/UB6+6UCnrSzBFCHd24SIoNrDwbbcEEWoWoiNojPU44lRLdPB4YblNF91bFRS4O9iw==}
 
   xrpl-secret-numbers@0.3.5:
     resolution: {integrity: sha512-5W2Ijp4nFpplEJ4IEK8JNAnRN9+3/+8BdBQ0hOZ3bZfa/+K9c9GNdN5fHDkKoECJN3nzXNcj6/Ejg7wUQDtRnQ==}
@@ -8328,6 +8331,8 @@ snapshots:
   xml-name-validator@4.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  xrpl-connect@0.8.2: {}
 
   xrpl-secret-numbers@0.3.5(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^4.4.2
         version: 4.4.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       xrpl-connect:
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: workspace:*
+        version: link:../packages/xrpl-connect
     devDependencies:
       vitepress:
         specifier: ^1.6.4
@@ -109,6 +109,9 @@ importers:
       '@xrpl-connect/adapter-ledger':
         specifier: workspace:*
         version: link:../../packages/adapters/ledger
+      '@xrpl-connect/adapter-metamask-snap':
+        specifier: workspace:*
+        version: link:../../packages/adapters/metamask-snap
       '@xrpl-connect/adapter-otsu':
         specifier: workspace:*
         version: link:../../packages/adapters/otsu
@@ -4142,9 +4145,6 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
-
-  xrpl-connect@0.6.0:
-    resolution: {integrity: sha512-w7Izg0QqH6iU9/wURYyTG3sFzyeBpIc/c5MGm1eHCW3z1Yj97OrIU0wCCNgAzVHAE4QFF6AF7CrVxIm/jYMz5Q==}
 
   xrpl-secret-numbers@0.3.5:
     resolution: {integrity: sha512-5W2Ijp4nFpplEJ4IEK8JNAnRN9+3/+8BdBQ0hOZ3bZfa/+K9c9GNdN5fHDkKoECJN3nzXNcj6/Ejg7wUQDtRnQ==}
@@ -8328,8 +8328,6 @@ snapshots:
   xml-name-validator@4.0.0: {}
 
   xmlchars@2.2.0: {}
-
-  xrpl-connect@0.6.0: {}
 
   xrpl-secret-numbers@0.3.5(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^4.4.2
         version: 4.4.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       xrpl-connect:
-        specifier: ^0.8.0
-        version: 0.8.2
+        specifier: workspace:*
+        version: link:../packages/xrpl-connect
     devDependencies:
       vitepress:
         specifier: ^1.6.4
@@ -4145,9 +4145,6 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
-
-  xrpl-connect@0.8.2:
-    resolution: {integrity: sha512-te3NDPSJGZhk+5yMppbv/UB6+6UCnrSzBFCHd24SIoNrDwbbcEEWoWoiNojPU44lRLdPB4YblNF91bFRS4O9iw==}
 
   xrpl-secret-numbers@0.3.5:
     resolution: {integrity: sha512-5W2Ijp4nFpplEJ4IEK8JNAnRN9+3/+8BdBQ0hOZ3bZfa/+K9c9GNdN5fHDkKoECJN3nzXNcj6/Ejg7wUQDtRnQ==}
@@ -8331,8 +8328,6 @@ snapshots:
   xml-name-validator@4.0.0: {}
 
   xmlchars@2.2.0: {}
-
-  xrpl-connect@0.8.2: {}
 
   xrpl-secret-numbers@0.3.5(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     dependencies:


### PR DESCRIPTION
## Summary

- separate prepared WalletConnect handshakes from user-selected connection attempts and cancel pending approvals safely
- let explicit Xaman authorization supersede silent session restoration while browser activation is still available
- preserve Xaman popup timing, add non-sensitive connection lifecycle diagnostics, and cover the race conditions with regressions
- register MetaMask Snap in the React, vanilla JavaScript, and interactive docs examples

## Root cause

WalletConnect pre-initialization and active connection attempts shared lifecycle state, so leaving WalletConnect could block the next wallet. Xaman also treated its silent restoration probe as an active authorization request, causing a user click to wait indefinitely and lose the popup activation window.

## React example

The React example uses the workspace `@xrpl-connect/react` package for `XrplConnectProvider`, `WalletConnector`, `useWallet`, and `useSigner`. MetaMask Snap is registered through the current workspace `xrpl-connect` umbrella export.

## Validation

- Xaman adapter: 80 tests passed; source lint passed
- WalletConnect adapter: 13 tests passed; source lint passed
- UI package: 44 tests passed; source lint passed
- React example production build passed
- vanilla JavaScript example production build passed
- VitePress docs production build passed
- formatting and `git diff --check` passed

The docs build continues to emit its existing SSR `window is not defined` and Rolldown plugin warnings, but completes successfully.
