### PR TITLE
feat: add Vue 3 bindings

### DIFF
--- a/docs/guide/frameworks/nuxt.md
+++ b/docs/guide/frameworks/nuxt.md
@@ -1,158 +1,45 @@
 ---
-description: Integrate XRPL-Connect into your Nuxt 3 application using the Composition API.
+description: Integrate XRPL-Connect into Nuxt with the first-party Vue bindings.
 ---
 
-# Nuxt 3
+# Nuxt
 
-Integrate XRPL-Connect into your Nuxt 3 application with the Composition API.
+XRPL Connect's modal is a browser custom element. In Nuxt, register it and install the
+`@xrpl-connect/vue` plugin from a client-only Nuxt plugin.
 
 ## Installation
 
 ```bash
-npm install xrpl-connect xrpl
+npm install @xrpl-connect/vue xrpl-connect xrpl vue
 ```
 
-## Basic Setup
+## Client plugin
 
-Create a composable for wallet management:
+Create `plugins/xrpl-connect.client.ts`:
 
-```typescript
-// composables/useWallet.ts
-import { ref, onMounted } from 'vue';
-import { WalletManager, XamanAdapter, CrossmarkAdapter } from 'xrpl-connect';
-import type { AccountInfo, WalletError, WalletAdapter } from 'xrpl-connect';
+```ts
+import 'xrpl-connect';
+import { CrossmarkAdapter, XamanAdapter } from 'xrpl-connect';
+import { createXrplConnect } from '@xrpl-connect/vue';
 
-interface UseWalletOptions {
-  adapters: WalletAdapter[];
-  network?: 'mainnet' | 'testnet' | 'devnet';
-}
-
-export const useWallet = (options: UseWalletOptions) => {
-  const { adapters, network = 'testnet' } = options;
-
-  const walletManager = ref<WalletManager | null>(null);
-  const account = ref<AccountInfo | null>(null);
-  const connected = ref(false);
-  const error = ref<WalletError | null>(null);
-  const loading = ref(true);
-  const connectorRef = ref<HTMLElement | null>(null);
-
-  onMounted(() => {
-    const manager = new WalletManager({
-      adapters,
-      network,
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.use(
+    createXrplConnect({
+      adapters: [
+        new XamanAdapter({ apiKey: useRuntimeConfig().public.xamanApiKey }),
+        new CrossmarkAdapter(),
+      ],
+      network: 'testnet',
       autoConnect: true,
-    });
-
-    manager.on('connect', (acc: AccountInfo) => {
-      account.value = acc;
-      connected.value = true;
-      error.value = null;
-    });
-
-    manager.on('disconnect', () => {
-      account.value = null;
-      connected.value = false;
-    });
-
-    manager.on('error', (err: WalletError) => {
-      error.value = err;
-    });
-
-    walletManager.value = manager;
-    loading.value = false;
-
-    if (connectorRef.value) {
-      connectorRef.value.setWalletManager(manager);
-    }
-  });
-
-  const disconnect = async () => {
-    if (walletManager.value) {
-      await walletManager.value.disconnect();
-    }
-  };
-
-  return {
-    walletManager,
-    account,
-    connected,
-    error,
-    loading,
-    connectorRef,
-    disconnect,
-  };
-};
-```
-
-## Creating a Plugin
-
-Create a Nuxt plugin to provide wallet globally:
-
-```typescript
-// plugins/wallet.client.ts
-import { defineNuxtPlugin } from '#app';
-import { WalletManager, XamanAdapter, CrossmarkAdapter } from 'xrpl-connect';
-import type { AccountInfo, WalletError } from 'xrpl-connect';
-
-declare module '#app' {
-  interface NuxtApp {
-    $wallet: {
-      manager: WalletManager | null;
-      account: any;
-      connected: boolean;
-      error: WalletError | null;
-    };
-  }
-}
-
-export default defineNuxtPlugin(() => {
-  const config = useRuntimeConfig();
-
-  const manager = new WalletManager({
-    adapters: [
-      new XamanAdapter({
-        apiKey: config.public.xamanApiKey || '',
-      }),
-      new CrossmarkAdapter(),
-    ],
-    network: 'testnet',
-    autoConnect: true,
-  });
-
-  const state = reactive({
-    manager,
-    account: null as AccountInfo | null,
-    connected: false,
-    error: null as WalletError | null,
-  });
-
-  manager.on('connect', (account: AccountInfo) => {
-    state.account = account;
-    state.connected = true;
-    state.error = null;
-  });
-
-  manager.on('disconnect', () => {
-    state.account = null;
-    state.connected = false;
-  });
-
-  manager.on('error', (error: WalletError) => {
-    state.error = error;
-  });
-
-  return {
-    provide: {
-      wallet: state,
-    },
-  };
+    })
+  );
 });
 ```
 
-Add to your `nuxt.config.ts`:
+Expose the public API key through runtime configuration:
 
-```typescript
+```ts
+// nuxt.config.ts
 export default defineNuxtConfig({
   runtimeConfig: {
     public: {
@@ -162,536 +49,59 @@ export default defineNuxtConfig({
 });
 ```
 
-## Using the Plugin
+The `.client.ts` suffix prevents wallet adapters and custom-element registration from running
+during server rendering. `@xrpl-connect/vue` itself remains safe to import in universal modules.
 
-Access the wallet in any component:
+## Wallet component
 
-```vue
-<template>
-  <div>
-    <xrpl-wallet-connector ref="connectorRef" primary-wallet="xaman" />
-
-    <div v-if="$wallet.error" style="color: red">Error: {{ $wallet.error.message }}</div>
-
-    <div v-if="$wallet.account" style="margin-top: 20px">
-      <h3>Connected Account</h3>
-      <p><strong>Address:</strong> {{ $wallet.account.address }}</p>
-      <p><strong>Network:</strong> {{ $wallet.account.network.name }}</p>
-      <button @click="handleDisconnect">Disconnect</button>
-    </div>
-  </div>
-</template>
-
-<script setup lang="ts">
-const connectorRef = ref<HTMLElement | null>(null);
-const { $wallet } = useNuxtApp();
-
-onMounted(() => {
-  if (connectorRef.value && $wallet.manager) {
-    connectorRef.value.setWalletManager($wallet.manager);
-  }
-});
-
-const handleDisconnect = async () => {
-  if ($wallet.manager) {
-    await $wallet.manager.disconnect();
-  }
-};
-</script>
-```
-
-## Composable with Plugin
-
-Combine composable + plugin for maximum flexibility:
-
-```typescript
-// composables/useWalletManager.ts
-export const useWalletManager = () => {
-  const { $wallet } = useNuxtApp();
-  const connectorRef = ref<HTMLElement | null>(null);
-
-  onMounted(() => {
-    if (connectorRef.value && $wallet.manager) {
-      connectorRef.value.setWalletManager($wallet.manager);
-    }
-  });
-
-  return {
-    ...toRefs($wallet),
-    connectorRef,
-  };
-};
-```
-
-Usage:
+Render the connector inside Nuxt's `ClientOnly` boundary. The injected refs are automatically
+unwrapped in the template.
 
 ```vue
 <script setup lang="ts">
-const { account, connected, error, connectorRef, manager } = useWalletManager();
+import { WalletConnector, useWallet, useWalletModal } from '@xrpl-connect/vue';
 
-const handlePayment = async () => {
-  if (!manager?.connected) return;
-
-  try {
-    const result = await manager.signAndSubmit({
-      TransactionType: 'Payment',
-      Account: account.value.address,
-      Destination: 'rN7n7otQDd6FczFgLdlqtyMVrn3HMfXoQT',
-      Amount: '1000000',
-    });
-    console.log('Payment sent:', result.hash);
-  } catch (error) {
-    console.error('Payment failed:', error);
-  }
-};
+const { connected, account, connecting, error, disconnect } = useWallet();
+const { open } = useWalletModal();
 </script>
-```
 
-## Signing Transactions
-
-Handle transactions in Nuxt:
-
-```vue
 <template>
-  <form @submit.prevent="handleSubmit">
-    <button type="submit" :disabled="loading || !$wallet.connected">
-      {{ loading ? 'Sending...' : 'Send Payment' }}
+  <ClientOnly>
+    <button v-if="!connected" :disabled="connecting" @click="open">
+      {{ connecting ? 'Connecting…' : 'Connect wallet' }}
     </button>
-    <p v-if="errorMsg" style="color: red">{{ errorMsg }}</p>
-    <p v-if="result" style="color: green">Success! Hash: {{ result.hash }}</p>
-  </form>
-</template>
+    <button v-else @click="disconnect">Disconnect {{ account?.address }}</button>
 
-<script setup lang="ts">
-const { $wallet } = useNuxtApp();
-
-const loading = ref(false);
-const errorMsg = ref('');
-const result = ref<any>(null);
-
-const handleSubmit = async () => {
-  if (!$wallet.manager?.connected) {
-    errorMsg.value = 'Wallet not connected';
-    return;
-  }
-
-  loading.value = true;
-  errorMsg.value = '';
-
-  try {
-    const txResult = await $wallet.manager.signAndSubmit({
-      TransactionType: 'Payment',
-      Account: $wallet.account.address,
-      Destination: 'rN7n7otQDd6FczFgLdlqtyMVrn3HMfXoQT',
-      Amount: '1000000',
-    });
-
-    result.value = txResult;
-  } catch (error: any) {
-    errorMsg.value = error.message;
-  } finally {
-    loading.value = false;
-  }
-};
-</script>
-```
-
-## Middleware for Protected Routes
-
-Protect routes that require wallet connection:
-
-```typescript
-// middleware/requireWallet.ts
-export default defineRouteMiddleware((to, from) => {
-  const { $wallet } = useNuxtApp();
-
-  if (!$wallet.connected) {
-    return navigateTo('/');
-  }
-});
-```
-
-Use in a page:
-
-```vue
-<!-- pages/transactions.vue -->
-<script setup lang="ts">
-definePageMeta({
-  middleware: 'requireWallet',
-});
-</script>
-
-<template>
-  <div>Protected content here</div>
+    <p v-if="error">Error [{{ error.code }}]: {{ error.message }}</p>
+    <WalletConnector theme="dark" primary-wallet="xaman" />
+  </ClientOnly>
 </template>
 ```
 
