### PR TITLE
docs: prepare v1 documentation and Vue guides

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -3,7 +3,7 @@ import llmstxt from 'vitepress-plugin-llms';
 import { copyOrDownloadAsMarkdownButtons } from 'vitepress-plugin-llms';
 
 export default defineConfig({
-  title: ' ',
+  title: 'XRPL Connect',
   description: 'A framework-agnostic wallet connection toolkit for the XRP Ledger',
 
   lang: 'en-US',
@@ -46,7 +46,7 @@ export default defineConfig({
         ],
       },
       {
-        text: 'v0.6.0',
+        text: 'v1.0.0',
         link: 'https://github.com/XRPL-Commons/xrpl-connect/releases',
       },
     ],
@@ -55,13 +55,19 @@ export default defineConfig({
       {
         text: 'Start Here',
         items: [
+          { text: 'Introduction', link: '/' },
+          { text: 'Installation & Quick Start', link: '/guide/getting-started' },
+          { text: 'Core Concepts', link: '/concepts' },
           { text: 'Try It Out', link: '/try-it-out' },
-          { text: 'Concepts', link: '/concepts' },
         ],
       },
       {
-        text: 'Getting Started',
-        items: [{ text: 'Installation & Setup', link: '/guide/getting-started' }],
+        text: 'Build',
+        items: [
+          { text: 'Wallets & Capabilities', link: '/guide/wallets' },
+          { text: 'Transactions & Signing', link: '/guide/transactions' },
+          { text: 'Production & Security', link: '/guide/production' },
+        ],
       },
       {
         text: 'Framework Integration',
@@ -88,7 +94,10 @@ export default defineConfig({
       },
       {
         text: 'Reference',
-        items: [{ text: 'API Reference', link: '/guide/api-reference' }],
+        items: [
+          { text: 'API Reference', link: '/guide/api-reference' },
+          { text: 'Migrating to v1.0', link: '/guide/migration-v1' },
+        ],
       },
     ],
 
@@ -96,7 +105,7 @@ export default defineConfig({
 
     footer: {
       message: 'Released under the MIT License.',
-      copyright: 'Copyright © 2025 XRPL Commons',
+      copyright: 'Copyright © 2026 XRPL Commons',
     },
 
     search: {
@@ -108,6 +117,14 @@ export default defineConfig({
     lineNumbers: true,
     config(md) {
       md.use(copyOrDownloadAsMarkdownButtons);
+    },
+  },
+
+  vue: {
+    template: {
+      compilerOptions: {
+        isCustomElement: (tag) => tag === 'xrpl-wallet-connector',
+      },
     },
   },
 

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,7 +1,6 @@
 import { h } from 'vue';
 import type { Theme } from 'vitepress';
 import DefaultTheme from 'vitepress/theme';
-import CopyOrDownloadAsMarkdownButtons from 'vitepress-plugin-llms/vitepress-components/CopyOrDownloadAsMarkdownButtons.vue';
 import DownloadLLMsFullDoc from './DownloadLLMsFullDoc.vue';
 import './custom.css';
 
@@ -13,19 +12,24 @@ export default {
     return h(DefaultTheme.Layout, null, {});
   },
   async enhanceApp({ app }) {
-    // Register CopyOrDownloadAsMarkdownButtons component
-    app.component('CopyOrDownloadAsMarkdownButtons', CopyOrDownloadAsMarkdownButtons);
+    if (typeof window !== 'undefined') {
+      const { default: CopyOrDownloadAsMarkdownButtons } =
+        await import('vitepress-plugin-llms/vitepress-components/CopyOrDownloadAsMarkdownButtons.vue');
+      app.component('CopyOrDownloadAsMarkdownButtons', CopyOrDownloadAsMarkdownButtons);
+    } else {
+      app.component('CopyOrDownloadAsMarkdownButtons', { render: () => null });
+    }
 
     // Register DownloadLLMsFullDoc component
     app.component('DownloadLLMsFullDoc', DownloadLLMsFullDoc);
 
-    // Only import web components on client side
+    // Register the web component without loading every wallet adapter.
     if (typeof window !== 'undefined' && !componentImported) {
       try {
-        await import('xrpl-connect');
+        await import('@xrpl-connect/ui');
         componentImported = true;
       } catch (err) {
-        console.error('Failed to import xrpl-connect:', err);
+        console.error('Failed to register XRPL Connect web components:', err);
       }
     }
 

--- a/docs/components/ThemeBuilder.vue
+++ b/docs/components/ThemeBuilder.vue
@@ -292,6 +292,7 @@ const copyToClipboard = async () => {
 
 onMounted(async () => {
   try {
+    await customElements.whenDefined('xrpl-wallet-connector');
     const walletManager = await getWalletManager();
 
     // Set wallet manager on preview connector

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -109,7 +109,7 @@ const adapter = new XamanAdapter({
 });
 ```
 
-**Features:** Transaction signing, message signing, QR codes, push notifications
+**Features:** Transaction signing, live account refresh, QR codes, and push notifications. Arbitrary message signing is not supported.
 
 #### Crossmark Adapter
 
@@ -122,6 +122,21 @@ const adapter = new CrossmarkAdapter();
 ```
 
 **Features:** Transaction signing, message signing, no API keys required
+
+#### MetaMask Snap Adapter
+
+Connect to XRPL through MetaMask and the XRPL Snap.
+
+```javascript
+import { MetaMaskSnapAdapter } from 'xrpl-connect';
+
+const adapter = new MetaMaskSnapAdapter({
+  // Optional: override this when developing a custom Snap.
+  snapId: 'npm:xrpl-snap',
+});
+```
+
+**Features:** Transaction signing and message signing through MetaMask. No application API key is required.
 
 #### GemWallet Adapter
 
@@ -199,6 +214,7 @@ const walletManager = new WalletManager({
     new CrossmarkAdapter(),
     new GemWalletAdapter(),
     new WalletConnectAdapter({ projectId: 'YOUR_PROJECT_ID' }),
+    new MetaMaskSnapAdapter(),
   ],
   network: 'testnet',
 });

--- a/docs/guide/adapter-integration.md
+++ b/docs/guide/adapter-integration.md
@@ -84,7 +84,7 @@ Use the Xaman adapter as a template. Replace `my-wallet` and `MyWallet` with you
 ```json
 {
   "name": "@xrpl-connect/adapter-my-wallet",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "My Wallet adapter for XRPL Connect",
   "author": "Your Name",
   "license": "MIT",

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -449,6 +449,34 @@ the same typed `WalletError` values as the core manager.
 `wallets`, `theme`, `cssVars`, `style`, `className`, `onConnecting`, `onConnect`,
 and `onError`. See the [React guide](/guide/frameworks/react) for a complete setup.
 
+## Vue API
+
+Install `@xrpl-connect/vue` alongside `xrpl-connect` for Vue 3 and Nuxt applications.
+
+### createXrplConnect
+
+`createXrplConnect(config)` creates an application-scoped Vue plugin and one isolated
+`WalletManager`. Install it with `app.use(...)` before mounting the application. All Vue
+composables and `<WalletConnector>` must run beneath that installation.
+
+### Composables
+
+- `useWallet()` returns the manager, readonly `connected`, `account`, `network`, `connecting`, and `error` refs, plus `connect` and `disconnect`.
+- `useSigner()` returns `sign`, `signAndSubmit`, and `signMessage`.
+- `useWalletModal()` returns `open` and `close` for the most recently mounted connector.
+
+Call `connect(walletId, options?)` for a headless connection flow, or mount at least one
+connector before using the modal composable. Gate optional signing operations with
+`manager.supports(...)`.
+
+### WalletConnector
+
+`<WalletConnector />` accepts `primaryWallet`, `wallets`, `theme`, and `cssVars`, and emits
+`connecting`, `connect`, and typed `error` events. Public types include `XrplConnectConfig`,
+`XrplConnectContextValue`, `WalletConnectorElement`, and `WalletConnectorTheme`. The package
+also re-exports the core wallet error classes, enums, and `isWalletError` guard. See the
+[Vue guide](/guide/frameworks/vue) and [Nuxt guide](/guide/frameworks/nuxt).
+
 ## Direct Wallet SDK Access
 
 `xrpl-connect` exposes the complete upstream APIs used by its Xaman, Crossmark,

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -226,6 +226,14 @@ close(): void
 
 Close any open modals.
 
+#### toggle()
+
+```typescript
+toggle(): void
+```
+
+Open the wallet modal when it is closed, or close it when it is open.
+
 Wallet choices are ordered by most recent successful use. The component stores
 that ordering in `localStorage` under `xrpl-connect:mru-wallets`; an explicit
 `primary-wallet` still takes precedence.
@@ -278,9 +286,17 @@ Emitted when connection fails.
 
 ```javascript
 connector.addEventListener('error', (e) => {
-  console.error('Error:', e.detail.error.message);
+  console.error(e.detail.walletId, e.detail.errorType, e.detail.error.message);
 });
 ```
+
+Event details are typed as follows:
+
+| Event        | `detail` payload                                                    |
+| ------------ | ------------------------------------------------------------------- |
+| `connecting` | `{ walletId: string }`                                              |
+| `connected`  | `{ walletId: string }` plus Ledger account metadata when applicable |
+| `error`      | `{ error: WalletError, walletId: string, errorType: string }`       |
 
 ## Wallet Adapters
 
@@ -390,6 +406,48 @@ const adapter = new OtsuAdapter();
 
 **Supported Features:** Transaction signing, message signing, and live account
 refresh
+
+### MetaMask Snap Adapter
+
+```typescript
+import { MetaMaskSnapAdapter } from 'xrpl-connect';
+
+const adapter = new MetaMaskSnapAdapter({
+  // Optional. Defaults to the production XRPL Snap.
+  snapId: 'npm:xrpl-snap',
+});
+```
+
+**Supported Features:** Transaction signing and message signing through
+MetaMask. The adapter does not require an application API key.
+
+Use a custom `snapId` only when developing or auditing a different Snap.
+
+## React API
+
+Install `@xrpl-connect/react` alongside `xrpl-connect` when using React.
+
+### XrplConnectProvider
+
+`<XrplConnectProvider config={config}>` creates one `WalletManager` and shares it
+with its subtree. `config` accepts the core `WalletManagerOptions`: `adapters`,
+`network`, `autoConnect`, `storage`, and `logger`. The manager is created once on
+mount; use a React `key` when an intentional configuration change must rebuild it.
+
+### Hooks
+
+- `useWallet()` returns `{ manager, connected, account, network, connecting, error, connect, disconnect }`.
+- `useSigner()` returns `{ sign, signAndSubmit, signMessage }`.
+- `useWalletModal()` returns `{ open, close }` for the mounted connector modal.
+
+All hooks must be used below `XrplConnectProvider`. Signing methods reject with
+the same typed `WalletError` values as the core manager.
+
+### WalletConnector
+
+`<WalletConnector />` wraps the web component. It accepts `primaryWallet`,
+`wallets`, `theme`, `cssVars`, `style`, `className`, `onConnecting`, `onConnect`,
+and `onError`. See the [React guide](/guide/frameworks/react) for a complete setup.
 
 ## Direct Wallet SDK Access
 

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -17,6 +17,9 @@ The React example application demonstrates the recommended v1 integration, inclu
 - Real-time event logging
 - Proper TypeScript integration with web components
 
+For Vue 3 and Nuxt, follow the maintained [Vue guide](/guide/frameworks/vue) and
+[Nuxt guide](/guide/frameworks/nuxt).
+
 **Check out the full example:** [`examples/react/`](https://github.com/XRPL-Commons/xrpl-connect/tree/main/examples/react)
 
 The example includes detailed setup instructions, best practices for React integration, and demonstrates how to properly handle web component lifecycle in React applications.

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -8,11 +8,11 @@ Real-world examples and pre-built theme configurations.
 
 ## Live React Example
 
-We now have a comprehensive React example application that demonstrates all features of XRPL-Connect, including:
+The React example application demonstrates the recommended v1 integration, including:
 
-- Multiple wallet adapter support (Xaman, WalletConnect, Crossmark, GemWallet, Ledger)
-- Custom React hooks for wallet management
-- Transaction and message signing
+- Multiple wallet adapters
+- The official provider and hooks from `@xrpl-connect/react`
+- Capability-aware transaction and message signing
 - Dynamic theme customization
 - Real-time event logging
 - Proper TypeScript integration with web components
@@ -169,7 +169,7 @@ Complete example with wallet connection and transaction signing:
 
 ## React Example
 
-> **Note:** For a complete, production-ready React example with all features, see the [React example application](https://github.com/XRPL-Commons/xrpl-connect/tree/main/examples/react).
+> **Note:** For the maintained v1 React integration, use the [React guide](/guide/frameworks/react) and [React example application](https://github.com/XRPL-Commons/xrpl-connect/tree/main/examples/react).
 
 ```jsx
 import { useEffect, useRef, useState } from 'react';

--- a/docs/guide/frameworks/nuxt.md
+++ b/docs/guide/frameworks/nuxt.md
@@ -10,7 +10,7 @@ XRPL Connect's modal is a browser custom element. In Nuxt, register it and insta
 ## Installation
 
 ```bash
-npm install @xrpl-connect/vue xrpl-connect xrpl vue
+npm install @xrpl-connect/vue@^1.0.0 xrpl-connect@^1.0.0 xrpl vue
 ```
 
 ## Client plugin
@@ -49,6 +49,10 @@ export default defineNuxtConfig({
 });
 ```
 
+The Xaman API key and WalletConnect project ID are public application identifiers. Restrict
+them by origin in their provider dashboards, and never place seeds, signing material, or API
+secrets in `runtimeConfig.public`.
+
 The `.client.ts` suffix prevents wallet adapters and custom-element registration from running
 during server rendering. `@xrpl-connect/vue` itself remains safe to import in universal modules.
 
@@ -84,7 +88,7 @@ Use `useSigner()` in any descendant component:
 
 ```vue
 <script setup lang="ts">
-import { useSigner, useWallet } from '@xrpl-connect/vue';
+import { isWalletError, useSigner, useWallet, WalletErrorCode } from '@xrpl-connect/vue';
 
 const { account, connected } = useWallet();
 const { signAndSubmit } = useSigner();
@@ -92,16 +96,29 @@ const { signAndSubmit } = useSigner();
 async function sendPayment() {
   if (!connected.value || !account.value) return;
 
-  await signAndSubmit({
-    TransactionType: 'Payment',
-    Account: account.value.address,
-    Destination: 'rN7n7otQDd6FczFgLdlqtyMVrn3HMfXoQT',
-    Amount: '1000000',
-  });
+  try {
+    await signAndSubmit({
+      TransactionType: 'Payment',
+      Account: account.value.address,
+      Destination: 'rN7n7otQDd6FczFgLdlqtyMVrn3HMfXoQT',
+      Amount: '1000000',
+    });
+  } catch (error) {
+    if (isWalletError(error) && error.code === WalletErrorCode.SIGN_REJECTED) return;
+    throw error;
+  }
 }
 </script>
 ```
 
+Signing rejects with typed `WalletError` values. Use `isWalletError()` to distinguish user
+rejection from failures, and check `manager.supports(...)` before exposing optional operations
+such as message signing. The [Vue guide](/guide/frameworks/vue) shows the complete pattern.
+
 The plugin owns one manager for the Nuxt application and removes its listeners and active
 connection when the Vue app unmounts. Do not create an additional `WalletManager` in a
 component or Pinia store.
+
+`autoConnect: true` restores the minimal persisted connection record on the client; it does
+not reconnect during SSR or store private signing material. See the
+[production guide](/guide/production) for deployment and storage guidance.

--- a/docs/guide/frameworks/react.md
+++ b/docs/guide/frameworks/react.md
@@ -1,754 +1,158 @@
 ---
-description: Integrate XRPL-Connect into your React application using hooks and best practices.
+description: Integrate XRPL Connect v1.0 with React and Next.js using the official provider, hooks, and connector.
 ---
 
-# React & Next.js
+# React and Next.js
 
-Integrate XRPL-Connect into your React application with hooks. This guide covers both standard React and Next.js applications.
+Use the official React bindings instead of building a custom context around the web component.
 
-## Recommended: `@xrpl-connect/react`
-
-The easiest way to use XRPL-Connect in React is the official bindings package — a
-provider that owns a single `WalletManager`, ready-made hooks, and a themeable
-`<WalletConnector>` modal. You no longer need to hand-roll a context/hooks layer.
+## Install
 
 ```bash
-npm install @xrpl-connect/react xrpl-connect xrpl
+pnpm add xrpl-connect@^1.0.0 @xrpl-connect/react@^1.0.0 xrpl react react-dom
 ```
 
+## Configure the provider
+
+Create the adapter configuration once, outside component render. Recreating it on every render can replace connection ownership and restart automatic reconnection.
+
 ```tsx
-// main.tsx — import xrpl-connect once to register the web component
-import 'xrpl-connect';
-import { XamanAdapter, CrossmarkAdapter } from 'xrpl-connect';
-import { XrplConnectProvider } from '@xrpl-connect/react';
+import { XrplConnectProvider, WalletConnector } from '@xrpl-connect/react';
+import {
+  CrossmarkAdapter,
+  MetaMaskSnapAdapter,
+  WalletConnectAdapter,
+  XamanAdapter,
+} from 'xrpl-connect';
 
 const config = {
-  adapters: [new XamanAdapter({ apiKey: 'YOUR_KEY' }), new CrossmarkAdapter()],
-  network: 'testnet',
+  adapters: [
+    new XamanAdapter({ apiKey: import.meta.env.VITE_XAMAN_API_KEY }),
+    new CrossmarkAdapter(),
+    new WalletConnectAdapter({
+      projectId: import.meta.env.VITE_WALLETCONNECT_PROJECT_ID,
+    }),
+    new MetaMaskSnapAdapter(),
+  ],
+  network: 'testnet' as const,
   autoConnect: true,
 };
 
-createRoot(document.getElementById('root')!).render(
-  <XrplConnectProvider config={config}>
-    <App />
-  </XrplConnectProvider>
-);
+export function App() {
+  return (
+    <XrplConnectProvider config={config}>
+      <Header />
+      <WalletConnector
+        wallets={['xaman', 'crossmark', 'walletconnect', 'metamask-snap']}
+        theme="dark"
+        onError={(error) => console.error(error.code, error.message)}
+      />
+    </XrplConnectProvider>
+  );
+}
 ```
+
+## Wallet state
+
+`useWallet()` provides the stable manager, reactive state, and direct connect/disconnect actions.
 
 ```tsx
-// App.tsx
-import { useWallet, useSigner, useWalletModal, WalletConnector } from '@xrpl-connect/react';
+import { useWallet, useWalletModal } from '@xrpl-connect/react';
 
-export function App() {
-  const { connected, account, disconnect, error } = useWallet();
+function Header() {
+  const { connected, connecting, account, network, error, disconnect } = useWallet();
   const { open } = useWalletModal();
+
+  if (!connected || !account) {
+    return (
+      <button onClick={open} disabled={connecting}>
+        Connect wallet
+      </button>
+    );
+  }
+
+  return (
+    <div>
+      <span>{account.address}</span>
+      <span>{network?.name}</span>
+      {error && <span role="alert">{error.message}</span>}
+      <button onClick={() => void disconnect()}>Disconnect</button>
+    </div>
+  );
+}
+```
+
+The hook returns `manager`, `connected`, `account`, `network`, `connecting`, `error`, `connect`, and `disconnect`.
+
+## Signing
+
+```tsx
+import { WalletErrorCode, isWalletError } from 'xrpl-connect';
+import { useSigner, useWallet } from '@xrpl-connect/react';
+
+function PaymentButton({ destination }: { destination: string }) {
+  const { account } = useWallet();
   const { signAndSubmit } = useSigner();
 
-  return (
-    <>
-      {connected ? (
-        <button onClick={disconnect}>Disconnect {account?.address}</button>
-      ) : (
-        <button onClick={open}>Connect Wallet</button>
-      )}
-      {error && (
-        <p>
-          Error [{error.code}]: {error.message}
-        </p>
-      )}
-      <WalletConnector theme="dark" onError={(e) => console.error(e.code, e.category)} />
-    </>
-  );
-}
-```
-
-**Hooks:** `useWallet()` (`connected`, `account`, `network`, `connect`, `disconnect`,
-`connecting`, `error`), `useSigner()` (`sign`, `signAndSubmit`, `signMessage` — reject
-with a typed `WalletError`), and `useWalletModal()` (`open`, `close`).
-
-**`<WalletConnector>` props:** `primaryWallet`, `wallets`, `theme`, `cssVars`,
-`onConnecting`, `onConnect`, `onError` — all typed.
-
-> **Next.js (App Router):** these are client components — add `'use client'` to the
-> file that renders the provider/connector.
-
-See the package README for the full API. The manual integration below remains valid
-if you'd rather wire the `WalletManager` and web component yourself.
-
-## Complete Example Application
-
-We provide a comprehensive React example application that demonstrates all XRPL-Connect features:
-
-**📁 [View the React Example →](https://github.com/XRPL-Commons/xrpl-connect/tree/main/examples/react)**
-
-### What's Included
-
-The example demonstrates:
-
-- ✅ Multiple wallet adapter support (Xaman, WalletConnect, Crossmark, GemWallet, Ledger)
-- ✅ Official provider and hooks from `@xrpl-connect/react`
-- ✅ React Context API for global wallet state
-- ✅ Transaction and message signing forms
-- ✅ Dynamic theme switching
-- ✅ Real-time event logging
-- ✅ Typed React wrapper around the wallet-connector web component
-- ✅ Demo-specific activity and status state kept separate from wallet state
-
-### Project Structure
-
-```
-examples/react/
-├── src/
-│   ├── App.tsx                      # Main app component
-│   ├── main.tsx                     # Entry point
-│   ├── components/
-│   │   ├── WalletConnector.tsx     # Web component wrapper
-│   │   ├── AccountInfo.tsx         # Display connected account
-│   │   ├── TransactionForm.tsx     # Sign transactions
-│   │   ├── MessageSignForm.tsx     # Sign messages
-│   │   ├── ThemeSelector.tsx       # Switch themes
-│   │   └── EventLog.tsx            # Display wallet events
-│   ├── context/
-│   │   └── DemoContext.tsx         # Demo activity/status state only
-│   └── types/
-│       └── index.ts                # TypeScript definitions
-```
-
-## Manual integration
-
-The remainder of this guide shows how to build the provider and hooks yourself.
-Use this approach only when you need lifecycle behavior beyond the official package.
-
-### Installation
-
-```bash
-npm install xrpl-connect xrpl
-```
-
-## Quick Start
-
-### 1. Register Web Components
-
-**File: `src/main.tsx`**
-
-In your entry point, import `xrpl-connect` to register the web component:
-
-```typescript
-// src/main.tsx
-import 'xrpl-connect'; // Register web components
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App';
-
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
-```
-
-### 2. TypeScript Declarations
-
-**File: `src/vite-env.d.ts`** (or `src/react-app-env.d.ts` for Create React App)
-
-Create TypeScript declarations for the web component:
-
-```typescript
-// src/vite-env.d.ts
-/// <reference types="vite/client" />
-
-declare namespace JSX {
-  interface IntrinsicElements {
-    'xrpl-wallet-connector': React.DetailedHTMLProps<
-      React.HTMLAttributes<HTMLElement> & {
-        'primary-wallet'?: string;
-        ref?: React.Ref<any>;
-      },
-      HTMLElement
-    >;
-  }
-}
-```
-
-### 3. Create Wallet Context
-
-**File: `src/context/WalletContext.tsx`**
-
-Create a context to share wallet state across your app:
-
-```typescript
-// src/context/WalletContext.tsx
-import { createContext, useContext, useState, useCallback, ReactNode } from 'react';
-import type { WalletManager } from 'xrpl-connect';
-
-interface AccountInfo {
-  address: string;
-  network: string;
-  walletName: string;
-}
-
-interface WalletContextType {
-  walletManager: WalletManager | null;
-  isConnected: boolean;
-  accountInfo: AccountInfo | null;
-  setWalletManager: (manager: WalletManager) => void;
-  setIsConnected: (connected: boolean) => void;
-  setAccountInfo: (info: AccountInfo | null) => void;
-}
-
-const WalletContext = createContext<WalletContextType | undefined>(undefined);
-
-export function WalletProvider({ children }: { children: ReactNode }) {
-  const [walletManager, setWalletManagerState] = useState<WalletManager | null>(null);
-  const [isConnected, setIsConnected] = useState(false);
-  const [accountInfo, setAccountInfo] = useState<AccountInfo | null>(null);
-
-  const setWalletManager = useCallback((manager: WalletManager) => {
-    setWalletManagerState(manager);
-  }, []);
-
-  return (
-    <WalletContext.Provider
-      value={{
-        walletManager,
-        isConnected,
-        accountInfo,
-        setWalletManager,
-        setIsConnected,
-        setAccountInfo,
-      }}
-    >
-      {children}
-    </WalletContext.Provider>
-  );
-}
-
-export function useWallet() {
-  const context = useContext(WalletContext);
-  if (context === undefined) {
-    throw new Error('useWallet must be used within a WalletProvider');
-  }
-  return context;
-}
-```
-
-### 4. Create WalletManager Hook
-
-**File: `src/hooks/useWalletManager.ts`**
-
-Create a hook to initialize and manage the WalletManager:
-
-```typescript
-// src/hooks/useWalletManager.ts
-import { useEffect } from 'react';
-import {
-  WalletManager,
-  XamanAdapter,
-  WalletConnectAdapter,
-  CrossmarkAdapter,
-  GemWalletAdapter,
-  LedgerAdapter,
-} from 'xrpl-connect';
-import { useWallet } from '../context/WalletContext';
-
-// Configuration - ADD YOUR API KEYS HERE
-const XAMAN_API_KEY = 'YOUR_XAMAN_API_KEY';
-const WALLETCONNECT_PROJECT_ID = 'YOUR_WALLETCONNECT_PROJECT_ID';
-
-export function useWalletManager() {
-  const { setWalletManager, setIsConnected, setAccountInfo } = useWallet();
-
-  useEffect(() => {
-    const manager = new WalletManager({
-      adapters: [
-        new XamanAdapter({ apiKey: XAMAN_API_KEY }),
-        new WalletConnectAdapter({ projectId: WALLETCONNECT_PROJECT_ID }),
-        new CrossmarkAdapter(),
-        new GemWalletAdapter(),
-        new LedgerAdapter(), // Hardware wallet support
-      ],
-      network: 'testnet',
-      autoConnect: true,
-      logger: { level: 'info' },
-    });
-
-    setWalletManager(manager);
-
-    // Event listeners
-    manager.on('connect', (account) => {
-      updateConnectionState(manager);
-    });
-
-    manager.on('disconnect', () => {
-      updateConnectionState(manager);
-    });
-
-    // Check initial connection
-    if (manager.connected) {
-      updateConnectionState(manager);
-    }
-  }, [setWalletManager, setIsConnected, setAccountInfo]);
-
-  const updateConnectionState = (manager: WalletManager) => {
-    const connected = manager.connected;
-    setIsConnected(connected);
-
-    if (connected) {
-      const account = manager.account;
-      const wallet = manager.wallet;
-
-      if (account && wallet) {
-        setAccountInfo({
-          address: account.address,
-          network: `${account.network.name} (${account.network.id})`,
-          walletName: wallet.name,
-        });
-      }
-    } else {
-      setAccountInfo(null);
-    }
-  };
-}
-```
-
-### 5. Create Web Component Connector Hook
-
-**File: `src/hooks/useWalletConnector.ts`**
-
-Create a hook to properly connect the web component with the WalletManager:
-
-```typescript
-// src/hooks/useWalletConnector.ts
-import { useEffect, useRef } from 'react';
-import type { WalletManager } from 'xrpl-connect';
-
-export function useWalletConnector(walletManager: WalletManager | null) {
-  const walletConnectorRef = useRef<HTMLElement | null>(null);
-
-  useEffect(() => {
-    if (!walletConnectorRef.current || !walletManager) return;
-
-    const setupConnector = async () => {
-      // Wait for custom element to be defined
-      await customElements.whenDefined('xrpl-wallet-connector');
-
-      // Small delay to ensure element is fully initialized
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      if (
-        walletConnectorRef.current &&
-        typeof (walletConnectorRef.current as any).setWalletManager === 'function'
-      ) {
-        (walletConnectorRef.current as any).setWalletManager(walletManager);
-      }
-    };
-
-    setupConnector();
-  }, [walletManager]);
-
-  return walletConnectorRef;
-}
-```
-
-### 6. Create Wallet Connector Component
-
-**File: `src/components/WalletConnector.tsx`**
-
-Wrap the web component in a React component:
-
-```typescript
-// src/components/WalletConnector.tsx
-import { useState } from 'react';
-import { useWallet } from '../context/WalletContext';
-import { useWalletConnector } from '../hooks/useWalletConnector';
-
-const THEMES = {
-  dark: {
-    '--xc-background-color': '#1a202c',
-    '--xc-text-color': '#F5F4E7',
-    '--xc-primary-color': '#3b99fc',
-  },
-  light: {
-    '--xc-background-color': '#ffffff',
-    '--xc-text-color': '#111111',
-    '--xc-primary-color': '#2563eb',
-  },
-};
-
-export function WalletConnector() {
-  const { walletManager } = useWallet();
-  const walletConnectorRef = useWalletConnector(walletManager);
-  const [currentTheme] = useState<'dark' | 'light'>('dark');
-
-  return (
-    <xrpl-wallet-connector
-      ref={walletConnectorRef}
-      id="wallet-connector"
-      style={{
-        ...THEMES[currentTheme],
-        '--xc-border-radius': '12px',
-      } as any}
-      primary-wallet="xaman"
-    />
-  );
-}
-```
-
-### 7. Put It All Together
-
-**File: `src/App.tsx`**
-
-Create your main app component:
-
-```typescript
-// src/App.tsx
-import { WalletProvider, useWallet } from './context/WalletContext';
-import { useWalletManager } from './hooks/useWalletManager';
-import { WalletConnector } from './components/WalletConnector';
-
-function AppContent() {
-  const { accountInfo, isConnected } = useWallet();
-  useWalletManager();
-
-  return (
-    <div>
-      <h1>XRPL Connect Demo</h1>
-
-      <WalletConnector />
-
-      {isConnected && accountInfo && (
-        <div>
-          <h2>Connected Account</h2>
-          <p><strong>Address:</strong> {accountInfo.address}</p>
-          <p><strong>Network:</strong> {accountInfo.network}</p>
-          <p><strong>Wallet:</strong> {accountInfo.walletName}</p>
-        </div>
-      )}
-    </div>
-  );
-}
-
-function App() {
-  return (
-    <WalletProvider>
-      <AppContent />
-    </WalletProvider>
-  );
-}
-
-export default App;
-```
-
-## Signing Transactions
-
-**File: `src/components/TransactionForm.tsx`**
-
-Create a transaction form component:
-
-```typescript
-// src/components/TransactionForm.tsx
-import { useState, FormEvent } from 'react';
-import { useWallet } from '../context/WalletContext';
-
-export function TransactionForm() {
-  const { walletManager, isConnected } = useWallet();
-  const [destination, setDestination] = useState('');
-  const [amount, setAmount] = useState('');
-  const [result, setResult] = useState('');
-
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-
-    if (!walletManager || !walletManager.account) return;
+  const pay = async () => {
+    if (!account) return;
 
     try {
-      setResult('Signing transaction...');
-
-      const txResult = await walletManager.signAndSubmit({
+      const result = await signAndSubmit({
         TransactionType: 'Payment',
-        Account: walletManager.account.address,
+        Account: account.address,
         Destination: destination,
-        Amount: amount,
+        Amount: '1000000',
       });
-
-      setResult(`Success! Hash: ${(txResult as any).hash}`);
-    } catch (error: any) {
-      setResult(`Failed: ${error.message}`);
+      console.log(result.hash);
+    } catch (error) {
+      if (isWalletError(error) && error.code === WalletErrorCode.SIGN_REJECTED) return;
+      throw error;
     }
   };
 
-  if (!isConnected) {
-    return null;
-  }
-
   return (
-    <form onSubmit={handleSubmit}>
-      <div>
-        <label>Destination Address</label>
-        <input
-          type="text"
-          value={destination}
-          onChange={(e) => setDestination(e.target.value)}
-          placeholder="rN7n7otQDd6FczFgLdlqtyMVrn3HMfXoQT"
-          required
-        />
-      </div>
-      <div>
-        <label>Amount (drops)</label>
-        <input
-          type="number"
-          value={amount}
-          onChange={(e) => setAmount(e.target.value)}
-          placeholder="1000000"
-          required
-        />
-        <small>1 XRP = 1,000,000 drops</small>
-      </div>
-      <button type="submit">Sign & Submit Transaction</button>
-      {result && <div>{result}</div>}
-    </form>
+    <button onClick={() => void pay()} disabled={!account}>
+      Pay 1 XRP
+    </button>
   );
 }
 ```
 
-## Next.js Integration
+`useSigner()` exposes `sign`, `signAndSubmit`, and `signMessage`. Check `manager.supports('signMessage')` before offering arbitrary message signing.
 
-XRPL-Connect works seamlessly with Next.js. Here's how to integrate it:
+## Modal control
 
-### 1. Mark Components as Client Components
+`useWalletModal()` returns `open` and `close`. Render one or more `<WalletConnector>` components inside the provider; modal ownership follows the mounted connector. `WalletConnector` accepts:
 
-**File: `app/components/WalletConnector.tsx`**
+- `primaryWallet` and ordered `wallets`
+- `theme`: `dark`, `light`, or `purple`
+- typed `--xc-*` values through `cssVars`
+- `className`, `style`, `onConnecting`, `onConnect`, and `onError`
 
-Since XRPL-Connect uses browser APIs, mark your wallet components with `'use client'`:
+## Next.js App Router
 
-```typescript
-// app/components/WalletConnector.tsx
+The package is safe to import during server rendering. Provider and wallet UI usage still require a client boundary because they use browser wallet APIs:
+
+```tsx
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
-import { WalletManager, XamanAdapter, LedgerAdapter } from 'xrpl-connect';
+import { XrplConnectProvider, WalletConnector } from '@xrpl-connect/react';
 
-export default function WalletConnector() {
-  const connectorRef = useRef<HTMLElement>(null);
-  const [walletManager, setWalletManager] = useState<WalletManager | null>(null);
-
-  useEffect(() => {
-    const manager = new WalletManager({
-      adapters: [
-        new XamanAdapter({ apiKey: process.env.NEXT_PUBLIC_XAMAN_API_KEY || '' }),
-        new LedgerAdapter(),
-      ],
-      network: 'testnet',
-      autoConnect: true,
-    });
-
-    setWalletManager(manager);
-
-    const setupConnector = async () => {
-      await customElements.whenDefined('xrpl-wallet-connector');
-      if (connectorRef.current) {
-        (connectorRef.current as any).setWalletManager(manager);
-      }
-    };
-
-    setupConnector();
-
-    return () => {
-      manager.disconnect();
-    };
-  }, []);
-
-  return <xrpl-wallet-connector ref={connectorRef} />;
-}
-```
-
-### 2. Environment Variables
-
-**File: `.env.local`** (at the root of your Next.js project)
-
-Create an environment variables file:
-
-```bash
-NEXT_PUBLIC_XAMAN_API_KEY=your_api_key_here
-NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=your_project_id_here
-```
-
-> **Note:** Variables prefixed with `NEXT_PUBLIC_` are exposed to the browser.
-
-### 3. Use the Same Hooks
-
-You can use the same hooks and context pattern shown above. Just add `'use client'` at the top of each file.
-
-### 4. Dynamic Import (Optional)
-
-**File: `app/page.tsx`**
-
-If you want to avoid SSR issues, use dynamic imports:
-
-```typescript
-// app/page.tsx
-import dynamic from 'next/dynamic';
-
-const WalletConnector = dynamic(
-  () => import('./components/WalletConnector'),
-  { ssr: false }
-);
-
-export default function Home() {
+export function WalletProviders({ children }: { children: React.ReactNode }) {
   return (
-    <main>
-      <h1>My XRPL App</h1>
+    <XrplConnectProvider config={config}>
+      {children}
       <WalletConnector />
-    </main>
+    </XrplConnectProvider>
   );
 }
 ```
 
-## Best Practices
+Expose browser identifiers with `NEXT_PUBLIC_*`; do not expose secrets. Dynamic import with `ssr: false` is optional for route-level code splitting, not required to make the package importable.
 
-### 1. Wait for Custom Element Definition
+## Lifecycle guarantees
 
-Always wait for the custom element to be defined before calling methods:
+The provider owns one manager, subscribes before auto-connect can update state, and cancels owned pending connections on unmount. Do not add a second custom context or duplicate manager listeners around it.
 
-```typescript
-await customElements.whenDefined('xrpl-wallet-connector');
-await new Promise((resolve) => setTimeout(resolve, 0));
-```
-
-### 2. Cleanup on Unmount
-
-Always disconnect the wallet manager when component unmounts:
-
-```typescript
-useEffect(() => {
-  const manager = new WalletManager({...});
-
-  return () => {
-    manager.disconnect();
-  };
-}, []);
-```
-
-### 3. Use TypeScript
-
-Add proper type definitions for the web component in your TypeScript declarations.
-
-### 4. Context for Global State
-
-Use React Context to share wallet state across components instead of prop drilling.
-
-### 5. Memoize Adapters
-
-Use `useMemo` to prevent unnecessary adapter recreation:
-
-```typescript
-const adapters = useMemo(
-  () => [new XamanAdapter({ apiKey: XAMAN_API_KEY }), new LedgerAdapter()],
-  []
-);
-```
-
-### 6. Error Boundaries
-
-Wrap wallet components in error boundaries to handle errors gracefully:
-
-```typescript
-import { Component, ReactNode } from 'react';
-
-class WalletErrorBoundary extends Component<
-  { children: ReactNode },
-  { hasError: boolean }
-> {
-  state = { hasError: false };
-
-  static getDerivedStateFromError() {
-    return { hasError: true };
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return <div>Wallet failed to load. Please refresh.</div>;
-    }
-    return this.props.children;
-  }
-}
-```
-
-## Common Patterns
-
-### Account Display
-
-```typescript
-function AccountDisplay() {
-  const { accountInfo, isConnected } = useWallet();
-
-  if (!isConnected || !accountInfo) {
-    return <p>Please connect your wallet</p>;
-  }
-
-  return (
-    <div>
-      <p>Address: {accountInfo.address}</p>
-      <p>Network: {accountInfo.network}</p>
-      <p>Wallet: {accountInfo.walletName}</p>
-    </div>
-  );
-}
-```
-
-### Protected Component
-
-```typescript
-function ProtectedFeature() {
-  const { isConnected } = useWallet();
-
-  if (!isConnected) {
-    return <p>Please connect your wallet to use this feature</p>;
-  }
-
-  return <div>Protected content here</div>;
-}
-```
-
-### Loading States
-
-```typescript
-function WalletStatus() {
-  const { walletManager, isConnected } = useWallet();
-
-  if (!walletManager) {
-    return <div>Loading wallet...</div>;
-  }
-
-  return isConnected ? <div>Connected</div> : <div>Disconnected</div>;
-}
-```
-
-## Troubleshooting
-
-### "setWalletManager is not a function"
-
-Make sure you're waiting for the custom element to be defined:
-
-```typescript
-await customElements.whenDefined('xrpl-wallet-connector');
-```
-
-### Next.js: "document is not defined"
-
-Add `'use client'` to your component or use dynamic imports with `{ ssr: false }`.
-
-### TypeScript Errors with Web Component
-
-Make sure you have the JSX type declarations in your `vite-env.d.ts` or `react-app-env.d.ts` file.
-
-### Wallet Doesn't Reconnect on Refresh
-
-Ensure `autoConnect: true` is set in your WalletManager configuration.
-
-## Resources
-
-- [Complete React Example](https://github.com/XRPL-Commons/xrpl-connect/tree/main/examples/react)
-- [Next.js Documentation](https://nextjs.org/docs)
-- [React Documentation](https://react.dev/)
-- [XRPL Connect API Reference](/guide/api-reference)
+See [transactions and signing](/guide/transactions), [production and security](/guide/production), and the runnable [`examples/react`](https://github.com/XRPL-Commons/xrpl-connect/tree/develop/examples/react) application.

--- a/docs/guide/frameworks/vue.md
+++ b/docs/guide/frameworks/vue.md
@@ -11,7 +11,7 @@ in the application.
 ## Installation
 
 ```bash
-npm install @xrpl-connect/vue xrpl-connect xrpl vue
+npm install @xrpl-connect/vue@^1.0.0 xrpl-connect@^1.0.0 xrpl vue
 ```
 
 ## Configure the plugin
@@ -48,6 +48,19 @@ from other Vue applications on the same page and are released when the app unmou
 `useWallet()` returns readonly Vue refs, so use them directly in templates and through `.value`
 in scripts. `useWalletModal()` controls the most recently mounted connector.
 
+All composables must run below an application that installed `createXrplConnect()`. Keep one
+mounted `<WalletConnector>` for predictable modal ownership.
+
+For a headless flow, connect directly by adapter ID:
+
+```ts
+const { connect } = useWallet();
+await connect('crossmark');
+```
+
+With `autoConnect: true`, the plugin restores the persisted session on the client after its
+reactive listeners are ready.
+
 ```vue
 <script setup lang="ts">
 import { WalletConnector, useWallet, useWalletModal } from '@xrpl-connect/vue';
@@ -83,7 +96,7 @@ Signing actions are bound to the injected manager and reject with typed `WalletE
 ```vue
 <script setup lang="ts">
 import { ref } from 'vue';
-import { isWalletError, useSigner, useWallet } from '@xrpl-connect/vue';
+import { isWalletError, useSigner, useWallet, WalletErrorCode } from '@xrpl-connect/vue';
 
 const { account, connected } = useWallet();
 const { signAndSubmit } = useSigner();
@@ -103,7 +116,7 @@ async function sendPayment() {
     });
     result.value = submitted.hash;
   } catch (error) {
-    if (isWalletError(error)) console.error(error.code, error.category, error.message);
+    if (isWalletError(error) && error.code === WalletErrorCode.SIGN_REJECTED) return;
     throw error;
   } finally {
     submitting.value = false;
@@ -125,6 +138,10 @@ async function sendPayment() {
 - `useSigner()` returns `sign`, `signAndSubmit`, and `signMessage`.
 - `useWalletModal()` returns `open` and `close`.
 - `<WalletConnector>` wraps the browser custom element with typed Vue props and events.
+
+`WalletConnector` accepts `primaryWallet`, `wallets`, `theme`, and `cssVars`, and emits
+`connecting`, `connect`, and typed `error` events. Use `manager.supports('signMessage')` before
+showing optional signing actions.
 
 ## SSR and Nuxt
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -14,6 +14,16 @@ Get up and running with XRPL-Connect in minutes.
 npm install xrpl-connect@^1.0.0 xrpl
 ```
 
+Add the official bindings for your framework:
+
+```bash
+# React
+npm install @xrpl-connect/react@^1.0.0 react react-dom
+
+# Vue 3 or Nuxt
+npm install @xrpl-connect/vue@^1.0.0 vue
+```
+
 ### Using pnpm
 
 ```bash
@@ -31,6 +41,7 @@ The `xrpl-connect` package includes:
 - **Core** - WalletManager, event system, and state management
 - **UI** - Beautiful web component for wallet connection
 - **Adapters** - Built-in support for Xaman, Crossmark, GemWallet, WalletConnect, Ledger, Xyra, Otsu, and MetaMask Snap
+- **Framework bindings** - Official packages for React and Vue 3 / Nuxt
 
 > **Note:** The `xrpl` package is required for transaction types and utilities.
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -11,26 +11,26 @@ Get up and running with XRPL-Connect in minutes.
 ### Using npm
 
 ```bash
-npm install xrpl-connect xrpl
+npm install xrpl-connect@^1.0.0 xrpl
 ```
 
 ### Using pnpm
 
 ```bash
-pnpm add xrpl-connect xrpl
+pnpm add xrpl-connect@^1.0.0 xrpl
 ```
 
 ### Using yarn
 
 ```bash
-yarn add xrpl-connect xrpl
+yarn add xrpl-connect@^1.0.0 xrpl
 ```
 
 The `xrpl-connect` package includes:
 
 - **Core** - WalletManager, event system, and state management
 - **UI** - Beautiful web component for wallet connection
-- **Adapters** - Built-in support for Xaman, Crossmark, GemWallet, WalletConnect, Ledger hardware wallets, Xyra, and Otsu
+- **Adapters** - Built-in support for Xaman, Crossmark, GemWallet, WalletConnect, Ledger, Xyra, Otsu, and MetaMask Snap
 
 > **Note:** The `xrpl` package is required for transaction types and utilities.
 
@@ -78,6 +78,7 @@ const crossmarkAdapter = new CrossmarkAdapter();
 const gemWalletAdapter = new GemWalletAdapter();
 const xyraAdapter = new XyraAdapter();
 const otsuAdapter = new OtsuAdapter();
+const metaMaskAdapter = new MetaMaskSnapAdapter();
 ```
 
 ### Ledger Hardware Wallet
@@ -118,7 +119,13 @@ A minimal, copy-pasteable example covering the patterns you almost always need: 
 ```
 
 ```javascript
-import { WalletManager, XamanAdapter, CrossmarkAdapter } from 'xrpl-connect';
+import {
+  CrossmarkAdapter,
+  WalletErrorCode,
+  WalletManager,
+  XamanAdapter,
+  isWalletError,
+} from 'xrpl-connect';
 
 const walletManager = new WalletManager({
   adapters: [new XamanAdapter({ apiKey: 'YOUR_API_KEY' }), new CrossmarkAdapter()],
@@ -158,7 +165,7 @@ async function sendPayment() {
     });
     console.log('Signed:', signed);
   } catch (error) {
-    if (error.code === 'SIGN_FAILED') {
+    if (isWalletError(error) && error.code === WalletErrorCode.SIGN_REJECTED) {
       // User rejected the prompt in their wallet — usually a no-op.
       console.log('User rejected the transaction');
     } else {

--- a/docs/guide/migration-v1.md
+++ b/docs/guide/migration-v1.md
@@ -1,0 +1,40 @@
+---
+description: Upgrade applications from pre-1.0 XRPL Connect releases to v1.0.
+---
+
+# Migrating to v1.0
+
+v1.0 stabilizes the manager, adapter, UI, and React surfaces. Upgrade all XRPL Connect packages together and retest wallet-specific flows.
+
+```bash
+pnpm up xrpl-connect@^1.0.0 @xrpl-connect/react@^1.0.0
+```
+
+## Required checks
+
+1. Use separate `sign(transaction)` and `signAndSubmit(transaction)` calls. The old boolean submit argument is not supported.
+2. Handle signing cancellation as `WalletErrorCode.SIGN_REJECTED`, not `SIGN_FAILED`.
+3. Check optional operations with `manager.supports(...)`; Xaman and WalletConnect do not support arbitrary message signing.
+4. Read signed artifacts from `tx_blob`, `tx_json`, and `signature`. Wallets do not all return the same representation.
+5. Treat `signAndSubmit()` as submission, not validated-ledger confirmation.
+6. Keep one stable Xaman API key per page lifetime.
+7. Use `openAndWait()` when application code needs a modal promise, and handle rejection when the modal closes.
+8. Clean up pending connections when UI ownership ends; the official React provider and connector do this automatically.
+
+## New in v1.0
+
+- Official `@xrpl-connect/react` provider, hooks, and connector component.
+- MetaMask Snap adapter and complete adapter exports from `xrpl-connect`.
+- Capability discovery with `manager.supports()`.
+- Typed error categories and stable error codes.
+- Versioned, adapter-owned reconnect state and configurable storage.
+- Typed signed transaction artifacts and signer addresses.
+- Safer availability timeouts, connection cancellation, and account/network refresh behavior.
+
+## React migration
+
+Replace custom contexts and custom-element refs with `XrplConnectProvider`, `WalletConnector`, `useWallet`, `useSigner`, and `useWalletModal`. Keep the provider config stable outside render or memoize it.
+
+## Need help?
+
+Review the [wallet capability table](/guide/wallets), [production guide](/guide/production), and [GitHub releases](https://github.com/XRPL-Commons/xrpl-connect/releases). Report upgrade problems with the wallet, browser, network, and exact `WalletError` code.

--- a/docs/guide/migration-v1.md
+++ b/docs/guide/migration-v1.md
@@ -4,10 +4,10 @@ description: Upgrade applications from pre-1.0 XRPL Connect releases to v1.0.
 
 # Migrating to v1.0
 
-v1.0 stabilizes the manager, adapter, UI, and React surfaces. Upgrade all XRPL Connect packages together and retest wallet-specific flows.
+v1.0 stabilizes the manager, adapter, UI, React, and Vue surfaces. Upgrade all XRPL Connect packages together and retest wallet-specific flows.
 
 ```bash
-pnpm up xrpl-connect@^1.0.0 @xrpl-connect/react@^1.0.0
+pnpm up xrpl-connect@^1.0.0 @xrpl-connect/react@^1.0.0 @xrpl-connect/vue@^1.0.0
 ```
 
 ## Required checks
@@ -19,11 +19,12 @@ pnpm up xrpl-connect@^1.0.0 @xrpl-connect/react@^1.0.0
 5. Treat `signAndSubmit()` as submission, not validated-ledger confirmation.
 6. Keep one stable Xaman API key per page lifetime.
 7. Use `openAndWait()` when application code needs a modal promise, and handle rejection when the modal closes.
-8. Clean up pending connections when UI ownership ends; the official React provider and connector do this automatically.
+8. Clean up pending connections when UI ownership ends; the official React and Vue integrations do this automatically.
 
 ## New in v1.0
 
 - Official `@xrpl-connect/react` provider, hooks, and connector component.
+- Official `@xrpl-connect/vue` plugin, composables, and connector component for Vue 3 and Nuxt.
 - MetaMask Snap adapter and complete adapter exports from `xrpl-connect`.
 - Capability discovery with `manager.supports()`.
 - Typed error categories and stable error codes.
@@ -34,6 +35,13 @@ pnpm up xrpl-connect@^1.0.0 @xrpl-connect/react@^1.0.0
 ## React migration
 
 Replace custom contexts and custom-element refs with `XrplConnectProvider`, `WalletConnector`, `useWallet`, `useSigner`, and `useWalletModal`. Keep the provider config stable outside render or memoize it.
+
+## Vue migration
+
+Replace hand-written `provide` / `inject` state and direct custom-element refs with
+`createXrplConnect()`, `useWallet()`, `useSigner()`, `useWalletModal()`, and the typed
+`<WalletConnector>`. In Nuxt, install the plugin from `plugins/xrpl-connect.client.ts` and keep
+the connector inside `<ClientOnly>`.
 
 ## Need help?
 

--- a/docs/guide/production.md
+++ b/docs/guide/production.md
@@ -1,0 +1,58 @@
+---
+description: Production, security, SSR, persistence, and browser guidance for XRPL Connect v1.0.
+---
+
+# Production and security
+
+## Client boundaries and SSR
+
+Wallet adapters interact with browser APIs. Create the manager and render the connector in client code. The `@xrpl-connect/react` package can be imported during SSR, but its provider and connector belong below a React/Next.js client boundary.
+
+```tsx
+'use client';
+
+import { XrplConnectProvider, WalletConnector } from '@xrpl-connect/react';
+```
+
+For Vue/Nuxt, initialize in a client plugin or `onMounted`, retain named event handlers, and remove them with `manager.off()` during teardown.
+
+## Credentials
+
+- Xaman API keys and WalletConnect project IDs are visible in browser bundles. Apply origin/domain allowlists in their dashboards.
+- Never expose Xaman API secrets, wallet seeds, private keys, or backend credentials.
+- Keep Xaman's API key stable for the page lifetime.
+- Use environment variables intended for public client configuration (`VITE_*`, `NEXT_PUBLIC_*`, or equivalent).
+
+## Persistence and reconnection
+
+`autoConnect: true` stores a minimal, versioned connection record and asks the adapter to restore it. It never stores arbitrary connect options or private signing material. Register manager listeners immediately after construction because reconnection may finish before UI mount.
+
+Supply a custom `StorageAdapter` when local storage is inappropriate, or `MemoryStorageAdapter` for non-persistent/test environments.
+
+## Browser support
+
+- Serve production applications over HTTPS.
+- Ledger requires WebHID or WebUSB and an unlocked device with the XRP app open.
+- Extension adapters depend on the wallet's supported browser and injection mechanism.
+- WalletConnect and Xaman provide QR/deep-link flows for mobile use.
+- Test popup and deep-link behavior without inserting delays between a user click and wallet authorization.
+
+## Error UX
+
+Branch on `WalletError.category` for broad UX and `WalletError.code` for specific recovery. Render wallet/provider messages as text, never unsanitized HTML.
+
+```ts
+if (isWalletError(error)) {
+  if (error.category === WalletErrorCategory.USER_ACTION) return;
+  if (error.category === WalletErrorCategory.WALLET_UNAVAILABLE) showInstallOrUnlockHelp();
+  else reportError(error);
+}
+```
+
+## Release checklist
+
+- Exercise every enabled wallet on testnet and the production origin.
+- Verify network mismatch handling and account/network change events.
+- Test reconnect, disconnect, modal close, route unmount, and late wallet approval.
+- Confirm CSP, popup, deep-link, WebHID, and iframe policies.
+- Monitor failures without logging addresses, tokens, payload URLs, or credentials.

--- a/docs/guide/production.md
+++ b/docs/guide/production.md
@@ -6,7 +6,7 @@ description: Production, security, SSR, persistence, and browser guidance for XR
 
 ## Client boundaries and SSR
 
-Wallet adapters interact with browser APIs. Create the manager and render the connector in client code. The `@xrpl-connect/react` package can be imported during SSR, but its provider and connector belong below a React/Next.js client boundary.
+Wallet adapters interact with browser APIs. Create the manager and render the connector in client code. The official React and Vue packages can be imported during SSR, but their provider/plugin and connector setup belongs in client code.
 
 ```tsx
 'use client';
@@ -14,7 +14,8 @@ Wallet adapters interact with browser APIs. Create the manager and render the co
 import { XrplConnectProvider, WalletConnector } from '@xrpl-connect/react';
 ```
 
-For Vue/Nuxt, initialize in a client plugin or `onMounted`, retain named event handlers, and remove them with `manager.off()` during teardown.
+For Nuxt, install `createXrplConnect()` from a `.client.ts` plugin and render
+`<WalletConnector>` inside `<ClientOnly>`. See the [Nuxt guide](/guide/frameworks/nuxt).
 
 ## Credentials
 

--- a/docs/guide/transactions.md
+++ b/docs/guide/transactions.md
@@ -1,0 +1,67 @@
+---
+description: Safely sign transactions, submit transactions, and sign messages with XRPL Connect v1.0.
+---
+
+# Transactions and signing
+
+`WalletManager` exposes three operations. Their results and side effects are intentionally different.
+
+| Method                       | Ledger submission | Result                                                                       |
+| ---------------------------- | ----------------- | ---------------------------------------------------------------------------- |
+| `sign(transaction)`          | No                | Signed JSON/blob/signature when supplied by the wallet, plus `signerAddress` |
+| `signAndSubmit(transaction)` | Yes               | Transaction hash and wallet-provided signed artifacts                        |
+| `signMessage(message)`       | No                | Message signature plus `signerAddress`                                       |
+
+## Sign and submit
+
+```ts
+import { WalletErrorCode, isWalletError } from 'xrpl-connect';
+
+async function submitPayment() {
+  const account = manager.account;
+  if (!account) throw new Error('Connect a wallet first');
+
+  try {
+    const result = await manager.signAndSubmit({
+      TransactionType: 'Payment',
+      Account: account.address,
+      Destination: destination,
+      Amount: amountInDrops,
+    });
+
+    console.log('Submitted transaction:', result.hash);
+  } catch (error) {
+    if (isWalletError(error) && error.code === WalletErrorCode.SIGN_REJECTED) return;
+    throw error;
+  }
+}
+```
+
+A returned hash means the wallet accepted/submitted the transaction according to its protocol. Query a trusted XRPL client when your application needs validated-ledger confirmation.
+
+## Sign without submitting
+
+Use `sign()` when your application submits separately or needs the signed artifact. Wallets expose different artifacts, so check `tx_blob` and `tx_json` instead of assuming one representation:
+
+```ts
+const signed = await manager.sign(transaction);
+
+if (signed.tx_blob) {
+  await xrplClient.submit(signed.tx_blob);
+} else if (signed.tx_json) {
+  await xrplClient.submit(xrpl.encode(signed.tx_json));
+}
+```
+
+## Message signing
+
+Not every XRPL wallet supports arbitrary messages. Gate the UI with `manager.supports('signMessage')` and include domain, origin, purpose, nonce, and expiry in authentication messages to prevent replay.
+
+## Safety checklist
+
+- Validate destination, amount, flags, network, and transaction type before opening the wallet.
+- Show users a human-readable summary of what they are signing.
+- Never request or handle a seed/private key.
+- Treat caught values as `unknown`; narrow with `isWalletError`.
+- Distinguish `SIGN_REJECTED` from `SIGN_FAILED` so cancellation does not look like a system failure.
+- Do not call signing methods concurrently on the same manager.

--- a/docs/guide/wallets.md
+++ b/docs/guide/wallets.md
@@ -1,0 +1,80 @@
+---
+description: Choose and configure the wallet adapters included with XRPL Connect v1.0.
+---
+
+# Wallets and capabilities
+
+XRPL Connect v1.0 ships eight adapters behind one `WalletManager` API. Register only the wallets your application intends to support; the connector checks availability before presenting them.
+
+| Adapter ID      | Wallet        | Requirement                     | Sign | Submit | Messages | Live account refresh |
+| --------------- | ------------- | ------------------------------- | :--: | :----: | :------: | :------------------: |
+| `xaman`         | Xaman         | Browser API key                 | Yes  |  Yes   |    No    |         Yes          |
+| `crossmark`     | Crossmark     | Browser extension               | Yes  |  Yes   |   Yes    |         Yes          |
+| `gemwallet`     | GemWallet     | Browser extension               | Yes  |  Yes   |   Yes    |         Yes          |
+| `walletconnect` | WalletConnect | Project ID                      | Yes  |  Yes   |    No    |          No          |
+| `ledger`        | Ledger        | XRP app and WebHID/WebUSB       | Yes  |  Yes   |   Yes    |         Yes          |
+| `xyra`          | Xyra          | Browser wallet                  | Yes  |  Yes   |   Yes    |          No          |
+| `otsu`          | Otsu          | Browser wallet                  | Yes  |  Yes   |   Yes    |         Yes          |
+| `metamask-snap` | MetaMask Snap | MetaMask with XRPL Snap support | Yes  |  Yes   |   Yes    |          No          |
+
+Treat this table as the default feature set and check capabilities at runtime before displaying an action:
+
+```ts
+if (manager.supports('signMessage')) {
+  const signed = await manager.signMessage('Sign in to Example');
+}
+```
+
+## Recommended configuration
+
+```ts
+import {
+  CrossmarkAdapter,
+  GemWalletAdapter,
+  MetaMaskSnapAdapter,
+  WalletConnectAdapter,
+  WalletManager,
+  XamanAdapter,
+} from 'xrpl-connect';
+
+export const manager = new WalletManager({
+  adapters: [
+    new XamanAdapter({ apiKey: import.meta.env.VITE_XAMAN_API_KEY }),
+    new CrossmarkAdapter(),
+    new GemWalletAdapter(),
+    new WalletConnectAdapter({ projectId: import.meta.env.VITE_WALLETCONNECT_PROJECT_ID }),
+    new MetaMaskSnapAdapter(),
+  ],
+  network: 'testnet',
+  autoConnect: true,
+});
+```
+
+Xaman API keys and WalletConnect project IDs are browser identifiers, not server secrets. Restrict them to your production origins in the provider dashboard. Never place private keys, seeds, API secrets, or signing credentials in client code.
+
+## Adapter options
+
+- `XamanAdapter`: `apiKey`, QR callback, and deep-link transformation.
+- `WalletConnectAdapter`: `projectId`, metadata, QR/deep-link callbacks, modal mode, and theme.
+- `LedgerAdapter`: derivation path, operation timeout, and WebHID preference. Ledger requires HTTPS outside localhost.
+- `MetaMaskSnapAdapter`: optional `snapId`; use the default published Snap unless developing a local Snap.
+- Xyra, Otsu, Crossmark, and GemWallet work without application credentials.
+
+Connect-time options can override supported adapter settings. Keep the Xaman API key stable for the lifetime of the page because its browser SDK owns page-global OAuth state.
+
+## Networks
+
+Pass `mainnet`, `testnet`, `devnet`, or a supported `NetworkConfig` to `WalletManager`. Adapters validate the selected network and reject contradictory wallet responses. Start development on testnet and display the active network beside every signing action.
+
+## Availability and ordering
+
+The web component hides unavailable wallets by default. Use its `wallets` attribute to restrict and order the list, and `show-unavailable` when you want installation links to remain visible:
+
+```html
+<xrpl-wallet-connector
+  wallets="xaman,crossmark,gemwallet,walletconnect,metamask-snap"
+  show-unavailable
+></xrpl-wallet-connector>
+```
+
+See the [API reference](/guide/api-reference) for constructor and connect-option types.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ description: A framework-agnostic wallet connection toolkit for the XRP Ledger w
 
 <DownloadLLMsFullDoc />
 
-XRPL Connect is the stable, typed wallet layer for XRP Ledger applications. v1.0 combines a framework-agnostic manager, eight wallet adapters, a customizable web component, and official React bindings.
+XRPL Connect is the stable, typed wallet layer for XRP Ledger applications. v1.0 combines a framework-agnostic manager, eight wallet adapters, a customizable web component, and official React and Vue bindings.
 
 ## What is XRPL-Connect?
 
@@ -15,7 +15,7 @@ XRPL-Connect is a complete solution for integrating wallet functionality into we
 - **Web Component UI** - Beautiful, customizable `<xrpl-wallet-connector>` component for wallet selection and account management
 - **Wallet Manager** - Central event-driven system for managing wallet connections and transactions
 - **Multiple Wallet Support** - Built-in adapters for Xaman, Crossmark, GemWallet, WalletConnect, Ledger, Xyra, Otsu, and MetaMask Snap
-- **Official React bindings** - Provider, hooks, and connector component in `@xrpl-connect/react`
+- **Official framework bindings** - Providers, composables, hooks, and connector components for React and Vue
 - **Framework Agnostic** - Works seamlessly with Vanilla JS, React, Vue, Next.js, Nuxt, and any modern web framework
 - **TypeScript Ready** - Full type definitions for a great developer experience
 - **Production Ready** - Used in production applications across the XRPL ecosystem
@@ -101,7 +101,7 @@ The XRPL-Connect package includes:
 - **Core Library** - WalletManager, event system, and state management
 - **Web Component** - Beautiful UI component for wallet connection
 - **Adapters** - Pre-built integrations for major wallets
-- **React bindings** - Official provider, hooks, and connector component
+- **Framework bindings** - Official React and Vue integrations with shared lifecycle management
 - **TypeScript Definitions** - Full type safety and IDE support
 - **Documentation** - Complete guides and API reference
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,11 +2,11 @@
 description: A framework-agnostic wallet connection toolkit for the XRP Ledger with support for multiple wallet adapters and comprehensive documentation.
 ---
 
-# Introduction to XRPL-Connect
+# XRPL Connect v1.0
 
 <DownloadLLMsFullDoc />
 
-XRPL-Connect is a comprehensive, framework-agnostic wallet connection toolkit for the XRP Ledger. It provides developers with everything needed to add secure wallet connectivity to their applications through a modern, modular architecture.
+XRPL Connect is the stable, typed wallet layer for XRP Ledger applications. v1.0 combines a framework-agnostic manager, eight wallet adapters, a customizable web component, and official React bindings.
 
 ## What is XRPL-Connect?
 
@@ -14,7 +14,8 @@ XRPL-Connect is a complete solution for integrating wallet functionality into we
 
 - **Web Component UI** - Beautiful, customizable `<xrpl-wallet-connector>` component for wallet selection and account management
 - **Wallet Manager** - Central event-driven system for managing wallet connections and transactions
-- **Multiple Wallet Support** - Built-in adapters for Xaman, Crossmark, GemWallet, WalletConnect, Ledger hardware wallets, Xyra, and Otsu
+- **Multiple Wallet Support** - Built-in adapters for Xaman, Crossmark, GemWallet, WalletConnect, Ledger, Xyra, Otsu, and MetaMask Snap
+- **Official React bindings** - Provider, hooks, and connector component in `@xrpl-connect/react`
 - **Framework Agnostic** - Works seamlessly with Vanilla JS, React, Vue, Next.js, Nuxt, and any modern web framework
 - **TypeScript Ready** - Full type definitions for a great developer experience
 - **Production Ready** - Used in production applications across the XRPL ecosystem
@@ -38,7 +39,7 @@ Customize colors, fonts, and styling using CSS variables without touching HTML o
 
 ### 🔌 Multiple Wallets
 
-Support for all major XRP Ledger wallets including Xaman, Crossmark, GemWallet, WalletConnect, Ledger hardware wallets, Xyra, and Otsu. Give users choice without increasing complexity.
+Support Xaman, Crossmark, GemWallet, WalletConnect, Ledger, Xyra, Otsu, and MetaMask Snap through the same manager API.
 
 ### ⚡ Framework Agnostic
 
@@ -65,25 +66,16 @@ Enhanced mobile experience with optimized support for Xaman wallet connections. 
 
 XRPL-Connect uses a modular, adapter-based architecture that separates concerns and makes it easy to extend:
 
-```
-Your Application
-       ↓
-┌─────────────────────────────┐
-│   xrpl-connect/core        │
-│   ┌───────────────────────┐ │
-│   │  WalletManager        │ │
-│   │  - Event system       │ │
-│   │  - State management   │ │
-│   │  - Storage layer      │ │
-│   └───────────────────────┘ │
-└──────────────┬──────────────┘
-               ↓
-    ┌──────────┬──────────┬─────────┬─────────────┬────────┬────────┬────────┐
-    ↓          ↓          ↓         ↓             ↓        ↓        ↓
-┌────────┐ ┌──────────┐ ┌────────┐ ┌─────────┐ ┌────────┐ ┌──────┐ ┌──────┐
-│ Xaman  │ │Crossmark │ │GemWal  │ │WalletCon│ │Ledger  │ │Xyra  │ │Otsu  │
-│ Adapter│ │Adapter   │ │Adapter │ │Adapter  │ │Adapter │ │Adptr │ │Adptr │
-└────────┘ └──────────┘ └────────┘ └─────────┘ └────────┘ └──────┘ └──────┘
+```text
+Application UI / framework bindings
+                ↓
+          WalletManager
+   (state, events, persistence)
+                ↓
+         WalletAdapter API
+                ↓
+Xaman · Crossmark · GemWallet · WalletConnect
+Ledger · Xyra · Otsu · MetaMask Snap
 ```
 
 ## How It Works
@@ -109,6 +101,7 @@ The XRPL-Connect package includes:
 - **Core Library** - WalletManager, event system, and state management
 - **Web Component** - Beautiful UI component for wallet connection
 - **Adapters** - Pre-built integrations for major wallets
+- **React bindings** - Official provider, hooks, and connector component
 - **TypeScript Definitions** - Full type safety and IDE support
 - **Documentation** - Complete guides and API reference
 
@@ -126,6 +119,7 @@ Ready to get started? Here's the recommended learning path:
    - [Nuxt](/guide/frameworks/nuxt)
 5. **[Customization](/guide/customization)** - Style the component to match your design
 6. **[API Reference](/guide/api-reference)** - Deep dive into the complete API
+7. **[Migrating to v1.0](/guide/migration-v1)** - Upgrade pre-1.0 applications safely
 
 ## Community & Support
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrpl-connect/docs",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "private": true,
   "description": "XRPL Connect Documentation",
   "scripts": {
@@ -9,12 +9,13 @@
     "preview": "vitepress preview ."
   },
   "dependencies": {
+    "@xrpl-connect/ui": "workspace:*",
     "xrpl": "^4.4.2",
     "xrpl-connect": "workspace:*"
   },
   "devDependencies": {
-    "vitepress": "^1.6.4",
-    "vitepress-plugin-llms": "^1.8.1",
+    "vitepress": "^2.0.0-alpha.18",
+    "vitepress-plugin-llms": "^1.13.3",
     "vue": "^3.5.22"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.5.0",
     "vite": "catalog:",
     "vite-plus": "catalog:",
-    "vitepress": "^1.6.4",
+    "vitepress": "^2.0.0-alpha.18",
     "vue": "^3.5.22"
   },
   "packageManager": "pnpm@10.18.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,14 +39,17 @@ importers:
         specifier: 'catalog:'
         version: 0.2.5(@types/node@20.19.21)(@voidzero-dev/vite-plus-core@0.2.5(@types/node@20.19.21)(esbuild@0.28.1)(typescript@5.9.3))(bufferutil@4.0.9)(esbuild@0.28.1)(jsdom@22.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10)
       vitepress:
-        specifier: ^1.6.4
-        version: 1.6.4(@algolia/client-search@5.41.0)(@types/node@20.19.21)(@types/react@18.3.26)(esbuild@0.28.1)(idb-keyval@6.2.2)(postcss@8.5.19)(qrcode@1.5.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3)
+        specifier: ^2.0.0-alpha.18
+        version: 2.0.0-alpha.18(@types/node@20.19.21)(esbuild@0.28.1)(idb-keyval@6.2.2)(postcss@8.5.19)(qrcode@1.5.3)(typescript@5.9.3)
       vue:
         specifier: ^3.5.22
         version: 3.5.24(typescript@5.9.3)
 
   docs:
     dependencies:
+      '@xrpl-connect/ui':
+        specifier: workspace:*
+        version: link:../packages/ui
       xrpl:
         specifier: ^4.4.2
         version: 4.4.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -55,11 +58,11 @@ importers:
         version: link:../packages/xrpl-connect
     devDependencies:
       vitepress:
-        specifier: ^1.6.4
-        version: 1.6.4(@algolia/client-search@5.41.0)(@types/node@20.19.21)(@types/react@18.3.26)(esbuild@0.28.1)(idb-keyval@6.2.2)(postcss@8.5.19)(qrcode@1.5.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3)
+        specifier: ^2.0.0-alpha.18
+        version: 2.0.0-alpha.18(@types/node@20.19.21)(esbuild@0.28.1)(idb-keyval@6.2.2)(postcss@8.5.19)(qrcode@1.5.3)(typescript@5.9.3)
       vitepress-plugin-llms:
-        specifier: ^1.8.1
-        version: 1.8.1
+        specifier: ^1.13.3
+        version: 1.13.3
       vue:
         specifier: ^3.5.22
         version: 3.5.24(typescript@5.9.3)
@@ -495,82 +498,6 @@ packages:
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
-  '@algolia/abtesting@1.7.0':
-    resolution: {integrity: sha512-hOEItTFOvNLI6QX6TSGu7VE4XcUcdoKZT8NwDY+5mWwu87rGhkjlY7uesKTInlg6Sh8cyRkDBYRumxbkoBbBhA==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/autocomplete-core@1.17.7':
-    resolution: {integrity: sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==}
-
-  '@algolia/autocomplete-plugin-algolia-insights@1.17.7':
-    resolution: {integrity: sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==}
-    peerDependencies:
-      search-insights: '>= 1 < 3'
-
-  '@algolia/autocomplete-preset-algolia@1.17.7':
-    resolution: {integrity: sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==}
-    peerDependencies:
-      '@algolia/client-search': '>= 4.9.1 < 6'
-      algoliasearch: '>= 4.9.1 < 6'
-
-  '@algolia/autocomplete-shared@1.17.7':
-    resolution: {integrity: sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==}
-    peerDependencies:
-      '@algolia/client-search': '>= 4.9.1 < 6'
-      algoliasearch: '>= 4.9.1 < 6'
-
-  '@algolia/client-abtesting@5.41.0':
-    resolution: {integrity: sha512-iRuvbEyuHCAhIMkyzG3tfINLxTS7mSKo7q8mQF+FbQpWenlAlrXnfZTN19LRwnVjx0UtAdZq96ThMWGS6cQ61A==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/client-analytics@5.41.0':
-    resolution: {integrity: sha512-OIPVbGfx/AO8l1V70xYTPSeTt/GCXPEl6vQICLAXLCk9WOUbcLGcy6t8qv0rO7Z7/M/h9afY6Af8JcnI+FBFdQ==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/client-common@5.41.0':
-    resolution: {integrity: sha512-8Mc9niJvfuO8dudWN5vSUlYkz7U3M3X3m1crDLc9N7FZrIVoNGOUETPk3TTHviJIh9y6eKZKbq1hPGoGY9fqPA==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/client-insights@5.41.0':
-    resolution: {integrity: sha512-vXzvCGZS6Ixxn+WyzGUVDeR3HO/QO5POeeWy1kjNJbEf6f+tZSI+OiIU9Ha+T3ntV8oXFyBEuweygw4OLmgfiQ==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/client-personalization@5.41.0':
-    resolution: {integrity: sha512-tkymXhmlcc7w/HEvLRiHcpHxLFcUB+0PnE9FcG6hfFZ1ZXiWabH+sX+uukCVnluyhfysU9HRU2kUmUWfucx1Dg==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/client-query-suggestions@5.41.0':
-    resolution: {integrity: sha512-vyXDoz3kEZnosNeVQQwf0PbBt5IZJoHkozKRIsYfEVm+ylwSDFCW08qy2YIVSHdKy69/rWN6Ue/6W29GgVlmKQ==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/client-search@5.41.0':
-    resolution: {integrity: sha512-G9I2atg1ShtFp0t7zwleP6aPS4DcZvsV4uoQOripp16aR6VJzbEnKFPLW4OFXzX7avgZSpYeBAS+Zx4FOgmpPw==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/ingestion@1.41.0':
-    resolution: {integrity: sha512-sxU/ggHbZtmrYzTkueTXXNyifn+ozsLP+Wi9S2hOBVhNWPZ8uRiDTDcFyL7cpCs1q72HxPuhzTP5vn4sUl74cQ==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/monitoring@1.41.0':
-    resolution: {integrity: sha512-UQ86R6ixraHUpd0hn4vjgTHbViNO8+wA979gJmSIsRI3yli2v89QSFF/9pPcADR6PbtSio/99PmSNxhZy+CR3Q==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/recommend@5.41.0':
-    resolution: {integrity: sha512-DxP9P8jJ8whJOnvmyA5mf1wv14jPuI0L25itGfOHSU6d4ZAjduVfPjTS3ROuUN5CJoTdlidYZE+DtfWHxJwyzQ==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/requester-browser-xhr@5.41.0':
-    resolution: {integrity: sha512-C21J+LYkE48fDwtLX7YXZd2Fn7Fe0/DOEtvohSfr/ODP8dGDhy9faaYeWB0n1AvmZltugjkjAXT7xk0CYNIXsQ==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/requester-fetch@5.41.0':
-    resolution: {integrity: sha512-FhJy/+QJhMx1Hajf2LL8og4J7SqOAHiAuUXq27cct4QnPhSIuIGROzeRpfDNH5BUbq22UlMuGd44SeD4HRAqvA==}
-    engines: {node: '>= 14.0.0'}
-
-  '@algolia/requester-node-http@5.41.0':
-    resolution: {integrity: sha512-tYv3rGbhBS0eZ5D8oCgV88iuWILROiemk+tQ3YsAKZv2J4kKUNvKkrX/If/SreRy4MGP2uJzMlyKcfSfO2mrsQ==}
-    engines: {node: '>= 14.0.0'}
-
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
@@ -613,8 +540,16 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.27.1':
@@ -627,6 +562,11 @@ packages:
 
   '@babel/parser@7.28.5':
     resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -658,6 +598,10 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
@@ -668,28 +612,14 @@ packages:
   '@crossmarkio/typings@0.0.6':
     resolution: {integrity: sha512-o5zjZBmi+/gYwmfT0L8gX/bilNOj03J6Ce0H/GvfA5djyw3WYrFZUybdAFBfNIiswQeoxUQJ+08loHl1Zes2gQ==}
 
-  '@docsearch/css@3.8.2':
-    resolution: {integrity: sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==}
+  '@docsearch/css@4.6.3':
+    resolution: {integrity: sha512-nlOwcXcsNAptQl4vlL4MA78qNJKO0Qlds5GuBjCoePgkebTXLSf8Qt1oyZ3YBshYupKXG9VRGEsk1zr23d+bzQ==}
 
-  '@docsearch/js@3.8.2':
-    resolution: {integrity: sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==}
+  '@docsearch/js@4.6.3':
+    resolution: {integrity: sha512-qUIX2b4Apew3tv4F0qhmgShsl/Lfw4m6mqv/5/5dWNxwTcDdLMp2s3YwZ+NMGh3IKCg0pBaXm7Q5VdyU5Rj+cQ==}
 
-  '@docsearch/react@3.8.2':
-    resolution: {integrity: sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==}
-    peerDependencies:
-      '@types/react': '>= 16.8.0 < 19.0.0'
-      react: '>= 16.8.0 < 19.0.0'
-      react-dom: '>= 16.8.0 < 19.0.0'
-      search-insights: '>= 1 < 3'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-      search-insights:
-        optional: true
+  '@docsearch/sidepanel-js@4.6.3':
+    resolution: {integrity: sha512-grGSmvXzG0if+mrzdIKykvpIAuEQ9u0sEJ2eLRRCaQfJvsWqh2C2/aY04bIzWvDh7myi5rvl8D+tUNsVrjYQ3A==}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -850,19 +780,11 @@ packages:
   '@gemwallet/api@3.8.0':
     resolution: {integrity: sha512-hZ6XC0mVm3Q54cgonrzk6tHS/wUMjtPHyqsqbtlnNGPouCR7OIfEDo5Y802qLZ5ah6PskhsK0DouVnwUykEM8Q==}
 
-  '@iconify-json/simple-icons@1.2.55':
-    resolution: {integrity: sha512-9vc04pmup/zcef8hDypWU8nMwMaFVkWuUzWkxyL++DVp5AA8baoJHK6RyKN1v+cvfR2agxkUb053XVggzFFkTA==}
+  '@iconify-json/simple-icons@1.2.91':
+    resolution: {integrity: sha512-plQJHZxzpkIXaeYjJF0Sc9nkzYF32EDX9olx7j1hcKYFaiTrQXbcngZmvzuV0pG6uZPU3ZuA/GIsgxSHOm6jrQ==}
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
-
-  '@isaacs/balanced-match@4.0.1':
-    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
-    engines: {node: 20 || >=22}
-
-  '@isaacs/brace-expansion@5.0.0':
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
-    engines: {node: 20 || >=22}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1248,6 +1170,9 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@rollup/plugin-inject@5.0.5':
     resolution: {integrity: sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==}
     engines: {node: '>=14.0.0'}
@@ -1430,26 +1355,37 @@ packages:
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
-  '@shikijs/core@2.5.0':
-    resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
+  '@shikijs/core@4.3.1':
+    resolution: {integrity: sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==}
+    engines: {node: '>=20'}
 
-  '@shikijs/engine-javascript@2.5.0':
-    resolution: {integrity: sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==}
+  '@shikijs/engine-javascript@4.3.1':
+    resolution: {integrity: sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ==}
+    engines: {node: '>=20'}
 
-  '@shikijs/engine-oniguruma@2.5.0':
-    resolution: {integrity: sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==}
+  '@shikijs/engine-oniguruma@4.3.1':
+    resolution: {integrity: sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg==}
+    engines: {node: '>=20'}
 
-  '@shikijs/langs@2.5.0':
-    resolution: {integrity: sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==}
+  '@shikijs/langs@4.3.1':
+    resolution: {integrity: sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==}
+    engines: {node: '>=20'}
 
-  '@shikijs/themes@2.5.0':
-    resolution: {integrity: sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==}
+  '@shikijs/primitive@4.3.1':
+    resolution: {integrity: sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==}
+    engines: {node: '>=20'}
 
-  '@shikijs/transformers@2.5.0':
-    resolution: {integrity: sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==}
+  '@shikijs/themes@4.3.1':
+    resolution: {integrity: sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==}
+    engines: {node: '>=20'}
 
-  '@shikijs/types@2.5.0':
-    resolution: {integrity: sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==}
+  '@shikijs/transformers@4.3.1':
+    resolution: {integrity: sha512-z6ir0bGDgWcF2FduktEfPgIsdOtIlDiLAjFBgBzE42Q9xHbkkIXZtORHzlLVB71iZP9elEcqKg6keajvOUwE2A==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.3.1':
+    resolution: {integrity: sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==}
+    engines: {node: '>=20'}
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
@@ -1613,11 +1549,11 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@vitejs/plugin-vue@5.2.4':
-    resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  '@vitejs/plugin-vue@6.0.8':
+    resolution: {integrity: sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^5.0.0 || ^6.0.0
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
   '@vitest/browser-preview@4.1.10':
@@ -1767,62 +1703,89 @@ packages:
   '@vue/compiler-core@3.5.24':
     resolution: {integrity: sha512-eDl5H57AOpNakGNAkFDH+y7kTqrQpJkZFXhWZQGyx/5Wh7B1uQYvcWkvZi11BDhscPgj8N7XV3oRwiPnx1Vrig==}
 
+  '@vue/compiler-core@3.5.40':
+    resolution: {integrity: sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==}
+
   '@vue/compiler-dom@3.5.24':
     resolution: {integrity: sha512-1QHGAvs53gXkWdd3ZMGYuvQFXHW4ksKWPG8HP8/2BscrbZ0brw183q2oNWjMrSWImYLHxHrx1ItBQr50I/q2zw==}
+
+  '@vue/compiler-dom@3.5.40':
+    resolution: {integrity: sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==}
 
   '@vue/compiler-sfc@3.5.24':
     resolution: {integrity: sha512-8EG5YPRgmTB+YxYBM3VXy8zHD9SWHUJLIGPhDovo3Z8VOgvP+O7UP5vl0J4BBPWYD9vxtBabzW1EuEZ+Cqs14g==}
 
+  '@vue/compiler-sfc@3.5.40':
+    resolution: {integrity: sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==}
+
   '@vue/compiler-ssr@3.5.24':
     resolution: {integrity: sha512-trOvMWNBMQ/odMRHW7Ae1CdfYx+7MuiQu62Jtu36gMLXcaoqKvAyh+P73sYG9ll+6jLB6QPovqoKGGZROzkFFg==}
 
-  '@vue/devtools-api@7.7.7':
-    resolution: {integrity: sha512-lwOnNBH2e7x1fIIbVT7yF5D+YWhqELm55/4ZKf45R9T8r9dE2AIOy8HKjfqzGsoTHFbWbr337O4E0A0QADnjBg==}
+  '@vue/compiler-ssr@3.5.40':
+    resolution: {integrity: sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==}
 
-  '@vue/devtools-kit@7.7.7':
-    resolution: {integrity: sha512-wgoZtxcTta65cnZ1Q6MbAfePVFxfM+gq0saaeytoph7nEa7yMXoi6sCPy4ufO111B9msnw0VOWjPEFCXuAKRHA==}
+  '@vue/devtools-api@8.1.5':
+    resolution: {integrity: sha512-YJipMVAKe5wT5CWf5kTYCaNV7NMNjFVxJkIkJaJ4W/nCxEBzlZzrOsYKeCymdCrFZmBS/+wTWFoUs3Jf/Q6XSQ==}
 
-  '@vue/devtools-shared@7.7.7':
-    resolution: {integrity: sha512-+udSj47aRl5aKb0memBvcUG9koarqnxNM5yjuREvqwK6T3ap4mn3Zqqc17QrBFTqSMjr3HK1cvStEZpMDpfdyw==}
+  '@vue/devtools-kit@8.1.5':
+    resolution: {integrity: sha512-FcSAxsi4eWuXLCB7Rv9lj0aIVHHPNVQ2BazGf4RJTc2JCqb4BQg0hk87ZFhminCfl+mD5OUI0rX2cgyu4kJOGA==}
+
+  '@vue/devtools-shared@8.1.5':
+    resolution: {integrity: sha512-mhT4zcPFhF+Xk1O4BfhhrbXzpmfqY03fS6xGpcllbQG7lDjhQf8pQHcTIhqQIYx1hfwtHmk/6jM96ele0UxPqQ==}
 
   '@vue/reactivity@3.5.24':
     resolution: {integrity: sha512-BM8kBhtlkkbnyl4q+HiF5R5BL0ycDPfihowulm02q3WYp2vxgPcJuZO866qa/0u3idbMntKEtVNuAUp5bw4teg==}
 
+  '@vue/reactivity@3.5.40':
+    resolution: {integrity: sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==}
+
   '@vue/runtime-core@3.5.24':
     resolution: {integrity: sha512-RYP/byyKDgNIqfX/gNb2PB55dJmM97jc9wyF3jK7QUInYKypK2exmZMNwnjueWwGceEkP6NChd3D2ZVEp9undQ==}
 
+  '@vue/runtime-core@3.5.40':
+    resolution: {integrity: sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw==}
+
   '@vue/runtime-dom@3.5.24':
     resolution: {integrity: sha512-Z8ANhr/i0XIluonHVjbUkjvn+CyrxbXRIxR7wn7+X7xlcb7dJsfITZbkVOeJZdP8VZwfrWRsWdShH6pngMxRjw==}
+
+  '@vue/runtime-dom@3.5.40':
+    resolution: {integrity: sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ==}
 
   '@vue/server-renderer@3.5.24':
     resolution: {integrity: sha512-Yh2j2Y4G/0/4z/xJ1Bad4mxaAk++C2v4kaa8oSYTMJBJ00/ndPuxCnWeot0/7/qafQFLh5pr6xeV6SdMcE/G1w==}
     peerDependencies:
       vue: 3.5.24
 
-  '@vue/shared@3.5.22':
-    resolution: {integrity: sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w==}
+  '@vue/server-renderer@3.5.40':
+    resolution: {integrity: sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw==}
 
   '@vue/shared@3.5.24':
     resolution: {integrity: sha512-9cwHL2EsJBdi8NY22pngYYWzkTDhld6fAD6jlaeloNGciNSJL6bLpbxVgXl96X00Jtc6YWQv96YA/0sxex/k1A==}
 
-  '@vueuse/core@12.8.2':
-    resolution: {integrity: sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==}
+  '@vue/shared@3.5.40':
+    resolution: {integrity: sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==}
 
-  '@vueuse/integrations@12.8.2':
-    resolution: {integrity: sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==}
+  '@vueuse/core@14.3.0':
+    resolution: {integrity: sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  '@vueuse/integrations@14.3.0':
+    resolution: {integrity: sha512-76I5FT2ESvCmCaSwapI+a/u/CFtNXmzl9f9lNp1hRtx8vKB8hfiokJr8IvQqcQG5ckGXElyXK516b54ozV3MvA==}
     peerDependencies:
       async-validator: ^4
       axios: ^1
       change-case: ^5
       drauu: ^0.4
-      focus-trap: ^7
+      focus-trap: ^7 || ^8
       fuse.js: ^7
       idb-keyval: ^6
       jwt-decode: ^4
       nprogress: ^0.2
       qrcode: ^1.5
       sortablejs: ^1
-      universal-cookie: ^7
+      universal-cookie: ^7 || ^8
+      vue: ^3.5.0
     peerDependenciesMeta:
       async-validator:
         optional: true
@@ -1849,11 +1812,13 @@ packages:
       universal-cookie:
         optional: true
 
-  '@vueuse/metadata@12.8.2':
-    resolution: {integrity: sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==}
+  '@vueuse/metadata@14.3.0':
+    resolution: {integrity: sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==}
 
-  '@vueuse/shared@12.8.2':
-    resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
+  '@vueuse/shared@14.3.0':
+    resolution: {integrity: sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==}
+    peerDependencies:
+      vue: ^3.5.0
 
   '@walletconnect/core@2.22.3':
     resolution: {integrity: sha512-14qELKSVdLiXHUzFhErhP16DT58JaK7Aw5PM/x94tSKvjrI5Y3ttq8E1aF7c/yoETgJ0VVINav/YfKr2cYH7vQ==}
@@ -2088,10 +2053,6 @@ packages:
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
-
-  algoliasearch@5.41.0:
-    resolution: {integrity: sha512-9E4b3rJmYbBkn7e3aAPt1as+VVnRhsR4qwRRgOzpeyz4PAOuwKh0HI4AN6mTrqK0S0M9fCCSTOUnuJ8gPY/tvA==}
-    engines: {node: '>= 14.0.0'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -2330,10 +2291,6 @@ packages:
   cookie-es@1.2.2:
     resolution: {integrity: sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==}
 
-  copy-anything@4.0.5:
-    resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
-    engines: {node: '>=18'}
-
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -2478,9 +2435,6 @@ packages:
   elliptic@6.6.1:
     resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
 
-  emoji-regex-xs@1.0.0:
-    resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
-
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -2493,6 +2447,10 @@ packages:
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   es-define-property@1.0.1:
@@ -2615,8 +2573,8 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
-  focus-trap@7.6.6:
-    resolution: {integrity: sha512-v/Z8bvMCajtx4mEXmOo7QEsIzlIOqRXTIwgUfsFOF9gEsespdbD0AkPIka1bSXZ8Y8oZ+2IVDQZePkTfEHZl7Q==}
+  focus-trap@8.2.2:
+    resolution: {integrity: sha512-qV0g8hRYBqgACcFOH3f9wXc4zPKhr/0z9RI2a6ZijZ72EeBi4g8oBy8zAWuUR1TsMpOzwpUMFvjdasrC41Joug==}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -2808,10 +2766,6 @@ packages:
   is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
 
-  is-what@5.5.0:
-    resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
-    engines: {node: '>=18'}
-
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
@@ -3001,8 +2955,8 @@ packages:
   md5.js@1.3.5:
     resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
 
-  mdast-util-from-markdown@2.0.2:
-    resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
 
   mdast-util-frontmatter@2.0.1:
     resolution: {integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==}
@@ -3113,19 +3067,16 @@ packages:
   minimalistic-crypto-utils@1.0.1:
     resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
 
-  minimatch@10.0.3:
-    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
-    engines: {node: 20 || >=22}
-
   minimatch@10.2.3:
     resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minisearch@7.2.0:
     resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
-
-  mitt@3.0.1:
-    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
   motion@10.16.2:
     resolution: {integrity: sha512-p+PurYqfUdcJZvtnmAqu5fJgV2kR0uLFQuBKtLeFVTrYEVllI99tiOTSefVNYuip9ELTEkepIIDftNdze76NAQ==}
@@ -3232,8 +3183,11 @@ packages:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
 
-  oniguruma-to-es@3.1.1:
-    resolution: {integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==}
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
   os-browserify@0.3.0:
     resolution: {integrity: sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==}
@@ -3320,8 +3274,8 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -3330,8 +3284,8 @@ packages:
     resolution: {integrity: sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==}
     engines: {node: '>= 0.10'}
 
-  perfect-debounce@1.0.0:
-    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+  perfect-debounce@2.1.0:
+    resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3377,9 +3331,6 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
-
-  preact@10.27.2:
-    resolution: {integrity: sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==}
 
   pretty-bytes@7.1.0:
     resolution: {integrity: sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==}
@@ -3494,8 +3445,8 @@ packages:
   regex-utilities@2.3.0:
     resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
 
-  regex@6.0.1:
-    resolution: {integrity: sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==}
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
   remark-frontmatter@5.0.0:
     resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
@@ -3527,9 +3478,6 @@ packages:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
     hasBin: true
-
-  rfdc@1.4.1:
-    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   ripemd160@2.0.3:
     resolution: {integrity: sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==}
@@ -3594,9 +3542,6 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
-  search-insights@2.17.3:
-    resolution: {integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==}
-
   section-matter@1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
@@ -3638,8 +3583,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shiki@2.5.0:
-    resolution: {integrity: sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==}
+  shiki@4.3.1:
+    resolution: {integrity: sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==}
+    engines: {node: '>=20'}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -3680,10 +3626,6 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
-
-  speakingurl@14.0.1:
-    resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
-    engines: {node: '>=0.10.0'}
 
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
@@ -3726,10 +3668,6 @@ packages:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
 
-  superjson@2.2.3:
-    resolution: {integrity: sha512-ay3d+LW/S6yppKoTz3Bq4mG0xrS5bFwfWEBmQfbC7lt5wmtk+Obq0TxVuA9eYRirBTQb1K3eEpBRHMQEo0WyVw==}
-    engines: {node: '>=16'}
-
   supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
@@ -3741,8 +3679,8 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
-  tabbable@6.3.0:
-    resolution: {integrity: sha512-EIHvdY5bPLuWForiR/AN2Bxngzpuwn1is4asboytXtpTgsArc+WmSJKVLlhdh71u7jFcryDqB2A8lQvj78MkyQ==}
+  tabbable@6.5.0:
+    resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
 
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
@@ -3778,8 +3716,8 @@ packages:
     resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
     engines: {node: '>= 0.4'}
 
-  tokenx@1.2.0:
-    resolution: {integrity: sha512-x4bRrL23b22H+EqW2pbhIkkt3ouj27ZGmAS1QoIqpocEO4m0sAl2H1M4L1UzKqleikY4U9lz/TbEw4jeG8tm2A==}
+  tokenx@1.3.0:
+    resolution: {integrity: sha512-NLdXTEZkKiO0gZuLtMoZKjCXTREXeZZt8nnnNeyoXtNZAfG/GKGSbQtLU5STspc0rMSwcA+UJfWZkbNU01iKmQ==}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -3864,6 +3802,9 @@ packages:
 
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
@@ -3999,11 +3940,12 @@ packages:
       '@vitest/browser-webdriverio':
         optional: true
 
-  vitepress-plugin-llms@1.8.1:
-    resolution: {integrity: sha512-Bxf7tbCvfNyANMip2cSydBQ14mV3c1t+1kqTd26CgMjehYtD7s4ANQ465OMLxw1apnT37PCktyXdLi3TWWihQA==}
+  vitepress-plugin-llms@1.13.3:
+    resolution: {integrity: sha512-C6bygRzuVp54kveM6pngVNg4H9sKMx7K67iwoO4PUzBK22NiXF9SoFm/WdjKp2fJrMcOabKtQMuyNFF20c2Anw==}
+    engines: {node: '>=18'}
 
-  vitepress@1.6.4:
-    resolution: {integrity: sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==}
+  vitepress@2.0.0-alpha.18:
+    resolution: {integrity: sha512-Lk1G2/QqSf+MwNLICl9fmzWOtoCEwjZoWgaQy41QvWTfcGpLE9XwJDbcCyES/9rj6R2g1zFqFvLVkYKLLDALFw==}
     hasBin: true
     peerDependencies:
       markdown-it-mathjax3: ^4
@@ -4060,6 +4002,14 @@ packages:
 
   vue@3.5.24:
     resolution: {integrity: sha512-uTHDOpVQTMjcGgrqFPSb8iO2m1DUvo+WbGqoXQz8Y1CeBYQ0FXf2z1gLRaBtHjlRz7zZUBHxjVB5VTLzYkvftg==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  vue@3.5.40:
+    resolution: {integrity: sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -4250,118 +4200,6 @@ snapshots:
 
   '@adraffy/ens-normalize@1.11.1': {}
 
-  '@algolia/abtesting@1.7.0':
-    dependencies:
-      '@algolia/client-common': 5.41.0
-      '@algolia/requester-browser-xhr': 5.41.0
-      '@algolia/requester-fetch': 5.41.0
-      '@algolia/requester-node-http': 5.41.0
-
-  '@algolia/autocomplete-core@1.17.7(@algolia/client-search@5.41.0)(algoliasearch@5.41.0)(search-insights@2.17.3)':
-    dependencies:
-      '@algolia/autocomplete-plugin-algolia-insights': 1.17.7(@algolia/client-search@5.41.0)(algoliasearch@5.41.0)(search-insights@2.17.3)
-      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.41.0)(algoliasearch@5.41.0)
-    transitivePeerDependencies:
-      - '@algolia/client-search'
-      - algoliasearch
-      - search-insights
-
-  '@algolia/autocomplete-plugin-algolia-insights@1.17.7(@algolia/client-search@5.41.0)(algoliasearch@5.41.0)(search-insights@2.17.3)':
-    dependencies:
-      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.41.0)(algoliasearch@5.41.0)
-      search-insights: 2.17.3
-    transitivePeerDependencies:
-      - '@algolia/client-search'
-      - algoliasearch
-
-  '@algolia/autocomplete-preset-algolia@1.17.7(@algolia/client-search@5.41.0)(algoliasearch@5.41.0)':
-    dependencies:
-      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.41.0)(algoliasearch@5.41.0)
-      '@algolia/client-search': 5.41.0
-      algoliasearch: 5.41.0
-
-  '@algolia/autocomplete-shared@1.17.7(@algolia/client-search@5.41.0)(algoliasearch@5.41.0)':
-    dependencies:
-      '@algolia/client-search': 5.41.0
-      algoliasearch: 5.41.0
-
-  '@algolia/client-abtesting@5.41.0':
-    dependencies:
-      '@algolia/client-common': 5.41.0
-      '@algolia/requester-browser-xhr': 5.41.0
-      '@algolia/requester-fetch': 5.41.0
-      '@algolia/requester-node-http': 5.41.0
-
-  '@algolia/client-analytics@5.41.0':
-    dependencies:
-      '@algolia/client-common': 5.41.0
-      '@algolia/requester-browser-xhr': 5.41.0
-      '@algolia/requester-fetch': 5.41.0
-      '@algolia/requester-node-http': 5.41.0
-
-  '@algolia/client-common@5.41.0': {}
-
-  '@algolia/client-insights@5.41.0':
-    dependencies:
-      '@algolia/client-common': 5.41.0
-      '@algolia/requester-browser-xhr': 5.41.0
-      '@algolia/requester-fetch': 5.41.0
-      '@algolia/requester-node-http': 5.41.0
-
-  '@algolia/client-personalization@5.41.0':
-    dependencies:
-      '@algolia/client-common': 5.41.0
-      '@algolia/requester-browser-xhr': 5.41.0
-      '@algolia/requester-fetch': 5.41.0
-      '@algolia/requester-node-http': 5.41.0
-
-  '@algolia/client-query-suggestions@5.41.0':
-    dependencies:
-      '@algolia/client-common': 5.41.0
-      '@algolia/requester-browser-xhr': 5.41.0
-      '@algolia/requester-fetch': 5.41.0
-      '@algolia/requester-node-http': 5.41.0
-
-  '@algolia/client-search@5.41.0':
-    dependencies:
-      '@algolia/client-common': 5.41.0
-      '@algolia/requester-browser-xhr': 5.41.0
-      '@algolia/requester-fetch': 5.41.0
-      '@algolia/requester-node-http': 5.41.0
-
-  '@algolia/ingestion@1.41.0':
-    dependencies:
-      '@algolia/client-common': 5.41.0
-      '@algolia/requester-browser-xhr': 5.41.0
-      '@algolia/requester-fetch': 5.41.0
-      '@algolia/requester-node-http': 5.41.0
-
-  '@algolia/monitoring@1.41.0':
-    dependencies:
-      '@algolia/client-common': 5.41.0
-      '@algolia/requester-browser-xhr': 5.41.0
-      '@algolia/requester-fetch': 5.41.0
-      '@algolia/requester-node-http': 5.41.0
-
-  '@algolia/recommend@5.41.0':
-    dependencies:
-      '@algolia/client-common': 5.41.0
-      '@algolia/requester-browser-xhr': 5.41.0
-      '@algolia/requester-fetch': 5.41.0
-      '@algolia/requester-node-http': 5.41.0
-
-  '@algolia/requester-browser-xhr@5.41.0':
-    dependencies:
-      '@algolia/client-common': 5.41.0
-
-  '@algolia/requester-fetch@5.41.0':
-    dependencies:
-      '@algolia/client-common': 5.41.0
-
-  '@algolia/requester-node-http@5.41.0':
-    dependencies:
-      '@algolia/client-common': 5.41.0
-
   '@babel/code-frame@7.27.1':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -4428,7 +4266,11 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -4440,6 +4282,10 @@ snapshots:
   '@babel/parser@7.28.5':
     dependencies:
       '@babel/types': 7.28.5
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
 
   '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -4476,6 +4322,11 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
   '@blazediff/core@1.9.1': {}
 
   '@crossmarkio/sdk@0.4.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
@@ -4498,32 +4349,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@docsearch/css@3.8.2': {}
+  '@docsearch/css@4.6.3': {}
 
-  '@docsearch/js@3.8.2(@algolia/client-search@5.41.0)(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)':
-    dependencies:
-      '@docsearch/react': 3.8.2(@algolia/client-search@5.41.0)(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)
-      preact: 10.27.2
-    transitivePeerDependencies:
-      - '@algolia/client-search'
-      - '@types/react'
-      - react
-      - react-dom
-      - search-insights
+  '@docsearch/js@4.6.3': {}
 
-  '@docsearch/react@3.8.2(@algolia/client-search@5.41.0)(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)':
-    dependencies:
-      '@algolia/autocomplete-core': 1.17.7(@algolia/client-search@5.41.0)(algoliasearch@5.41.0)(search-insights@2.17.3)
-      '@algolia/autocomplete-preset-algolia': 1.17.7(@algolia/client-search@5.41.0)(algoliasearch@5.41.0)
-      '@docsearch/css': 3.8.2
-      algoliasearch: 5.41.0
-    optionalDependencies:
-      '@types/react': 18.3.26
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      search-insights: 2.17.3
-    transitivePeerDependencies:
-      - '@algolia/client-search'
+  '@docsearch/sidepanel-js@4.6.3': {}
 
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
@@ -4605,17 +4435,11 @@ snapshots:
 
   '@gemwallet/api@3.8.0': {}
 
-  '@iconify-json/simple-icons@1.2.55':
+  '@iconify-json/simple-icons@1.2.91':
     dependencies:
       '@iconify/types': 2.0.0
 
   '@iconify/types@2.0.0': {}
-
-  '@isaacs/balanced-match@4.0.1': {}
-
-  '@isaacs/brace-expansion@5.0.0':
-    dependencies:
-      '@isaacs/balanced-match': 4.0.1
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -4921,6 +4745,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@rollup/plugin-inject@5.0.5(rollup@4.62.2)':
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.62.2)
@@ -5064,40 +4890,45 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
-  '@shikijs/core@2.5.0':
+  '@shikijs/core@4.3.1':
     dependencies:
-      '@shikijs/engine-javascript': 2.5.0
-      '@shikijs/engine-oniguruma': 2.5.0
-      '@shikijs/types': 2.5.0
+      '@shikijs/primitive': 4.3.1
+      '@shikijs/types': 4.3.1
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
-  '@shikijs/engine-javascript@2.5.0':
+  '@shikijs/engine-javascript@4.3.1':
     dependencies:
-      '@shikijs/types': 2.5.0
+      '@shikijs/types': 4.3.1
       '@shikijs/vscode-textmate': 10.0.2
-      oniguruma-to-es: 3.1.1
+      oniguruma-to-es: 4.3.6
 
-  '@shikijs/engine-oniguruma@2.5.0':
+  '@shikijs/engine-oniguruma@4.3.1':
     dependencies:
-      '@shikijs/types': 2.5.0
+      '@shikijs/types': 4.3.1
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/langs@2.5.0':
+  '@shikijs/langs@4.3.1':
     dependencies:
-      '@shikijs/types': 2.5.0
+      '@shikijs/types': 4.3.1
 
-  '@shikijs/themes@2.5.0':
+  '@shikijs/primitive@4.3.1':
     dependencies:
-      '@shikijs/types': 2.5.0
+      '@shikijs/types': 4.3.1
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
-  '@shikijs/transformers@2.5.0':
+  '@shikijs/themes@4.3.1':
     dependencies:
-      '@shikijs/core': 2.5.0
-      '@shikijs/types': 2.5.0
+      '@shikijs/types': 4.3.1
 
-  '@shikijs/types@2.5.0':
+  '@shikijs/transformers@4.3.1':
+    dependencies:
+      '@shikijs/core': 4.3.1
+      '@shikijs/types': 4.3.1
+
+  '@shikijs/types@4.3.1':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -5297,10 +5128,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.2.4(@voidzero-dev/vite-plus-core@0.2.5(@types/node@20.19.21)(esbuild@0.28.1)(typescript@5.9.3))(vue@3.5.24(typescript@5.9.3))':
+  '@vitejs/plugin-vue@6.0.8(@voidzero-dev/vite-plus-core@0.2.5(@types/node@20.19.21)(esbuild@0.28.1)(typescript@5.9.3))(vue@3.5.40(typescript@5.9.3))':
     dependencies:
+      '@rolldown/pluginutils': 1.0.1
       vite: '@voidzero-dev/vite-plus-core@0.2.5(@types/node@20.19.21)(esbuild@0.28.1)(typescript@5.9.3)'
-      vue: 3.5.24(typescript@5.9.3)
+      vue: 3.5.40(typescript@5.9.3)
 
   '@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.5(@types/node@20.19.21)(esbuild@0.28.1)(typescript@5.9.3))(bufferutil@4.0.9)(utf-8-validate@5.0.10)(vitest@4.1.10)':
     dependencies:
@@ -5418,10 +5250,23 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
+  '@vue/compiler-core@3.5.40':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.5.40
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
   '@vue/compiler-dom@3.5.24':
     dependencies:
       '@vue/compiler-core': 3.5.24
       '@vue/shared': 3.5.24
+
+  '@vue/compiler-dom@3.5.40':
+    dependencies:
+      '@vue/compiler-core': 3.5.40
+      '@vue/shared': 3.5.40
 
   '@vue/compiler-sfc@3.5.24':
     dependencies:
@@ -5435,37 +5280,58 @@ snapshots:
       postcss: 8.5.6
       source-map-js: 1.2.1
 
+  '@vue/compiler-sfc@3.5.40':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/compiler-core': 3.5.40
+      '@vue/compiler-dom': 3.5.40
+      '@vue/compiler-ssr': 3.5.40
+      '@vue/shared': 3.5.40
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.19
+      source-map-js: 1.2.1
+
   '@vue/compiler-ssr@3.5.24':
     dependencies:
       '@vue/compiler-dom': 3.5.24
       '@vue/shared': 3.5.24
 
-  '@vue/devtools-api@7.7.7':
+  '@vue/compiler-ssr@3.5.40':
     dependencies:
-      '@vue/devtools-kit': 7.7.7
+      '@vue/compiler-dom': 3.5.40
+      '@vue/shared': 3.5.40
 
-  '@vue/devtools-kit@7.7.7':
+  '@vue/devtools-api@8.1.5':
     dependencies:
-      '@vue/devtools-shared': 7.7.7
+      '@vue/devtools-kit': 8.1.5
+
+  '@vue/devtools-kit@8.1.5':
+    dependencies:
+      '@vue/devtools-shared': 8.1.5
       birpc: 2.6.1
       hookable: 5.5.3
-      mitt: 3.0.1
-      perfect-debounce: 1.0.0
-      speakingurl: 14.0.1
-      superjson: 2.2.3
+      perfect-debounce: 2.1.0
 
-  '@vue/devtools-shared@7.7.7':
-    dependencies:
-      rfdc: 1.4.1
+  '@vue/devtools-shared@8.1.5': {}
 
   '@vue/reactivity@3.5.24':
     dependencies:
       '@vue/shared': 3.5.24
 
+  '@vue/reactivity@3.5.40':
+    dependencies:
+      '@vue/shared': 3.5.40
+
   '@vue/runtime-core@3.5.24':
     dependencies:
       '@vue/reactivity': 3.5.24
       '@vue/shared': 3.5.24
+
+  '@vue/runtime-core@3.5.40':
+    dependencies:
+      '@vue/reactivity': 3.5.40
+      '@vue/shared': 3.5.40
 
   '@vue/runtime-dom@3.5.24':
     dependencies:
@@ -5474,44 +5340,51 @@ snapshots:
       '@vue/shared': 3.5.24
       csstype: 3.1.3
 
+  '@vue/runtime-dom@3.5.40':
+    dependencies:
+      '@vue/reactivity': 3.5.40
+      '@vue/runtime-core': 3.5.40
+      '@vue/shared': 3.5.40
+      csstype: 3.2.3
+
   '@vue/server-renderer@3.5.24(vue@3.5.24(typescript@5.9.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.24
       '@vue/shared': 3.5.24
       vue: 3.5.24(typescript@5.9.3)
 
-  '@vue/shared@3.5.22': {}
+  '@vue/server-renderer@3.5.40':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.40
+      '@vue/runtime-dom': 3.5.40
+      '@vue/shared': 3.5.40
 
   '@vue/shared@3.5.24': {}
 
-  '@vueuse/core@12.8.2(typescript@5.9.3)':
+  '@vue/shared@3.5.40': {}
+
+  '@vueuse/core@14.3.0(vue@3.5.40(typescript@5.9.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
-      '@vueuse/metadata': 12.8.2
-      '@vueuse/shared': 12.8.2(typescript@5.9.3)
-      vue: 3.5.24(typescript@5.9.3)
-    transitivePeerDependencies:
-      - typescript
+      '@vueuse/metadata': 14.3.0
+      '@vueuse/shared': 14.3.0(vue@3.5.40(typescript@5.9.3))
+      vue: 3.5.40(typescript@5.9.3)
 
-  '@vueuse/integrations@12.8.2(focus-trap@7.6.6)(idb-keyval@6.2.2)(qrcode@1.5.3)(typescript@5.9.3)':
+  '@vueuse/integrations@14.3.0(focus-trap@8.2.2)(idb-keyval@6.2.2)(qrcode@1.5.3)(vue@3.5.40(typescript@5.9.3))':
     dependencies:
-      '@vueuse/core': 12.8.2(typescript@5.9.3)
-      '@vueuse/shared': 12.8.2(typescript@5.9.3)
-      vue: 3.5.24(typescript@5.9.3)
+      '@vueuse/core': 14.3.0(vue@3.5.40(typescript@5.9.3))
+      '@vueuse/shared': 14.3.0(vue@3.5.40(typescript@5.9.3))
+      vue: 3.5.40(typescript@5.9.3)
     optionalDependencies:
-      focus-trap: 7.6.6
+      focus-trap: 8.2.2
       idb-keyval: 6.2.2
       qrcode: 1.5.3
-    transitivePeerDependencies:
-      - typescript
 
-  '@vueuse/metadata@12.8.2': {}
+  '@vueuse/metadata@14.3.0': {}
 
-  '@vueuse/shared@12.8.2(typescript@5.9.3)':
+  '@vueuse/shared@14.3.0(vue@3.5.40(typescript@5.9.3))':
     dependencies:
-      vue: 3.5.24(typescript@5.9.3)
-    transitivePeerDependencies:
-      - typescript
+      vue: 3.5.40(typescript@5.9.3)
 
   '@walletconnect/core@2.22.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
     dependencies:
@@ -5908,23 +5781,6 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  algoliasearch@5.41.0:
-    dependencies:
-      '@algolia/abtesting': 1.7.0
-      '@algolia/client-abtesting': 5.41.0
-      '@algolia/client-analytics': 5.41.0
-      '@algolia/client-common': 5.41.0
-      '@algolia/client-insights': 5.41.0
-      '@algolia/client-personalization': 5.41.0
-      '@algolia/client-query-suggestions': 5.41.0
-      '@algolia/client-search': 5.41.0
-      '@algolia/ingestion': 1.41.0
-      '@algolia/monitoring': 1.41.0
-      '@algolia/recommend': 5.41.0
-      '@algolia/requester-browser-xhr': 5.41.0
-      '@algolia/requester-fetch': 5.41.0
-      '@algolia/requester-node-http': 5.41.0
-
   ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
@@ -6190,10 +6046,6 @@ snapshots:
 
   cookie-es@1.2.2: {}
 
-  copy-anything@4.0.5:
-    dependencies:
-      is-what: 5.5.0
-
   core-util-is@1.0.3: {}
 
   create-ecdh@4.0.4:
@@ -6253,8 +6105,7 @@ snapshots:
 
   csstype@3.1.3: {}
 
-  csstype@3.2.3:
-    optional: true
+  csstype@3.2.3: {}
 
   d@1.0.2:
     dependencies:
@@ -6354,8 +6205,6 @@ snapshots:
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
 
-  emoji-regex-xs@1.0.0: {}
-
   emoji-regex@8.0.0: {}
 
   encode-utf8@1.0.3: {}
@@ -6363,6 +6212,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   es-define-property@1.0.1: {}
 
@@ -6506,9 +6357,9 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
-  focus-trap@7.6.6:
+  focus-trap@8.2.2:
     dependencies:
-      tabbable: 6.3.0
+      tabbable: 6.5.0
 
   for-each@0.3.5:
     dependencies:
@@ -6730,8 +6581,6 @@ snapshots:
 
   is-typedarray@1.0.0: {}
 
-  is-what@5.5.0: {}
-
   isarray@1.0.0: {}
 
   isarray@2.0.5: {}
@@ -6917,7 +6766,7 @@ snapshots:
       inherits: 2.0.4
       safe-buffer: 5.2.1
 
-  mdast-util-from-markdown@2.0.2:
+  mdast-util-from-markdown@2.0.3:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
@@ -6939,7 +6788,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       escape-string-regexp: 5.0.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       micromark-extension-frontmatter: 2.0.0
     transitivePeerDependencies:
@@ -6971,7 +6820,7 @@ snapshots:
       mdast-util-to-string: 4.0.0
       micromark-util-classify-character: 2.0.1
       micromark-util-decode-string: 2.0.1
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       zwitch: 2.0.4
 
   mdast-util-to-string@4.0.0:
@@ -7143,17 +6992,15 @@ snapshots:
 
   minimalistic-crypto-utils@1.0.1: {}
 
-  minimatch@10.0.3:
-    dependencies:
-      '@isaacs/brace-expansion': 5.0.0
-
   minimatch@10.2.3:
     dependencies:
       brace-expansion: 5.0.7
 
-  minisearch@7.2.0: {}
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.7
 
-  mitt@3.0.1: {}
+  minisearch@7.2.0: {}
 
   motion@10.16.2:
     dependencies:
@@ -7260,10 +7107,12 @@ snapshots:
 
   on-exit-leak-free@2.1.2: {}
 
-  oniguruma-to-es@3.1.1:
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
     dependencies:
-      emoji-regex-xs: 1.0.0
-      regex: 6.0.1
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
       regex-recursion: 6.0.2
 
   os-browserify@0.3.0: {}
@@ -7381,7 +7230,7 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  path-to-regexp@8.3.0: {}
+  path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
 
@@ -7394,7 +7243,7 @@ snapshots:
       sha.js: 2.4.12
       to-buffer: 1.2.2
 
-  perfect-debounce@1.0.0: {}
+  perfect-debounce@2.1.0: {}
 
   picocolors@1.1.1: {}
 
@@ -7443,8 +7292,6 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-
-  preact@10.27.2: {}
 
   pretty-bytes@7.1.0: {}
 
@@ -7557,7 +7404,7 @@ snapshots:
 
   regex-utilities@2.3.0: {}
 
-  regex@6.0.1:
+  regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
 
@@ -7573,7 +7420,7 @@ snapshots:
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -7607,8 +7454,6 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-
-  rfdc@1.4.1: {}
 
   ripemd160@2.0.3:
     dependencies:
@@ -7723,8 +7568,6 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  search-insights@2.17.3: {}
-
   section-matter@1.0.0:
     dependencies:
       extend-shallow: 2.0.1
@@ -7761,14 +7604,14 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shiki@2.5.0:
+  shiki@4.3.1:
     dependencies:
-      '@shikijs/core': 2.5.0
-      '@shikijs/engine-javascript': 2.5.0
-      '@shikijs/engine-oniguruma': 2.5.0
-      '@shikijs/langs': 2.5.0
-      '@shikijs/themes': 2.5.0
-      '@shikijs/types': 2.5.0
+      '@shikijs/core': 4.3.1
+      '@shikijs/engine-javascript': 4.3.1
+      '@shikijs/engine-oniguruma': 4.3.1
+      '@shikijs/langs': 4.3.1
+      '@shikijs/themes': 4.3.1
+      '@shikijs/types': 4.3.1
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
@@ -7820,8 +7663,6 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  speakingurl@14.0.1: {}
-
   split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
@@ -7865,10 +7706,6 @@ snapshots:
 
   strip-bom-string@1.0.0: {}
 
-  superjson@2.2.3:
-    dependencies:
-      copy-anything: 4.0.5
-
   supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
@@ -7877,7 +7714,7 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
-  tabbable@6.3.0: {}
+  tabbable@6.5.0: {}
 
   thread-stream@3.1.0:
     dependencies:
@@ -7914,7 +7751,7 @@ snapshots:
       safe-buffer: 5.2.1
       typed-array-buffer: 1.0.3
 
-  tokenx@1.2.0: {}
+  tokenx@1.3.0: {}
 
   totalist@3.0.1: {}
 
@@ -8003,6 +7840,12 @@ snapshots:
       unist-util-is: 6.0.1
 
   unist-util-visit@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  unist-util-visit@5.1.0:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
@@ -8143,52 +7986,51 @@ snapshots:
       - vite
       - yaml
 
-  vitepress-plugin-llms@1.8.1:
+  vitepress-plugin-llms@1.13.3:
     dependencies:
       gray-matter: 4.0.3
       markdown-it: 14.1.0
       markdown-title: 1.0.2
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       millify: 6.1.0
-      minimatch: 10.0.3
-      path-to-regexp: 8.3.0
+      minimatch: 10.2.5
+      path-to-regexp: 6.3.0
       picocolors: 1.1.1
       pretty-bytes: 7.1.0
       remark: 15.0.1
       remark-frontmatter: 5.0.0
-      tokenx: 1.2.0
+      tokenx: 1.3.0
       unist-util-remove: 4.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
     transitivePeerDependencies:
       - supports-color
 
-  vitepress@1.6.4(@algolia/client-search@5.41.0)(@types/node@20.19.21)(@types/react@18.3.26)(esbuild@0.28.1)(idb-keyval@6.2.2)(postcss@8.5.19)(qrcode@1.5.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3):
+  vitepress@2.0.0-alpha.18(@types/node@20.19.21)(esbuild@0.28.1)(idb-keyval@6.2.2)(postcss@8.5.19)(qrcode@1.5.3)(typescript@5.9.3):
     dependencies:
-      '@docsearch/css': 3.8.2
-      '@docsearch/js': 3.8.2(@algolia/client-search@5.41.0)(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)
-      '@iconify-json/simple-icons': 1.2.55
-      '@shikijs/core': 2.5.0
-      '@shikijs/transformers': 2.5.0
-      '@shikijs/types': 2.5.0
+      '@docsearch/css': 4.6.3
+      '@docsearch/js': 4.6.3
+      '@docsearch/sidepanel-js': 4.6.3
+      '@iconify-json/simple-icons': 1.2.91
+      '@shikijs/core': 4.3.1
+      '@shikijs/transformers': 4.3.1
+      '@shikijs/types': 4.3.1
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.4(@voidzero-dev/vite-plus-core@0.2.5(@types/node@20.19.21)(esbuild@0.28.1)(typescript@5.9.3))(vue@3.5.24(typescript@5.9.3))
-      '@vue/devtools-api': 7.7.7
-      '@vue/shared': 3.5.22
-      '@vueuse/core': 12.8.2(typescript@5.9.3)
-      '@vueuse/integrations': 12.8.2(focus-trap@7.6.6)(idb-keyval@6.2.2)(qrcode@1.5.3)(typescript@5.9.3)
-      focus-trap: 7.6.6
+      '@vitejs/plugin-vue': 6.0.8(@voidzero-dev/vite-plus-core@0.2.5(@types/node@20.19.21)(esbuild@0.28.1)(typescript@5.9.3))(vue@3.5.40(typescript@5.9.3))
+      '@vue/devtools-api': 8.1.5
+      '@vue/shared': 3.5.40
+      '@vueuse/core': 14.3.0(vue@3.5.40(typescript@5.9.3))
+      '@vueuse/integrations': 14.3.0(focus-trap@8.2.2)(idb-keyval@6.2.2)(qrcode@1.5.3)(vue@3.5.40(typescript@5.9.3))
+      focus-trap: 8.2.2
       mark.js: 8.11.1
       minisearch: 7.2.0
-      shiki: 2.5.0
+      shiki: 4.3.1
       vite: '@voidzero-dev/vite-plus-core@0.2.5(@types/node@20.19.21)(esbuild@0.28.1)(typescript@5.9.3)'
-      vue: 3.5.24(typescript@5.9.3)
+      vue: 3.5.40(typescript@5.9.3)
     optionalDependencies:
       postcss: 8.5.19
     transitivePeerDependencies:
-      - '@algolia/client-search'
       - '@arethetypeswrong/core'
       - '@types/node'
-      - '@types/react'
       - '@vitejs/devtools'
       - async-validator
       - axios
@@ -8203,11 +8045,8 @@ snapshots:
       - nprogress
       - publint
       - qrcode
-      - react
-      - react-dom
       - sass
       - sass-embedded
-      - search-insights
       - sortablejs
       - stylus
       - sugarss
@@ -8257,6 +8096,16 @@ snapshots:
       '@vue/runtime-dom': 3.5.24
       '@vue/server-renderer': 3.5.24(vue@3.5.24(typescript@5.9.3))
       '@vue/shared': 3.5.24
+    optionalDependencies:
+      typescript: 5.9.3
+
+  vue@3.5.40(typescript@5.9.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.40
+      '@vue/compiler-sfc': 3.5.40
+      '@vue/runtime-dom': 3.5.40
+      '@vue/server-renderer': 3.5.40
+      '@vue/shared': 3.5.40
     optionalDependencies:
       typescript: 5.9.3
 


### PR DESCRIPTION
## Summary

- refresh the documentation for the XRPL Connect v1.0 release
- document the official Vue 3 and Nuxt bindings introduced by PR #114
- add wallet, transaction, production, migration, and expanded API guidance
- upgrade the docs site to VitePress 2 and restore the interactive theme builder

## Impact

Developers now have consistent v1 installation and integration guidance for vanilla JavaScript, React, Vue 3, and Nuxt, including typed errors, capability checks, SSR boundaries, persistence, and signing flows.

## Validation

- `pnpm docs:build`
- `pnpm format:check`
- `git diff --check origin/develop...HEAD`