-## Pinia Store Integration
+## Signing
 
-For larger apps, use Pinia with XRPL-Connect:
-
-```typescript
-// stores/wallet.ts
-import { defineStore } from 'pinia';
-import { WalletManager, XamanAdapter } from 'xrpl-connect';
-import type { AccountInfo, WalletError } from 'xrpl-connect';
-
-export const useWalletStore = defineStore('wallet', () => {
-  const manager = ref<WalletManager | null>(null);
-  const account = ref<AccountInfo | null>(null);
-  const connected = ref(false);
-  const error = ref<WalletError | null>(null);
-
-  const initializeWallet = (adapters: any[]) => {
-    const newManager = new WalletManager({
-      adapters,
-      network: 'testnet',
-      autoConnect: true,
-    });
-
-    newManager.on('connect', (acc: AccountInfo) => {
-      account.value = acc;
-      connected.value = true;
-      error.value = null;
-    });
-
-    newManager.on('disconnect', () => {
-      account.value = null;
-      connected.value = false;
-    });
-
-    newManager.on('error', (err: WalletError) => {
-      error.value = err;
-    });
-
-    manager.value = newManager;
-  };
-
-  const disconnect = async () => {
-    if (manager.value) {
-      await manager.value.disconnect();
-    }
-  };
-
-  const sign = async (transaction: any) => {
-    if (!manager.value?.connected) {
-      throw new Error('Wallet not connected');
-    }
-    return manager.value.sign(transaction);
-  };
-
-  const signAndSubmit = async (transaction: any) => {
-    if (!manager.value?.connected) {
-      throw new Error('Wallet not connected');
-    }
-    return manager.value.signAndSubmit(transaction);
-  };
-
-  return {
-    manager,
-    account,
-    connected,
-    error,
-    initializeWallet,
-    disconnect,
-    sign,
-    signAndSubmit,
-  };
-});
-```
-
-Use in a page:
+Use `useSigner()` in any descendant component:
 
 ```vue
 <script setup lang="ts">
-import { useWalletStore } from '~/stores/wallet';
-import { XamanAdapter } from 'xrpl-connect';
+import { useSigner, useWallet } from '@xrpl-connect/vue';
 
-const wallet = useWalletStore();
-const config = useRuntimeConfig();
+const { account, connected } = useWallet();
+const { signAndSubmit } = useSigner();
 
-onMounted(() => {
-  if (!wallet.manager) {
-    wallet.initializeWallet([new XamanAdapter({ apiKey: config.public.xamanApiKey })]);
-  }
-});
+async function sendPayment() {
+  if (!connected.value || !account.value) return;
 
-const handlePayment = async () => {
-  try {
-    const result = await wallet.signAndSubmit({
-      TransactionType: 'Payment',
-      Account: wallet.account.address,
-      Destination: 'rN7n7otQDd6FczFgLdlqtyMVrn3HMfXoQT',
-      Amount: '1000000',
-    });
-    console.log('Payment sent:', result.hash);
-  } catch (error) {
-    console.error('Payment failed:', error);
-  }
-};
-</script>
-```
-
-## Error Handling
-
-Handle errors gracefully:
-
-```vue
-<template>
-  <div>
-    <xrpl-wallet-connector ref="connectorRef" />
-
-    <ErrorAlert v-if="$wallet.error" :error="$wallet.error" />
-  </div>
-</template>
-
-<script setup lang="ts">
-const ErrorAlert = defineAsyncComponent(() => import('~/components/ErrorAlert.vue'));
-</script>
-```
-
-Create the error component:
-
-```vue
-<!-- components/ErrorAlert.vue -->
-<template>
-  <div class="error-alert">
-    {{ getErrorMessage(error) }}
-  </div>
-</template>
-
-<script setup lang="ts">
-interface Props {
-  error: any;
-}
-
-const props = defineProps<Props>();
-
-const getErrorMessage = (error: any) => {
-  if (error.code === 'WALLET_NOT_FOUND') {
-    return 'Please install a wallet to continue';
-  } else if (error.code === 'CONNECTION_FAILED') {
-    return 'Failed to connect. Please try again.';
-  } else if (error.code === 'SIGN_FAILED') {
-    return 'You rejected the transaction';
-  }
-  return error.message;
-};
-</script>
-
-<style scoped>
-.error-alert {
-  padding: 10px;
-  background: #fee;
-  color: #c00;
-  border-radius: 4px;
-}
-</style>
-```
-
-## Server Routes for Backend Operations
-
-Use Nuxt server routes for secure operations:
-
-```typescript
-// server/api/transactions/sign.ts
-export default defineEventHandler(async (event) => {
-  const body = await readBody(event);
-
-  try {
-    // Validate transaction on backend
-    if (!body.transaction.Account || !body.transaction.Destination) {
-      throw createError({
-        statusCode: 400,
-        statusMessage: 'Invalid transaction',
-      });
-    }
-
-    // Process transaction
-    // You could integrate server-side xrpl operations here
-
-    return { success: true };
-  } catch (error: any) {
-    throw createError({
-      statusCode: 500,
-      statusMessage: error.message,
-    });
-  }
-});
-```
-
-Use in your component:
-
-```typescript
-const submitTransaction = async () => {
-  const result = await $fetch('/api/transactions/sign', {
-    method: 'POST',
-    body: {
-      transaction: {
-        TransactionType: 'Payment',
-        Account: $wallet.account.address,
-        Destination: 'rN7n7otQDd6FczFgLdlqtyMVrn3HMfXoQT',
-        Amount: '1000000',
-      },
-    },
+  await signAndSubmit({
+    TransactionType: 'Payment',
+    Account: account.value.address,
+    Destination: 'rN7n7otQDd6FczFgLdlqtyMVrn3HMfXoQT',
+    Amount: '1000000',
   });
-};
-```
-
-## Environment Variables
-
-Set up your `.env` file:
-
-```bash
-NUXT_PUBLIC_XAMAN_API_KEY=your_api_key
-NUXT_PUBLIC_WALLETCONNECT_PROJECT_ID=your_project_id
-```
-
-## Best Practices
-
-1. **Use Plugins** - Initialize wallet in a plugin for app-wide access
-
-2. **Composables** - Create composables for component-level wallet logic
-
-3. **Error Handling** - Handle errors gracefully in all wallet operations
-
-4. **Middleware** - Protect routes with middleware when needed
-
-5. **Pinia for Complex State** - Use Pinia for larger applications
-
-6. **Type Safety** - Use TypeScript for better type checking
-
-7. **Environment Variables** - Keep secrets in `.env` files
-
-8. **SSR Considerations** - Use `client-only` components for wallet UI
-
-```vue
-<!-- Prevent SSR for web components -->
-<ClientOnly>
-  <xrpl-wallet-connector ref="connectorRef" />
-</ClientOnly>
-```
-
-## Full Example: Complete Nuxt Page
-
-```vue
-<!-- pages/wallet.vue -->
-<template>
-  <div class="wallet-container">
-    <h1>XRPL-Connect Demo</h1>
-
-    <ClientOnly>
-      <xrpl-wallet-connector ref="connectorRef" primary-wallet="xaman" />
-    </ClientOnly>
-
-    <div v-if="$wallet.error" class="error">
-      {{ getErrorMessage($wallet.error) }}
-    </div>
-
-    <div v-if="$wallet.account" class="account-info">
-      <h2>Connected Account</h2>
-      <p><strong>Address:</strong> {{ shortAddress }}</p>
-      <p><strong>Network:</strong> {{ $wallet.account.network.name }}</p>
-      <button @click="handleDisconnect">Disconnect</button>
-    </div>
-
-    <form v-if="$wallet.connected" @submit.prevent="handlePayment" class="payment-form">
-      <h2>Send Payment</h2>
-      <button type="submit" :disabled="loading">
-        {{ loading ? 'Sending...' : 'Send 1 XRP' }}
-      </button>
-      <p v-if="paymentResult" class="success">Success! Hash: {{ paymentResult.hash }}</p>
-    </form>
-  </div>
-</template>
-
-<script setup lang="ts">
-import { computed, ref } from 'vue';
-
-const { $wallet } = useNuxtApp();
-const connectorRef = ref<HTMLElement | null>(null);
-const loading = ref(false);
-const paymentResult = ref<any>(null);
-
-onMounted(() => {
-  if (connectorRef.value && $wallet.manager) {
-    connectorRef.value.setWalletManager($wallet.manager);
-  }
-});
-
-const shortAddress = computed(() => {
-  if (!$wallet.account) return null;
-  const addr = $wallet.account.address;
-  return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
-});
-
-const handleDisconnect = async () => {
-  if ($wallet.manager) {
-    await $wallet.manager.disconnect();
-  }
-};
-
-const handlePayment = async () => {
-  if (!$wallet.manager?.connected) return;
-
-  loading.value = true;
-
-  try {
-    const result = await $wallet.manager.signAndSubmit({
-      TransactionType: 'Payment',
-      Account: $wallet.account.address,
-      Destination: 'rN7n7otQDd6FczFgLdlqtyMVrn3HMfXoQT',
-      Amount: '1000000',
-    });
-
-    paymentResult.value = result;
-  } catch (error) {
-    console.error('Payment failed:', error);
-  } finally {
-    loading.value = false;
-  }
-};
-
-const getErrorMessage = (error: any) => {
-  if (error.code === 'WALLET_NOT_FOUND') {
-    return 'Please install a wallet to continue';
-  }
-  return error.message;
-};
+}
 </script>
-
-<style scoped>
-.wallet-container {
-  max-width: 600px;
-  margin: 0 auto;
-  padding: 20px;
-}
-
-.error {
-  padding: 10px;
-  background: #fee;
-  color: #c00;
-  border-radius: 4px;
-  margin: 20px 0;
-}
-
-.account-info {
-  margin: 20px 0;
-  padding: 15px;
-  background: #f5f5f5;
-  border-radius: 8px;
-}
-
-.payment-form {
-  margin: 20px 0;
-  padding: 15px;
-  background: #e8f4f8;
-  border-radius: 8px;
-}
-
-.success {
-  color: green;
-  word-break: break-all;
-}
-</style>
 ```
+
+The plugin owns one manager for the Nuxt application and removes its listeners and active
+connection when the Vue app unmounts. Do not create an additional `WalletManager` in a
+component or Pinia store.

--- a/docs/guide/frameworks/vue.md
+++ b/docs/guide/frameworks/vue.md
@@ -1,508 +1,133 @@
 ---
-description: Integrate XRPL-Connect into your Vue 3 application using the Composition API.
+description: Integrate XRPL-Connect into your Vue 3 application with first-party composables.
 ---
 
 # Vue 3
 
-Integrate XRPL-Connect into your Vue 3 application with the Composition API.
+`@xrpl-connect/vue` provides a Vue plugin, reactive composables, and a typed wrapper for the
+wallet connector modal. Configure the wallet manager once and consume the same state anywhere
+in the application.
 
 ## Installation
 
 ```bash
-npm install xrpl-connect xrpl
+npm install @xrpl-connect/vue xrpl-connect xrpl vue
 ```
 
-## Basic Setup
+## Configure the plugin
 
-Here's a minimal Vue component using XRPL-Connect:
+Import `xrpl-connect` once in the browser entry point to register the wallet connector custom
+element, then install the Vue plugin before mounting the application:
 
-```vue
-<template>
-  <div>
-    <xrpl-wallet-connector ref="connectorRef" primary-wallet="xaman" />
+```ts
+// main.ts
+import { createApp } from 'vue';
+import 'xrpl-connect';
+import { CrossmarkAdapter, XamanAdapter } from 'xrpl-connect';
+import { createXrplConnect } from '@xrpl-connect/vue';
+import App from './App.vue';
 
-    <div v-if="error" style="color: red; margin-top: 20px">Error: {{ error }}</div>
+const app = createApp(App);
 
-    <div
-      v-if="account"
-      style="margin-top: 20px; padding: 15px; background: #f5f5f5; border-radius: 8px"
-    >
-      <h3>Connected Account</h3>
-      <p><strong>Address:</strong> {{ account.address }}</p>
-      <p><strong>Network:</strong> {{ account.network.name }}</p>
-      <button @click="handleDisconnect">Disconnect</button>
-    </div>
-  </div>
-</template>
-
-<script setup>
-import { ref, onMounted } from 'vue';
-import { WalletManager, XamanAdapter, CrossmarkAdapter } from 'xrpl-connect';
-
-const connectorRef = ref(null);
-const walletManager = ref(null);
-const account = ref(null);
-const error = ref(null);
-
-onMounted(() => {
-  // Initialize WalletManager
-  const manager = new WalletManager({
+app.use(
+  createXrplConnect({
     adapters: [new XamanAdapter({ apiKey: 'YOUR_API_KEY' }), new CrossmarkAdapter()],
     network: 'testnet',
     autoConnect: true,
-  });
+  })
+);
 
-  // Set up event listeners
-  manager.on('connect', (acc) => {
-    account.value = acc;
-    error.value = null;
-  });
-
-  manager.on('disconnect', () => {
-    account.value = null;
-  });
-
-  manager.on('error', (err) => {
-    error.value = err.message;
-  });
-
-  walletManager.value = manager;
-
-  // Connect component to manager
-  if (connectorRef.value) {
-    connectorRef.value.setWalletManager(manager);
-  }
-});
-
-const handleDisconnect = async () => {
-  if (walletManager.value) {
-    await walletManager.value.disconnect();
-  }
-};
-</script>
+app.mount('#app');
 ```
 
-## Creating a Composable
+Each plugin installation owns one `WalletManager`. Its state and event listeners are isolated
+from other Vue applications on the same page and are released when the app unmounts.
 
-For better reusability, create a composable:
+## Wallet state and modal
 
-```typescript
-// composables/useWallet.ts
-import { ref, onMounted } from 'vue';
-import { WalletManager } from 'xrpl-connect';
-import type { AccountInfo, WalletAdapter, WalletError } from 'xrpl-connect';
-
-interface UseWalletOptions {
-  adapters: WalletAdapter[];
-  network?: 'mainnet' | 'testnet' | 'devnet';
-}
-
-export function useWallet(options: UseWalletOptions) {
-  const { adapters, network = 'testnet' } = options;
-
-  const walletManager = ref<WalletManager | null>(null);
-  const account = ref<AccountInfo | null>(null);
-  const connected = ref(false);
-  const error = ref<WalletError | null>(null);
-  const loading = ref(true);
-  const connectorRef = ref<HTMLElement | null>(null);
-
-  onMounted(() => {
-    const manager = new WalletManager({
-      adapters,
-      network,
-      autoConnect: true,
-    });
-
-    manager.on('connect', (acc: AccountInfo) => {
-      account.value = acc;
-      connected.value = true;
-      error.value = null;
-    });
-
-    manager.on('disconnect', () => {
-      account.value = null;
-      connected.value = false;
-    });
-
-    manager.on('error', (err: WalletError) => {
-      error.value = err;
-    });
-
-    walletManager.value = manager;
-    loading.value = false;
-
-    if (connectorRef.value) {
-      connectorRef.value.setWalletManager(manager);
-    }
-  });
-
-  const disconnect = async () => {
-    if (walletManager.value) {
-      await walletManager.value.disconnect();
-    }
-  };
-
-  return {
-    walletManager,
-    account,
-    connected,
-    error,
-    loading,
-    connectorRef,
-    disconnect,
-  };
-}
-```
-
-Usage:
+`useWallet()` returns readonly Vue refs, so use them directly in templates and through `.value`
+in scripts. `useWalletModal()` controls the most recently mounted connector.
 
 ```vue
-<template>
-  <div>
-    <xrpl-wallet-connector ref="connectorRef" />
-    <button v-if="connected" @click="disconnect">Disconnect</button>
-  </div>
-</template>
+<script setup lang="ts">
+import { WalletConnector, useWallet, useWalletModal } from '@xrpl-connect/vue';
 
-<script setup>
-import { useWallet } from '@/composables/useWallet';
-import { XamanAdapter } from 'xrpl-connect';
-
-const { connectorRef, connected, disconnect } = useWallet({
-  adapters: [new XamanAdapter({ apiKey: 'YOUR_API_KEY' })],
-});
+const { connected, account, connecting, error, disconnect } = useWallet();
+const { open } = useWalletModal();
 </script>
+
+<template>
+  <button v-if="!connected" :disabled="connecting" @click="open">
+    {{ connecting ? 'Connecting…' : 'Connect wallet' }}
+  </button>
+  <button v-else @click="disconnect">Disconnect {{ account?.address }}</button>
+
+  <p v-if="error">Error [{{ error.code }}]: {{ error.message }}</p>
+
+  <WalletConnector
+    primary-wallet="xaman"
+    :wallets="['xaman', 'crossmark']"
+    theme="dark"
+    :css-vars="{ '--xc-primary-color': '#a78bfa' }"
+    @connecting="(walletId) => console.log('Connecting', walletId)"
+    @connect="(connectedAccount) => console.log('Connected', connectedAccount.address)"
+    @error="(walletError) => console.error(walletError.code, walletError.message)"
+  />
+</template>
 ```
 
-## Signing Transactions
+## Signing
 
-Sign transactions in Vue:
+Signing actions are bound to the injected manager and reject with typed `WalletError` values.
 
 ```vue
-<template>
-  <form @submit.prevent="handleSubmit">
-    <button type="submit" :disabled="loading || !connected">
-      {{ loading ? 'Sending...' : 'Send Payment' }}
-    </button>
-    <p v-if="error" style="color: red">{{ error }}</p>
-    <p v-if="result" style="color: green">Success! Hash: {{ result.hash }}</p>
-  </form>
-</template>
-
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
-import { useWallet } from '@/composables/useWallet';
+import { isWalletError, useSigner, useWallet } from '@xrpl-connect/vue';
 
-const { walletManager, connected } = useWallet({
-  adapters: [/* your adapters */],
-});
+const { account, connected } = useWallet();
+const { signAndSubmit } = useSigner();
+const submitting = ref(false);
+const result = ref<string | null>(null);
 
-const loading = ref(false);
-const error = ref(null);
-const result = ref(null);
-
-const handleSubmit = async () => {
-  if (!walletManager.value?.connected) {
-    error.value = 'Wallet not connected';
-    return;
-  }
-
-  loading.value = true;
-  error.value = null;
+async function sendPayment() {
+  if (!connected.value || !account.value) return;
+  submitting.value = true;
 
   try {
-    const txResult = await walletManager.value.signAndSubmit({
+    const submitted = await signAndSubmit({
       TransactionType: 'Payment',
-      Account: walletManager.value.account.address,
+      Account: account.value.address,
       Destination: 'rN7n7otQDd6FczFgLdlqtyMVrn3HMfXoQT',
       Amount: '1000000',
     });
-
-    result.value = txResult;
-  } catch (err) {
-    error.value = err.message;
-  } finally {
-    loading.value = false;
-  }
-};
-</script>
-```
-
-## Provide/Inject Pattern
-
-For larger apps, use Provide/Inject to share wallet state:
-
-```typescript
-// composables/useWalletState.ts
-import { provide, inject, ref, onMounted } from 'vue';
-import { WalletManager } from 'xrpl-connect';
-import type { AccountInfo, WalletAdapter } from 'xrpl-connect';
-
-const WalletSymbol = Symbol('wallet');
-
-export function provideWallet(adapters: WalletAdapter[], network = 'testnet') {
-  const walletManager = ref<WalletManager | null>(null);
-  const account = ref<AccountInfo | null>(null);
-  const connected = ref(false);
-
-  onMounted(() => {
-    const manager = new WalletManager({
-      adapters,
-      network,
-      autoConnect: true,
-    });
-
-    manager.on('connect', (acc: AccountInfo) => {
-      account.value = acc;
-      connected.value = true;
-    });
-
-    manager.on('disconnect', () => {
-      account.value = null;
-      connected.value = false;
-    });
-
-    walletManager.value = manager;
-  });
-
-  provide(WalletSymbol, {
-    walletManager,
-    account,
-    connected,
-  });
-
-  return { walletManager, account, connected };
-}
-
-export function useProvidedWallet() {
-  return inject<{
-    walletManager: any;
-    account: any;
-    connected: any;
-  }>(WalletSymbol)!;
-}
-```
-
-Usage in App.vue:
-
-```vue
-<script setup>
-import { provideWallet } from '@/composables/useWalletState';
-import { XamanAdapter } from 'xrpl-connect';
-
-provideWallet([new XamanAdapter({ apiKey: 'YOUR_API_KEY' })]);
-</script>
-
-<template>
-  <RouterView />
-</template>
-```
-
-Then use in any child component:
-
-```vue
-<script setup>
-import { useProvidedWallet } from '@/composables/useWalletState';
-
-const { account, connected } = useProvidedWallet();
-</script>
-
-<template>
-  <div v-if="connected">Connected: {{ account?.address }}</div>
-</template>
-```
-
-## Signing Messages
-
-Sign messages with Vue:
-
-```vue
-<template>
-  <form @submit.prevent="handleSignMessage">
-    <input v-model="message" placeholder="Message to sign" />
-    <button type="submit">Sign Message</button>
-    <p v-if="signature" style="word-break: break-all">Signature: {{ signature }}</p>
-  </form>
-</template>
-
-<script setup>
-import { ref } from 'vue';
-import { useWallet } from '@/composables/useWallet';
-
-const { walletManager, connected } = useWallet({
-  adapters: [/* your adapters */],
-});
-
-const message = ref('');
-const signature = ref('');
-
-const handleSignMessage = async () => {
-  if (!walletManager.value?.connected) return;
-
-  try {
-    const result = await walletManager.value.signMessage(message.value);
-    signature.value = result.signature;
+    result.value = submitted.hash;
   } catch (error) {
-    console.error('Sign failed:', error);
+    if (isWalletError(error)) console.error(error.code, error.category, error.message);
+    throw error;
+  } finally {
+    submitting.value = false;
   }
-};
-</script>
-```
-
-## Reactive Watchers
-
-Monitor wallet state changes:
-
-```vue
-<script setup>
-import { watch } from 'vue';
-import { useWallet } from '@/composables/useWallet';
-
-const { account, connected, error } = useWallet({
-  adapters: [/* your adapters */],
-});
-
-// Watch for connection changes
-watch(connected, (newValue) => {
-  if (newValue) {
-    console.log('Wallet connected:', account.value?.address);
-  } else {
-    console.log('Wallet disconnected');
-  }
-});
-
-// Watch for errors
-watch(error, (newError) => {
-  if (newError) {
-    console.error('Wallet error:', newError.message);
-  }
-});
-</script>
-```
-
-## Error Handling
-
-Handle errors gracefully:
-
-```vue
-<template>
-  <div v-if="error" class="error-alert">
-    {{ getErrorMessage(error) }}
-  </div>
-</template>
-
-<script setup>
-import { useWallet } from '@/composables/useWallet';
-
-const { error } = useWallet({
-  adapters: [/* your adapters */],
-});
-
-const getErrorMessage = (err: any) => {
-  if (err.code === 'WALLET_NOT_FOUND') {
-    return 'Please install a wallet to continue';
-  } else if (err.code === 'CONNECTION_FAILED') {
-    return 'Failed to connect. Please try again.';
-  } else if (err.code === 'SIGN_FAILED') {
-    return 'You rejected the transaction';
-  }
-  return err.message;
-};
-</script>
-
-<style scoped>
-.error-alert {
-  padding: 10px;
-  background: #fee;
-  color: #c00;
-  border-radius: 4px;
 }
-</style>
-```
-
-## Computed Properties
-
-Use computed for derived state:
-
-```vue
-<script setup>
-import { computed } from 'vue';
-import { useWallet } from '@/composables/useWallet';
-
-const { account, walletManager } = useWallet({
-  adapters: [/* your adapters */],
-});
-
-const shortAddress = computed(() => {
-  if (!account.value) return null;
-  const addr = account.value.address;
-  return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
-});
-
-const networkColor = computed(() => {
-  const network = account.value?.network.name;
-  if (network === 'mainnet') return 'green';
-  if (network === 'testnet') return 'orange';
-  return 'gray';
-});
 </script>
 
 <template>
-  <div v-if="account">
-    <p>{{ shortAddress }}</p>
-    <p :style="{ color: networkColor }">{{ account.network.name }}</p>
-  </div>
+  <button :disabled="submitting || !connected" @click="sendPayment">Send payment</button>
+  <p v-if="result">Submitted: {{ result }}</p>
 </template>
 ```
 
-## Best Practices
+## API summary
 
-1. **Use Composables** - Extract wallet logic into reusable composables
+- `createXrplConnect(config)` installs an isolated wallet manager using core `WalletManagerOptions`.
+- `useWallet()` returns `manager`, `connected`, `account`, `network`, `connecting`, `error`,
+  `connect`, and `disconnect`.
+- `useSigner()` returns `sign`, `signAndSubmit`, and `signMessage`.
+- `useWalletModal()` returns `open` and `close`.
+- `<WalletConnector>` wraps the browser custom element with typed Vue props and events.
 
-2. **Type Safety** - Use TypeScript for better type checking
+## SSR and Nuxt
 
-3. **Lazy Loading** - Load adapters only when needed
-
-4. **Error Boundaries** - Use error boundaries for wallet components
-
-5. **Memory Management** - Clean up listeners on component unmount
-
-6. **State Persistence** - Leverage XRPL-Connect's built-in persistence
-
-7. **Computed for Derived State** - Use computed properties instead of methods
-
-8. **Watch for Side Effects** - Use watch to react to state changes
-
-## Testing
-
-Example test using Vitest:
-
-```typescript
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vite-plus/test';
-import { mount } from '@vue/test-utils';
-import { useWallet } from '@/composables/useWallet';
-
-describe('useWallet', () => {
-  it('should initialize wallet manager', () => {
-    const { walletManager, loading } = useWallet({
-      adapters: [],
-    });
-
-    expect(walletManager.value).toBeDefined();
-  });
-
-  it('should handle connection events', async () => {
-    const mockAdapter = {
-      connect: vi.fn(),
-    };
-
-    const { account, connected } = useWallet({
-      adapters: [mockAdapter],
-    });
-
-    // Test account updates...
-    expect(account.value).toBeNull();
-  });
-});
-```
+The package itself is safe to import during server rendering. The connector is a browser custom
+element, so register `xrpl-connect`, install the plugin, and render the modal from client-only
+code. See the [Nuxt guide](./nuxt) for the client-plugin pattern.

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,0 +1,61 @@
+# @xrpl-connect/vue
+
+Vue 3 bindings for XRPL Connect: an app plugin that owns a `WalletManager`, reactive
+composables, and a typed `<WalletConnector>` modal component.
+
+## Install
+
+```bash
+npm install @xrpl-connect/vue xrpl-connect xrpl vue
+```
+
+## Usage
+
+```ts
+// main.ts
+import { createApp } from 'vue';
+import 'xrpl-connect';
+import { XamanAdapter, CrossmarkAdapter } from 'xrpl-connect';
+import { createXrplConnect } from '@xrpl-connect/vue';
+import App from './App.vue';
+
+const app = createApp(App);
+app.use(
+  createXrplConnect({
+    adapters: [new XamanAdapter({ apiKey: 'YOUR_KEY' }), new CrossmarkAdapter()],
+    network: 'testnet',
+    autoConnect: true,
+  })
+);
+app.mount('#app');
+```
+
+```vue
+<script setup lang="ts">
+import { WalletConnector, useSigner, useWallet, useWalletModal } from '@xrpl-connect/vue';
+
+const { connected, account, error, disconnect } = useWallet();
+const { signAndSubmit } = useSigner();
+const { open } = useWalletModal();
+</script>
+
+<template>
+  <button v-if="!connected" @click="open">Connect wallet</button>
+  <button v-else @click="disconnect">Disconnect {{ account?.address }}</button>
+  <p v-if="error">Error [{{ error.code }}]: {{ error.message }}</p>
+  <WalletConnector theme="dark" />
+</template>
+```
+
+## API
+
+- `createXrplConnect(config)` creates the app plugin and one isolated manager per installation.
+- `useWallet()` exposes `manager`, readonly `connected`, `account`, `network`, `connecting`,
+  and `error` refs, plus `connect` and `disconnect`.
+- `useSigner()` exposes `sign`, `signAndSubmit`, and `signMessage`.
+- `useWalletModal()` exposes `open` and `close` for the active connector.
+- `<WalletConnector>` accepts `primaryWallet`, `wallets`, `theme`, and `cssVars`, and emits
+  `connecting`, `connect`, and typed `error` events.
+
+Importing the package is SSR-safe. Install and render the wallet UI only on the client because
+the underlying modal is a browser custom element.

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@xrpl-connect/vue",
+  "version": "0.8.2",
+  "description": "Vue 3 bindings (plugin, composables, modal component) for XRPL Connect",
+  "author": "XRPL Connect Contributors",
+  "license": "MIT",
+  "homepage": "https://github.com/XRPL-Commons/xrpl-connect#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/XRPL-Commons/xrpl-connect",
+    "directory": "packages/vue"
+  },
+  "bugs": {
+    "url": "https://github.com/XRPL-Commons/xrpl-connect/issues"
+  },
+  "keywords": [
+    "xrpl",
+    "wallet",
+    "vue",
+    "composables",
+    "plugin",
+    "web3",
+    "wallet-connection",
+    "xaman",
+    "crossmark"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "vp pack",
+    "dev": "vp pack --watch",
+    "lint": "vp lint src",
+    "type-check": "tsc --noEmit",
+    "test": "node tests/ssr-smoke.mjs && vp test run",
+    "test:watch": "vp test",
+    "clean": "rm -rf dist"
+  },
+  "peerDependencies": {
+    "vue": "^3.5.0",
+    "xrpl": "^3.0.0 || ^4.0.0",
+    "xrpl-connect": "^0.8.0"
+  },
+  "devDependencies": {
+    "@xrpl-connect/core": "workspace:*",
+    "jsdom": "^22.1.0",
+    "typescript": "^5.5.0",
+    "vue": "^3.5.22",
+    "xrpl-connect": "workspace:*"
+  }
+}

--- a/packages/vue/src/WalletConnector.ts
+++ b/packages/vue/src/WalletConnector.ts
@@ -1,0 +1,136 @@
+import { defineComponent, h, onBeforeUnmount, onMounted, ref, type PropType } from 'vue';
+import {
+  createWalletError,
+  getErrorMessage,
+  isWalletError,
+  type AccountInfo,
+  type WalletError,
+} from '@xrpl-connect/core';
+import { useXrplConnectContext, type WalletConnectorElement } from './context';
+
+const THEMES: Record<WalletConnectorTheme, Record<string, string>> = {
+  dark: {
+    '--xc-background-color': '#1a202c',
+    '--xc-background-secondary': '#2d3748',
+    '--xc-text-color': '#F5F4E7',
+    '--xc-primary-color': '#3b99fc',
+  },
+  light: {
+    '--xc-background-color': '#ffffff',
+    '--xc-background-secondary': '#f5f5f5',
+    '--xc-text-color': '#111111',
+    '--xc-primary-color': '#2563eb',
+  },
+  purple: {
+    '--xc-background-color': '#1e1b4b',
+    '--xc-background-secondary': '#2d2659',
+    '--xc-text-color': '#f3e8ff',
+    '--xc-primary-color': '#a78bfa',
+  },
+};
+
+export type WalletConnectorTheme = 'dark' | 'light' | 'purple';
+
+export const WalletConnector = defineComponent({
+  name: 'WalletConnector',
+  inheritAttrs: false,
+  props: {
+    primaryWallet: String,
+    wallets: Array as PropType<string[]>,
+    theme: String as PropType<WalletConnectorTheme>,
+    cssVars: Object as PropType<Record<`--xc-${string}`, string>>,
+  },
+  emits: {
+    connecting: (walletId: string) => typeof walletId === 'string',
+    connect: (account: AccountInfo) => Boolean(account),
+    error: (error: WalletError) => isWalletError(error),
+  },
+  setup(props, { attrs, emit }) {
+    const context = useXrplConnectContext();
+    const element = ref<WalletConnectorElement | null>(null);
+    let active = false;
+    let registered: WalletConnectorElement | null = null;
+    let notifiedAccountKey: string | null = null;
+
+    const onManagerConnect = (account: AccountInfo) => {
+      const key = `${account.address}:${account.network.id}`;
+      if (notifiedAccountKey === key) return;
+      notifiedAccountKey = key;
+      emit('connect', account);
+    };
+    const onManagerDisconnect = () => {
+      notifiedAccountKey = null;
+    };
+    const onConnecting = (event: Event) => {
+      const walletId = (event as CustomEvent<{ walletId?: string }>).detail?.walletId;
+      if (!walletId) return;
+      context.reportModalConnecting();
+      emit('connecting', walletId);
+    };
+    const onError = (event: Event) => {
+      const detail = (
+        event as CustomEvent<{
+          error?: unknown;
+          errorType?: 'rejected' | 'unavailable' | 'failed';
+          walletId?: string;
+        }>
+      ).detail;
+      const error = normalizeModalError(detail?.error, detail?.errorType, detail?.walletId);
+      context.reportModalError(error);
+      emit('error', error);
+    };
+
+    onMounted(() => {
+      active = true;
+      context.manager.on('connect', onManagerConnect);
+      context.manager.on('disconnect', onManagerDisconnect);
+      if (context.manager.connected && context.manager.account)
+        onManagerConnect(context.manager.account);
+
+      void customElements.whenDefined('xrpl-wallet-connector').then(() => {
+        if (!active || !element.value) return;
+        element.value.setWalletManager(context.manager);
+        element.value.addEventListener('connecting', onConnecting);
+        element.value.addEventListener('error', onError);
+        context.registerConnector(element.value);
+        registered = element.value;
+      });
+    });
+
+    onBeforeUnmount(() => {
+      active = false;
+      context.manager.off('connect', onManagerConnect);
+      context.manager.off('disconnect', onManagerDisconnect);
+      if (!registered) return;
+      registered.removeEventListener('connecting', onConnecting);
+      registered.removeEventListener('error', onError);
+      context.unregisterConnector(registered);
+    });
+
+    return () =>
+      h('xrpl-wallet-connector', {
+        ...attrs,
+        ref: element,
+        'primary-wallet': props.primaryWallet,
+        wallets: props.wallets?.join(','),
+        style: [props.theme ? THEMES[props.theme] : undefined, props.cssVars, attrs.style],
+      });
+  },
+});
+
+function normalizeModalError(
+  value: unknown,
+  errorType?: 'rejected' | 'unavailable' | 'failed',
+  walletId?: string
+): WalletError {
+  if (isWalletError(value)) return value;
+  const walletName = walletId || 'wallet';
+  const originalError = value instanceof Error ? value : new Error(getErrorMessage(value));
+  if (errorType === 'rejected') return createWalletError.connectionRejected(walletName);
+  if (errorType === 'unavailable') {
+    return originalError.message.toLowerCase().includes('not installed')
+      ? createWalletError.notInstalled(walletName)
+      : createWalletError.notAvailable(walletName);
+  }
+  return createWalletError.connectionFailed(walletName, originalError);
+}

--- a/packages/vue/src/context.ts
+++ b/packages/vue/src/context.ts
@@ -8,7 +8,7 @@ import {
   type Plugin,
   type Ref,
 } from 'vue';
-import { WalletManager, isWalletError } from '@xrpl-connect/core';
+import { WalletErrorCode, WalletManager, isWalletError } from '@xrpl-connect/core';
 import type {
   AccountInfo,
   ConnectOptions,
@@ -19,8 +19,10 @@ import type {
 
 export interface WalletConnectorElement extends HTMLElement {
   setWalletManager(manager: WalletManager): void;
-  open(): void;
+  open(): Promise<void>;
+  openAndWait(): Promise<AccountInfo>;
   close(): void;
+  toggle(): void;
 }
 
 export interface XrplConnectContextValue {
@@ -57,7 +59,31 @@ export function createXrplConnect(config: XrplConnectConfig): Plugin {
       const connecting = shallowRef(false);
       const error = shallowRef<WalletError | null>(null);
       const connectors = new Set<WalletConnectorElement>();
+      const connectionAttempts = new Set<symbol>();
+      let modalConnecting = false;
       let active = true;
+
+      const syncConnecting = () => {
+        connecting.value = connectionAttempts.size > 0 || modalConnecting;
+      };
+      const beginConnectionAttempt = () => {
+        const attempt = Symbol('connectionAttempt');
+        connectionAttempts.add(attempt);
+        error.value = null;
+        syncConnecting();
+        return attempt;
+      };
+      const finishConnectionAttempt = (attempt: symbol, value?: unknown) => {
+        if (!connectionAttempts.delete(attempt)) return;
+        if (value !== undefined && isWalletError(value) && !manager.connected) error.value = value;
+        syncConnecting();
+      };
+      const cancelConnectionState = () => {
+        connectionAttempts.clear();
+        modalConnecting = false;
+        error.value = null;
+        syncConnecting();
+      };
 
       const sync = () => {
         connected.value = manager.connected;
@@ -66,14 +92,16 @@ export function createXrplConnect(config: XrplConnectConfig): Plugin {
       };
       const onConnect = () => {
         error.value = null;
-        connecting.value = false;
+        modalConnecting = false;
+        syncConnecting();
         sync();
       };
       const onDisconnect = () => sync();
       const onAccountChanged = () => sync();
       const onNetworkChanged = () => sync();
       const onError = (value: unknown) => {
-        connecting.value = false;
+        modalConnecting = false;
+        syncConnecting();
         if (isWalletError(value)) error.value = value;
       };
 
@@ -92,30 +120,34 @@ export function createXrplConnect(config: XrplConnectConfig): Plugin {
         connecting: readonly(connecting),
         error: readonly(error),
         async connect(walletId, options) {
-          connecting.value = true;
-          error.value = null;
+          const attempt = beginConnectionAttempt();
+          let failure: unknown;
           try {
             const connectedAccount = await manager.connect(walletId, options);
             if (!active && manager.connected) await manager.disconnect();
             return connectedAccount;
           } catch (value) {
-            if (active) {
-              connecting.value = false;
-              if (isWalletError(value)) error.value = value;
-            }
+            failure = value;
             throw value;
+          } finally {
+            if (active) finishConnectionAttempt(attempt, failure);
           }
         },
-        disconnect: () => manager.disconnect(),
+        async disconnect() {
+          cancelConnectionState();
+          await manager.disconnect();
+        },
         registerConnector: (element) => connectors.add(element),
         unregisterConnector: (element) => connectors.delete(element),
         reportModalConnecting() {
-          connecting.value = true;
+          modalConnecting = true;
           error.value = null;
+          syncConnecting();
         },
         reportModalError(value) {
-          connecting.value = false;
+          modalConnecting = false;
           error.value = value;
+          syncConnecting();
         },
         openModal() {
           const mountedConnectors = [...connectors];
@@ -131,14 +163,21 @@ export function createXrplConnect(config: XrplConnectConfig): Plugin {
 
       let reconnectDisposed = false;
       if (config.autoConnect && typeof window !== 'undefined') {
+        const attempt = beginConnectionAttempt();
         queueMicrotask(() => {
-          if (reconnectDisposed) return;
+          if (reconnectDisposed) {
+            finishConnectionAttempt(attempt);
+            return;
+          }
           void manager.reconnect().then(
             () => {
               if (!active && manager.connected) void manager.disconnect().catch(() => undefined);
+              if (active) finishConnectionAttempt(attempt);
             },
             (value: unknown) => {
-              if (active && isWalletError(value)) error.value = value;
+              const expectedOverlap =
+                isWalletError(value) && value.code === WalletErrorCode.ALREADY_CONNECTED;
+              if (active) finishConnectionAttempt(attempt, expectedOverlap ? undefined : value);
             }
           );
         });
@@ -147,6 +186,7 @@ export function createXrplConnect(config: XrplConnectConfig): Plugin {
       app.onUnmount(() => {
         active = false;
         reconnectDisposed = true;
+        cancelConnectionState();
         manager.off('connect', onConnect);
         manager.off('disconnect', onDisconnect);
         manager.off('accountChanged', onAccountChanged);

--- a/packages/vue/src/context.ts
+++ b/packages/vue/src/context.ts
@@ -1,0 +1,170 @@
+import {
+  inject,
+  markRaw,
+  readonly,
+  shallowRef,
+  type App,
+  type InjectionKey,
+  type Plugin,
+  type Ref,
+} from 'vue';
+import { WalletManager, isWalletError } from '@xrpl-connect/core';
+import type {
+  AccountInfo,
+  ConnectOptions,
+  NetworkInfo,
+  WalletError,
+  WalletManagerOptions,
+} from '@xrpl-connect/core';
+
+export interface WalletConnectorElement extends HTMLElement {
+  setWalletManager(manager: WalletManager): void;
+  open(): void;
+  close(): void;
+}
+
+export interface XrplConnectContextValue {
+  manager: WalletManager;
+  connected: Readonly<Ref<boolean>>;
+  account: Readonly<Ref<AccountInfo | null>>;
+  network: Readonly<Ref<NetworkInfo | null>>;
+  connecting: Readonly<Ref<boolean>>;
+  error: Readonly<Ref<WalletError | null>>;
+  connect(walletId: string, options?: ConnectOptions): Promise<AccountInfo>;
+  disconnect(): Promise<void>;
+}
+
+export type XrplConnectConfig = WalletManagerOptions;
+
+interface InternalContext extends XrplConnectContextValue {
+  registerConnector(element: WalletConnectorElement): void;
+  unregisterConnector(element: WalletConnectorElement): void;
+  reportModalConnecting(): void;
+  reportModalError(error: WalletError): void;
+  openModal(): void;
+  closeModal(): void;
+}
+
+const XrplConnectKey: InjectionKey<InternalContext> = Symbol('XrplConnect');
+
+export function createXrplConnect(config: XrplConnectConfig): Plugin {
+  return {
+    install(app: App) {
+      const manager = markRaw(new WalletManager({ ...config, autoConnect: false }));
+      const connected = shallowRef(manager.connected);
+      const account = shallowRef(manager.account);
+      const network = shallowRef(manager.account?.network ?? null);
+      const connecting = shallowRef(false);
+      const error = shallowRef<WalletError | null>(null);
+      const connectors = new Set<WalletConnectorElement>();
+      let active = true;
+
+      const sync = () => {
+        connected.value = manager.connected;
+        account.value = manager.account;
+        network.value = manager.account?.network ?? null;
+      };
+      const onConnect = () => {
+        error.value = null;
+        connecting.value = false;
+        sync();
+      };
+      const onDisconnect = () => sync();
+      const onAccountChanged = () => sync();
+      const onNetworkChanged = () => sync();
+      const onError = (value: unknown) => {
+        connecting.value = false;
+        if (isWalletError(value)) error.value = value;
+      };
+
+      manager.on('connect', onConnect);
+      manager.on('disconnect', onDisconnect);
+      manager.on('accountChanged', onAccountChanged);
+      manager.on('networkChanged', onNetworkChanged);
+      manager.on('error', onError);
+      sync();
+
+      const context: InternalContext = {
+        manager,
+        connected: readonly(connected),
+        account: readonly(account),
+        network: readonly(network),
+        connecting: readonly(connecting),
+        error: readonly(error),
+        async connect(walletId, options) {
+          connecting.value = true;
+          error.value = null;
+          try {
+            const connectedAccount = await manager.connect(walletId, options);
+            if (!active && manager.connected) await manager.disconnect();
+            return connectedAccount;
+          } catch (value) {
+            if (active) {
+              connecting.value = false;
+              if (isWalletError(value)) error.value = value;
+            }
+            throw value;
+          }
+        },
+        disconnect: () => manager.disconnect(),
+        registerConnector: (element) => connectors.add(element),
+        unregisterConnector: (element) => connectors.delete(element),
+        reportModalConnecting() {
+          connecting.value = true;
+          error.value = null;
+        },
+        reportModalError(value) {
+          connecting.value = false;
+          error.value = value;
+        },
+        openModal() {
+          const mountedConnectors = [...connectors];
+          mountedConnectors[mountedConnectors.length - 1]?.open();
+        },
+        closeModal() {
+          const mountedConnectors = [...connectors];
+          mountedConnectors[mountedConnectors.length - 1]?.close();
+        },
+      };
+
+      app.provide(XrplConnectKey, context);
+
+      let reconnectDisposed = false;
+      if (config.autoConnect && typeof window !== 'undefined') {
+        queueMicrotask(() => {
+          if (reconnectDisposed) return;
+          void manager.reconnect().then(
+            () => {
+              if (!active && manager.connected) void manager.disconnect().catch(() => undefined);
+            },
+            (value: unknown) => {
+              if (active && isWalletError(value)) error.value = value;
+            }
+          );
+        });
+      }
+
+      app.onUnmount(() => {
+        active = false;
+        reconnectDisposed = true;
+        manager.off('connect', onConnect);
+        manager.off('disconnect', onDisconnect);
+        manager.off('accountChanged', onAccountChanged);
+        manager.off('networkChanged', onNetworkChanged);
+        manager.off('error', onError);
+        connectors.clear();
+        void manager.disconnect().catch(() => undefined);
+      });
+    },
+  };
+}
+
+export function useXrplConnectContext(): InternalContext {
+  const context = inject(XrplConnectKey, null);
+  if (!context) {
+    throw new Error(
+      'xrpl-connect/vue: composables and <WalletConnector> require app.use(createXrplConnect(config)).'
+    );
+  }
+  return context;
+}

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,0 +1,41 @@
+import type {
+  SignedMessage,
+  SignedTransaction,
+  SubmittedTransaction,
+  Transaction,
+} from '@xrpl-connect/core';
+import { useXrplConnectContext } from './context';
+
+export { createXrplConnect } from './context';
+export { WalletConnector } from './WalletConnector';
+export type { WalletConnectorElement, XrplConnectConfig, XrplConnectContextValue } from './context';
+export type { WalletConnectorTheme } from './WalletConnector';
+
+export {
+  WalletError,
+  WalletErrorCode,
+  WalletErrorCategory,
+  isWalletError,
+} from '@xrpl-connect/core';
+
+export function useWallet() {
+  const { manager, connected, account, network, connecting, error, connect, disconnect } =
+    useXrplConnectContext();
+  return { manager, connected, account, network, connecting, error, connect, disconnect };
+}
+
+export function useSigner() {
+  const { manager } = useXrplConnectContext();
+  return {
+    sign: (transaction: Transaction): Promise<SignedTransaction> => manager.sign(transaction),
+    signAndSubmit: (transaction: Transaction): Promise<SubmittedTransaction> =>
+      manager.signAndSubmit(transaction),
+    signMessage: (message: string | Uint8Array): Promise<SignedMessage> =>
+      manager.signMessage(message),
+  };
+}
+
+export function useWalletModal() {
+  const { openModal, closeModal } = useXrplConnectContext();
+  return { open: openModal, close: closeModal };
+}

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,6 +1,6 @@
 import type {
-  SignedMessage,
-  SignedTransaction,
+  ManagedSignedMessage,
+  ManagedSignedTransaction,
   SubmittedTransaction,
   Transaction,
 } from '@xrpl-connect/core';
@@ -27,10 +27,11 @@ export function useWallet() {
 export function useSigner() {
   const { manager } = useXrplConnectContext();
   return {
-    sign: (transaction: Transaction): Promise<SignedTransaction> => manager.sign(transaction),
+    sign: (transaction: Transaction): Promise<ManagedSignedTransaction> =>
+      manager.sign(transaction),
     signAndSubmit: (transaction: Transaction): Promise<SubmittedTransaction> =>
       manager.signAndSubmit(transaction),
-    signMessage: (message: string | Uint8Array): Promise<SignedMessage> =>
+    signMessage: (message: string | Uint8Array): Promise<ManagedSignedMessage> =>
       manager.signMessage(message),
   };
 }

--- a/packages/vue/tests/ssr-smoke.mjs
+++ b/packages/vue/tests/ssr-smoke.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+
+delete globalThis.window;
+delete globalThis.document;
+delete globalThis.customElements;
+
+const esm = await import('../dist/index.mjs');
+assert.equal(typeof esm.createXrplConnect, 'function');
+assert.equal(typeof esm.WalletConnector, 'object');
+
+const cjs = await import('../dist/index.js');
+assert.equal(typeof cjs.createXrplConnect, 'function');
+assert.equal(typeof cjs.WalletConnector, 'object');

--- a/packages/vue/tests/vue.test.ts
+++ b/packages/vue/tests/vue.test.ts
@@ -1,13 +1,28 @@
 import { createApp, defineComponent, h, nextTick } from 'vue';
 import type { AccountInfo, WalletAdapter } from '@xrpl-connect/core';
 import { createWalletError, MemoryStorageAdapter, WalletErrorCode } from '@xrpl-connect/core';
-import { createXrplConnect, useSigner, useWallet, useWalletModal, WalletConnector } from '../src';
+import {
+  createXrplConnect,
+  useSigner,
+  useWallet,
+  useWalletModal,
+  WalletConnector,
+  type WalletConnectorElement,
+} from '../src';
 
 const ACCOUNT: AccountInfo = {
   address: 'rTEST',
   publicKey: 'EDTEST',
   network: { id: 'testnet', name: 'Testnet', rpcUrl: 'https://example.test' },
 };
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
 
 function makeAdapter(overrides: Partial<WalletAdapter> = {}): WalletAdapter {
   return {
@@ -73,9 +88,12 @@ describe('Vue plugin and composables', () => {
     await nextTick();
     expect(mounted.exposed.wallet.connected.value).toBe(true);
     expect(mounted.exposed.wallet.account.value).toEqual(ACCOUNT);
-    await expect(
-      mounted.exposed.signer.sign({ TransactionType: 'Payment' } as never)
-    ).resolves.toMatchObject({ txBlob: 'signed', signerAddress: ACCOUNT.address });
+    const signed = await mounted.exposed.signer.sign({ TransactionType: 'Payment' } as never);
+    const signedMessage = await mounted.exposed.signer.signMessage('hello');
+    expectTypeOf(signed.signerAddress).toEqualTypeOf<string>();
+    expectTypeOf(signedMessage.signerAddress).toEqualTypeOf<string>();
+    expect(signed).toMatchObject({ txBlob: 'signed', signerAddress: ACCOUNT.address });
+    expect(signedMessage).toMatchObject({ signature: 'signature', signerAddress: ACCOUNT.address });
 
     await mounted.exposed.wallet.disconnect();
     await nextTick();
@@ -145,9 +163,104 @@ describe('Vue plugin and composables', () => {
     expect(mounted.exposed.error.value?.code).toBe(WalletErrorCode.CONNECTION_REJECTED);
     mounted.app.unmount();
   });
+
+  it('keeps connecting true until every concurrent connection attempt settles', async () => {
+    const pending = deferred<AccountInfo>();
+    const connect = vi.fn(() => pending.promise);
+    const mounted = mountWithPlugin(() => useWallet(), [makeAdapter({ connect })]);
+
+    const first = mounted.exposed.connect('fake');
+    await vi.waitFor(() => expect(connect).toHaveBeenCalledTimes(1));
+    await expect(mounted.exposed.connect('fake')).rejects.toMatchObject({
+      code: WalletErrorCode.ALREADY_CONNECTED,
+    });
+    expect(mounted.exposed.connecting.value).toBe(true);
+
+    pending.resolve(ACCOUNT);
+    await expect(first).resolves.toEqual(ACCOUNT);
+    expect(mounted.exposed.connecting.value).toBe(false);
+    expect(mounted.exposed.error.value).toBeNull();
+    mounted.app.unmount();
+  });
+
+  it('clears connection state when a pending connection is cancelled', async () => {
+    const pending = deferred<AccountInfo>();
+    const connect = vi.fn(() => pending.promise);
+    const disconnect = vi.fn(async () => undefined);
+    const mounted = mountWithPlugin(() => useWallet(), [makeAdapter({ connect, disconnect })]);
+
+    const connection = mounted.exposed.connect('fake');
+    await vi.waitFor(() => expect(connect).toHaveBeenCalledTimes(1));
+    await mounted.exposed.disconnect();
+    expect(mounted.exposed.connecting.value).toBe(false);
+    expect(mounted.exposed.error.value).toBeNull();
+
+    pending.resolve(ACCOUNT);
+    await expect(connection).rejects.toMatchObject({ code: WalletErrorCode.NOT_CONNECTED });
+    expect(mounted.exposed.connecting.value).toBe(false);
+    expect(mounted.exposed.error.value).toBeNull();
+    mounted.app.unmount();
+  });
+
+  it('tracks auto-connect and suppresses a stale reconnect race error', async () => {
+    const storedState = deferred<string | null>();
+    const pendingConnection = deferred<AccountInfo>();
+    const connect = vi.fn(() => pendingConnection.promise);
+    const storage = {
+      get: vi.fn(() => storedState.promise),
+      set: vi.fn(async () => undefined),
+      remove: vi.fn(async () => undefined),
+      clear: vi.fn(async () => undefined),
+    };
+    let wallet: ReturnType<typeof useWallet> | undefined;
+    const root = document.createElement('div');
+    const app = createApp(
+      defineComponent({
+        setup() {
+          wallet = useWallet();
+          return () => null;
+        },
+      })
+    );
+    app.use(
+      createXrplConnect({ adapters: [makeAdapter({ connect })], autoConnect: true, storage })
+    );
+    app.mount(root);
+
+    expect(wallet!.connecting.value).toBe(true);
+    await vi.waitFor(() => expect(storage.get).toHaveBeenCalledTimes(1));
+    const manualConnection = wallet!.connect('fake');
+    await vi.waitFor(() => expect(connect).toHaveBeenCalledTimes(1));
+    storedState.resolve(
+      JSON.stringify({
+        walletId: 'fake',
+        account: ACCOUNT,
+        network: ACCOUNT.network,
+        timestamp: Date.now(),
+      })
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(wallet!.connecting.value).toBe(true);
+    expect(wallet!.error.value).toBeNull();
+
+    pendingConnection.resolve(ACCOUNT);
+    await expect(manualConnection).resolves.toEqual(ACCOUNT);
+    await vi.waitFor(() => expect(wallet!.connecting.value).toBe(false));
+    expect(wallet!.connected.value).toBe(true);
+    expect(wallet!.error.value).toBeNull();
+    app.unmount();
+  });
 });
 
 describe('<WalletConnector>', () => {
+  it('exposes the complete custom-element control contract', () => {
+    expectTypeOf<WalletConnectorElement['open']>().toEqualTypeOf<() => Promise<void>>();
+    expectTypeOf<WalletConnectorElement['openAndWait']>().toEqualTypeOf<
+      () => Promise<AccountInfo>
+    >();
+    expectTypeOf<WalletConnectorElement['toggle']>().toEqualTypeOf<() => void>();
+  });
+
   beforeAll(() => {
     if (customElements.get('xrpl-wallet-connector')) return;
     customElements.define(

--- a/packages/vue/tests/vue.test.ts
+++ b/packages/vue/tests/vue.test.ts
@@ -1,0 +1,225 @@
+import { createApp, defineComponent, h, nextTick } from 'vue';
+import type { AccountInfo, WalletAdapter } from '@xrpl-connect/core';
+import { createWalletError, MemoryStorageAdapter, WalletErrorCode } from '@xrpl-connect/core';
+import { createXrplConnect, useSigner, useWallet, useWalletModal, WalletConnector } from '../src';
+
+const ACCOUNT: AccountInfo = {
+  address: 'rTEST',
+  publicKey: 'EDTEST',
+  network: { id: 'testnet', name: 'Testnet', rpcUrl: 'https://example.test' },
+};
+
+function makeAdapter(overrides: Partial<WalletAdapter> = {}): WalletAdapter {
+  return {
+    id: 'fake',
+    name: 'Fake Wallet',
+    isAvailable: async () => true,
+    connect: async () => ACCOUNT,
+    disconnect: async () => undefined,
+    getAccount: async () => ACCOUNT,
+    getNetwork: async () => ACCOUNT.network,
+    sign: async () => ({ txBlob: 'signed' }),
+    signAndSubmit: async () => ({ hash: 'hash' }),
+    signMessage: async () => ({ signature: 'signature' }),
+    ...overrides,
+  };
+}
+
+function mountWithPlugin<T>(setup: () => T, adapters = [makeAdapter()]) {
+  let exposed: T | undefined;
+  const root = document.createElement('div');
+  document.body.append(root);
+  const app = createApp(
+    defineComponent({
+      setup() {
+        exposed = setup();
+        return () => null;
+      },
+    })
+  );
+  app.use(createXrplConnect({ adapters, storage: new MemoryStorageAdapter() }));
+  app.mount(root);
+  return {
+    app,
+    root,
+    get exposed() {
+      return exposed as T;
+    },
+  };
+}
+
+describe('Vue plugin and composables', () => {
+  it('rejects composables used without the plugin', () => {
+    const root = document.createElement('div');
+    const app = createApp(
+      defineComponent({
+        setup() {
+          useWallet();
+          return () => null;
+        },
+      })
+    );
+    app.config.errorHandler = (error) => {
+      throw error;
+    };
+    expect(() => app.mount(root)).toThrow(/app\.use\(createXrplConnect/);
+  });
+
+  it('reflects connection state and delegates signer actions', async () => {
+    const mounted = mountWithPlugin(() => ({ wallet: useWallet(), signer: useSigner() }));
+
+    expect(mounted.exposed.wallet.connected.value).toBe(false);
+    await mounted.exposed.wallet.connect('fake');
+    await nextTick();
+    expect(mounted.exposed.wallet.connected.value).toBe(true);
+    expect(mounted.exposed.wallet.account.value).toEqual(ACCOUNT);
+    await expect(
+      mounted.exposed.signer.sign({ TransactionType: 'Payment' } as never)
+    ).resolves.toMatchObject({ txBlob: 'signed', signerAddress: ACCOUNT.address });
+
+    await mounted.exposed.wallet.disconnect();
+    await nextTick();
+    expect(mounted.exposed.wallet.connected.value).toBe(false);
+    expect(mounted.exposed.wallet.account.value).toBeNull();
+    mounted.app.unmount();
+  });
+
+  it('keeps plugin instances isolated', async () => {
+    const first = mountWithPlugin(() => useWallet());
+    const second = mountWithPlugin(() => useWallet());
+
+    await first.exposed.connect('fake');
+    await nextTick();
+    expect(first.exposed.connected.value).toBe(true);
+    expect(second.exposed.connected.value).toBe(false);
+
+    first.app.unmount();
+    second.app.unmount();
+  });
+
+  it('attempts auto-connect once and releases listeners on teardown', async () => {
+    const storage = {
+      get: vi.fn(async () => null),
+      set: vi.fn(async () => undefined),
+      remove: vi.fn(async () => undefined),
+      clear: vi.fn(async () => undefined),
+    };
+    let wallet: ReturnType<typeof useWallet> | undefined;
+    const root = document.createElement('div');
+    const app = createApp(
+      defineComponent({
+        setup() {
+          wallet = useWallet();
+          return () => null;
+        },
+      })
+    );
+    app.use(createXrplConnect({ adapters: [makeAdapter()], autoConnect: true, storage }));
+    app.mount(root);
+    await vi.waitFor(() => expect(storage.get).toHaveBeenCalledTimes(1));
+    expect(wallet!.manager.listenerCount('connect')).toBe(1);
+
+    app.unmount();
+    expect(wallet!.manager.listenerCount('connect')).toBe(0);
+  });
+
+  it('disconnects its owned manager when the app unmounts', async () => {
+    const disconnect = vi.fn(async () => undefined);
+    const mounted = mountWithPlugin(() => useWallet(), [makeAdapter({ disconnect })]);
+    await mounted.exposed.connect('fake');
+
+    mounted.app.unmount();
+    await vi.waitFor(() => expect(disconnect).toHaveBeenCalledTimes(1));
+    expect(mounted.exposed.manager.connected).toBe(false);
+  });
+
+  it('exposes typed connection errors and clears connecting', async () => {
+    const error = createWalletError.connectionRejected('Fake Wallet');
+    const mounted = mountWithPlugin(
+      () => useWallet(),
+      [makeAdapter({ connect: async () => Promise.reject(error) })]
+    );
+
+    await expect(mounted.exposed.connect('fake')).rejects.toBe(error);
+    expect(mounted.exposed.connecting.value).toBe(false);
+    expect(mounted.exposed.error.value?.code).toBe(WalletErrorCode.CONNECTION_REJECTED);
+    mounted.app.unmount();
+  });
+});
+
+describe('<WalletConnector>', () => {
+  beforeAll(() => {
+    if (customElements.get('xrpl-wallet-connector')) return;
+    customElements.define(
+      'xrpl-wallet-connector',
+      class extends HTMLElement {
+        manager: unknown = null;
+        opened = false;
+        setWalletManager(manager: unknown) {
+          this.manager = manager;
+        }
+        open() {
+          this.opened = true;
+        }
+        close() {
+          this.opened = false;
+        }
+      }
+    );
+  });
+
+  it('binds the manager, forwards attributes/events, and supports modal control', async () => {
+    const onConnecting = vi.fn();
+    const onConnect = vi.fn();
+    const onError = vi.fn();
+    let wallet: ReturnType<typeof useWallet> | undefined;
+    let modal: ReturnType<typeof useWalletModal> | undefined;
+    const root = document.createElement('div');
+    const app = createApp(
+      defineComponent({
+        setup() {
+          wallet = useWallet();
+          modal = useWalletModal();
+          return () =>
+            h(WalletConnector, {
+              primaryWallet: 'fake',
+              wallets: ['fake'],
+              theme: 'purple',
+              class: 'connector',
+              onConnecting,
+              onConnect,
+              onError,
+            });
+        },
+      })
+    );
+    app.use(createXrplConnect({ adapters: [makeAdapter()], storage: new MemoryStorageAdapter() }));
+    app.mount(root);
+    const element = root.querySelector('xrpl-wallet-connector') as HTMLElement & {
+      manager: unknown;
+      opened: boolean;
+    };
+    await vi.waitFor(() => expect(element.manager).toBeTruthy());
+    expect(element.getAttribute('primary-wallet')).toBe('fake');
+    expect(element.getAttribute('wallets')).toBe('fake');
+    expect(element.className).toBe('connector');
+    expect(element.style.getPropertyValue('--xc-primary-color')).toBe('#a78bfa');
+
+    element.dispatchEvent(new CustomEvent('connecting', { detail: { walletId: 'fake' } }));
+    expect(wallet!.connecting.value).toBe(true);
+    expect(onConnecting).toHaveBeenCalledWith('fake');
+
+    const error = createWalletError.connectionRejected('Fake Wallet');
+    element.dispatchEvent(new CustomEvent('error', { detail: { error } }));
+    expect(wallet!.error.value).toBe(error);
+    expect(onError).toHaveBeenCalledWith(error);
+
+    await wallet!.connect('fake');
+    expect(onConnect).toHaveBeenCalledWith(ACCOUNT);
+    modal!.open();
+    expect(element.opened).toBe(true);
+    modal!.close();
+    expect(element.opened).toBe(false);
+    app.unmount();
+  });
+});

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["vite-plus/test"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/vue/vite.config.ts
+++ b/packages/vue/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite-plus';
+import { createPackConfig } from '../../vite.pack.config';
+
+export default defineConfig({
+  pack: createPackConfig({
+    deps: { neverBundle: ['vue'] },
+  }),
+  test: {
+    globals: true,
+    environment: 'jsdom',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,6 +401,28 @@ importers:
         specifier: npm:@voidzero-dev/vite-plus-core@0.2.5
         version: '@voidzero-dev/vite-plus-core@0.2.5(@types/node@20.19.21)(esbuild@0.28.1)(typescript@5.9.3)'
 
+  packages/vue:
+    dependencies:
+      xrpl:
+        specifier: ^3.0.0 || ^4.0.0
+        version: 4.4.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    devDependencies:
+      '@xrpl-connect/core':
+        specifier: workspace:*
+        version: link:../core
+      jsdom:
+        specifier: ^22.1.0
+        version: 22.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+      vue:
+        specifier: ^3.5.22
+        version: 3.5.24(typescript@5.9.3)
+      xrpl-connect:
+        specifier: workspace:*
+        version: link:../xrpl-connect
+
   packages/xrpl-connect:
     dependencies:
       '@xrpl-connect/adapter-crossmark':


### PR DESCRIPTION
## Summary
- add `@xrpl-connect/vue` with an app-scoped plugin, readonly reactive wallet state, signing and modal composables, and typed error exports
- add a typed Vue wrapper for the wallet connector custom element with theme, event, modal, and lifecycle integration
- cover state synchronization, app isolation, auto-connect, teardown, modal behavior, typed failures, and SSR imports
- replace manual Vue and Nuxt manager recipes with the supported first-party package

## Test plan
- [x] `pnpm --filter @xrpl-connect/vue build`
- [x] `pnpm --filter @xrpl-connect/vue type-check`
- [x] `pnpm --filter @xrpl-connect/vue lint`
- [x] `pnpm --filter @xrpl-connect/vue test`
- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm docs:build`
- [x] `pnpm test`

Fixes #113
