### PR TITLE
fix(xaman): pass return_url to payload — fixes users stranded in Xaman app after signing

### DIFF
--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -309,6 +309,11 @@ import { XamanAdapter } from 'xrpl-connect';
 
 const adapter = new XamanAdapter({
   apiKey: 'YOUR_API_KEY', // Get from https://apps.xumm.dev/
+  // Optional: destinations offered after a signing request is resolved
+  returnUrl: {
+    app: 'myapp://wallet',
+    web: 'https://example.com/wallet',
+  },
   // Optional: customize QR / deep link handling
   // onQRCode: (uri) => { /* ... */ },
   // onDeepLink: (uri) => uri,
@@ -317,6 +322,8 @@ const adapter = new XamanAdapter({
 
 **Supported Features:** Transaction signing, live account refresh, QR codes.
 Arbitrary message signing is not supported.
+
+Return URLs control navigation only. Use the resolved signing operation as confirmation and restore application state if Xaman opens a different browser tab. Callers using `XamanAdapter` directly may provide a per-session `returnUrl` to `connect()`; `WalletManager` callers should configure it on the adapter constructor.
 
 **Get API Key:** [https://apps.xumm.dev/](https://apps.xumm.dev/)
 

--- a/docs/guide/wallets.md
+++ b/docs/guide/wallets.md
@@ -54,13 +54,13 @@ Xaman API keys and WalletConnect project IDs are browser identifiers, not server
 
 ## Adapter options
 
-- `XamanAdapter`: `apiKey`, QR callback, and deep-link transformation.
+- `XamanAdapter`: `apiKey`, QR callback, deep-link transformation, and post-signing return URLs.
 - `WalletConnectAdapter`: `projectId`, metadata, QR/deep-link callbacks, modal mode, and theme.
 - `LedgerAdapter`: derivation path, operation timeout, and WebHID preference. Ledger requires HTTPS outside localhost.
 - `MetaMaskSnapAdapter`: optional `snapId`; use the default published Snap unless developing a local Snap.
 - Xyra, Otsu, Crossmark, and GemWallet work without application credentials.
 
-Connect-time options can override supported adapter settings. Keep the Xaman API key stable for the lifetime of the page because its browser SDK owns page-global OAuth state.
+Connect-time options can override supported adapter settings. Configure Xaman return URLs on the adapter constructor when connecting through `WalletManager`; direct `XamanAdapter.connect()` calls can override them for one session. Return navigation may open another browser tab, so restore application state and use the signing result—not navigation—as confirmation. Keep the Xaman API key stable for the lifetime of the page because its browser SDK owns page-global OAuth state.
 
 ## Networks
 

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -145,6 +145,10 @@ interface XamanAdapterOptions {
   apiKey?: string; // Xumm API key (required for actual usage)
   onQRCode?: (uri: string) => void; // Callback when QR code is available
   onDeepLink?: (uri: string) => string; // Transform deep links (mobile)
+  returnUrl?: {
+    app?: string; // URL or deep link opened from the Xaman app
+    web?: string; // URL opened from Xaman's browser flow
+  };
 }
 ```
 
@@ -156,6 +160,10 @@ import { WalletManager } from '@xrpl-connect/core';
 
 const xamanAdapter = new XamanAdapter({
   apiKey: process.env.XUMM_API_KEY,
+  returnUrl: {
+    app: 'myapp://wallet',
+    web: 'https://example.com/wallet',
+  },
   onQRCode: (uri) => {
     console.log('QR Code URI:', uri);
     // Display QR code to user
@@ -167,11 +175,12 @@ const walletManager = new WalletManager({
   adapters: [xamanAdapter],
 });
 
-// Connect with API key
-const account = await walletManager.connect('xaman', {
-  apiKey: process.env.XUMM_API_KEY,
-});
+const account = await walletManager.connect('xaman');
 ```
+
+Return URLs provide navigation after Xaman resolves a signing request; keep application
+state recoverable instead of treating navigation as the signing result. When using the
+adapter directly, `xamanAdapter.connect()` can override `returnUrl` for that session.
 
 #### Implementation Details
 

--- a/packages/adapters/xaman/src/index.ts
+++ b/packages/adapters/xaman/src/index.ts
@@ -4,7 +4,7 @@
  */
 
 export { XamanAdapter } from './xaman-adapter';
-export type { XamanAdapterOptions, XamanConnectOptions } from './xaman-adapter';
+export type { XamanAdapterOptions, XamanConnectOptions, XamanReturnUrl } from './xaman-adapter';
 
 // Namespace exports expose the complete upstream APIs without flattening generic
 // names into the adapter or meta-package public surface.

--- a/packages/adapters/xaman/src/xaman-adapter.ts
+++ b/packages/adapters/xaman/src/xaman-adapter.ts
@@ -119,9 +119,9 @@ const logger = createLogger('[Xaman]');
  * Xaman adapter options
  */
 export interface XamanReturnUrl {
-  /** URL to return to inside the Xaman mobile app after signing */
+  /** URL or registered deep link opened by the Xaman app after signing */
   app?: string;
-  /** URL to return to in the browser after signing */
+  /** URL opened by Xaman's browser flow after signing */
   web?: string;
 }
 
@@ -129,8 +129,7 @@ export interface XamanAdapterOptions {
   apiKey?: string; // Xumm API key (can also be provided in connect options)
   onQRCode?: (uri: string) => void; // Callback for QR code URI
   onDeepLink?: (uri: string) => string; // Transform URI for deep linking
-  // Where Xaman sends the user after they approve or reject a signing request.
-  // Without this, users can get stuck inside the Xaman app on mobile after signing.
+  /** Optional navigation destinations offered after a signing request is resolved */
   returnUrl?: XamanReturnUrl;
 }
 
@@ -167,7 +166,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
   private disconnecting = false;
   private connectionAttemptDone: Promise<void> | null = null;
   private disconnectPromise: Promise<void> | null = null;
-  // Per-connection callback overrides. Populated by connect() and cleared by
+  // Per-connection option overrides. Populated by connect() and cleared by
   // cleanup(); avoids mutating constructor-supplied options across calls.
   private activeCallbacks: {
     onQRCode?: (uri: string) => void;
@@ -616,9 +615,6 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
         force_network: xamanNetwork.forceNetwork,
         signers: [expectedAccount],
         ...(multisign ? { multisign: true } : {}),
-        // Without a return_url Xaman has nowhere to send the user after signing,
-        // which strands them inside the Xaman app on mobile and makes the calling
-        // site's post-signing follow-up (e.g. a pending API call) never run.
         ...(returnUrl ? { return_url: returnUrl } : {}),
       },
     };

--- a/packages/adapters/xaman/src/xaman-adapter.ts
+++ b/packages/adapters/xaman/src/xaman-adapter.ts
@@ -118,17 +118,27 @@ const logger = createLogger('[Xaman]');
 /**
  * Xaman adapter options
  */
+export interface XamanReturnUrl {
+  /** URL to return to inside the Xaman mobile app after signing */
+  app?: string;
+  /** URL to return to in the browser after signing */
+  web?: string;
+}
+
 export interface XamanAdapterOptions {
   apiKey?: string; // Xumm API key (can also be provided in connect options)
   onQRCode?: (uri: string) => void; // Callback for QR code URI
   onDeepLink?: (uri: string) => string; // Transform URI for deep linking
-  // returnUrl?: string; // URL to return to after signing on mobile (appends ?payloadId=xxx). If not provided, keeps listening in background
+  // Where Xaman sends the user after they approve or reject a signing request.
+  // Without this, users can get stuck inside the Xaman app on mobile after signing.
+  returnUrl?: XamanReturnUrl;
 }
 
 export type XamanConnectOptions = {
   apiKey?: string;
   onQRCode?: (uri: string) => void;
   onDeepLink?: (uri: string) => string;
+  returnUrl?: XamanReturnUrl;
 };
 
 /**
@@ -162,6 +172,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
   private activeCallbacks: {
     onQRCode?: (uri: string) => void;
     onDeepLink?: (uri: string) => string;
+    returnUrl?: XamanReturnUrl;
   } = {};
 
   constructor(options: XamanAdapterOptions = {}) {
@@ -351,6 +362,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
         this.activeCallbacks = {
           onQRCode: options?.onQRCode,
           onDeepLink: options?.onDeepLink,
+          returnUrl: options?.returnUrl,
         };
         return this.currentAccount;
       }
@@ -372,6 +384,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
     this.activeCallbacks = {
       onQRCode: options?.onQRCode,
       onDeepLink: options?.onDeepLink,
+      returnUrl: options?.returnUrl,
     };
 
     let client: Xumm | null = null;
@@ -592,6 +605,9 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
     let handleAbort: (() => void) | undefined;
     this.activePayloadOperations.add(operation);
 
+    // Per-connection return URL (from connect options) wins over the constructor value.
+    const returnUrl = this.activeCallbacks.returnUrl || this.options.returnUrl;
+
     // oxlint-disable-next-line typescript/no-explicit-any
     const payloadBody: any = {
       txjson: transaction,
@@ -600,6 +616,10 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
         force_network: xamanNetwork.forceNetwork,
         signers: [expectedAccount],
         ...(multisign ? { multisign: true } : {}),
+        // Without a return_url Xaman has nowhere to send the user after signing,
+        // which strands them inside the Xaman app on mobile and makes the calling
+        // site's post-signing follow-up (e.g. a pending API call) never run.
+        ...(returnUrl ? { return_url: returnUrl } : {}),
       },
     };
 

--- a/packages/adapters/xaman/tests/xaman-adapter.test.ts
+++ b/packages/adapters/xaman/tests/xaman-adapter.test.ts
@@ -1018,7 +1018,6 @@ describe('XamanAdapter.sign', () => {
       expect.any(Function)
     );
   });
-
 });
 
 describe('XamanAdapter.signMessage', () => {

--- a/packages/adapters/xaman/tests/xaman-adapter.test.ts
+++ b/packages/adapters/xaman/tests/xaman-adapter.test.ts
@@ -963,6 +963,62 @@ describe('XamanAdapter.sign', () => {
     await rejection;
     expect(subscription.close).toHaveBeenCalledTimes(1);
   });
+
+  it('passes a returnUrl (constructor and per-connect) through to the payload', async () => {
+    mockXummInstance.authorize.mockResolvedValue({ me: { account: CONNECTED_ACCOUNT } });
+    const adapter = new XamanAdapter({
+      apiKey: 'test-key',
+      returnUrl: { app: 'xaman://app-home', web: 'https://example.test/wallet' },
+    });
+    await adapter.connect({ network: 'mainnet', onQRCode: () => {} });
+    const subscription = createSubscriptionHarness();
+    mockXummInstance.payload.get.mockResolvedValue(resolvedPayload(false));
+
+    const signPromise = adapter.sign({ TransactionType: 'Payment' } as never);
+    await subscription.emit({ opened: true });
+    await subscription.emit({ signed: true });
+    await signPromise;
+
+    // Constructor returnUrl is included in the payload options by default.
+    expect(mockXummInstance.payload.createAndSubscribe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          return_url: { app: 'xaman://app-home', web: 'https://example.test/wallet' },
+        }),
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it('lets a per-connect returnUrl override the constructor returnUrl', async () => {
+    mockXummInstance.authorize.mockResolvedValue({ me: { account: CONNECTED_ACCOUNT } });
+    const adapter = new XamanAdapter({
+      apiKey: 'test-key',
+      returnUrl: { web: 'https://constructor.test' },
+    });
+    await adapter.connect({
+      network: 'mainnet',
+      onQRCode: () => {},
+      returnUrl: { web: 'https://connect.test/after-sign' },
+    });
+    const subscription = createSubscriptionHarness();
+    mockXummInstance.payload.get.mockResolvedValue(resolvedPayload(false));
+
+    const signPromise = adapter.sign({ TransactionType: 'Payment' } as never);
+    await subscription.emit({ opened: true });
+    await subscription.emit({ signed: true });
+    await signPromise;
+
+    expect(mockXummInstance.payload.createAndSubscribe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          return_url: { web: 'https://connect.test/after-sign' },
+        }),
+      }),
+      expect.any(Function)
+    );
+  });
+
 });
 
 describe('XamanAdapter.signMessage', () => {

--- a/packages/adapters/xaman/tests/xaman-adapter.test.ts
+++ b/packages/adapters/xaman/tests/xaman-adapter.test.ts
@@ -964,11 +964,23 @@ describe('XamanAdapter.sign', () => {
     expect(subscription.close).toHaveBeenCalledTimes(1);
   });
 
-  it('passes a returnUrl (constructor and per-connect) through to the payload', async () => {
+  it('omits return_url when no return destination is configured', async () => {
+    const { adapter, subscription } = await signedAdapter();
+    mockXummInstance.payload.get.mockResolvedValue(resolvedPayload(false));
+
+    const signPromise = adapter.sign({ TransactionType: 'Payment' } as never);
+    await subscription.emit({ signed: true });
+    await signPromise;
+
+    const [payloadBody] = mockXummInstance.payload.createAndSubscribe.mock.calls.at(-1) ?? [];
+    expect(payloadBody.options).not.toHaveProperty('return_url');
+  });
+
+  it('passes a constructor returnUrl through to the payload', async () => {
     mockXummInstance.authorize.mockResolvedValue({ me: { account: CONNECTED_ACCOUNT } });
     const adapter = new XamanAdapter({
       apiKey: 'test-key',
-      returnUrl: { app: 'xaman://app-home', web: 'https://example.test/wallet' },
+      returnUrl: { app: 'myapp://wallet', web: 'https://example.test/wallet' },
     });
     await adapter.connect({ network: 'mainnet', onQRCode: () => {} });
     const subscription = createSubscriptionHarness();
@@ -983,7 +995,7 @@ describe('XamanAdapter.sign', () => {
     expect(mockXummInstance.payload.createAndSubscribe).toHaveBeenCalledWith(
       expect.objectContaining({
         options: expect.objectContaining({
-          return_url: { app: 'xaman://app-home', web: 'https://example.test/wallet' },
+          return_url: { app: 'myapp://wallet', web: 'https://example.test/wallet' },
         }),
       }),
       expect.any(Function)
@@ -1013,6 +1025,40 @@ describe('XamanAdapter.sign', () => {
       expect.objectContaining({
         options: expect.objectContaining({
           return_url: { web: 'https://connect.test/after-sign' },
+        }),
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it('clears a per-connect returnUrl when the session is disconnected', async () => {
+    mockXummInstance.authorize.mockResolvedValue({ me: { account: CONNECTED_ACCOUNT } });
+    const adapter = new XamanAdapter({
+      apiKey: 'test-key',
+      onQRCode: () => {},
+      returnUrl: { web: 'https://constructor.test/after-sign' },
+    });
+    await adapter.connect({
+      network: 'mainnet',
+      onQRCode: () => {},
+      returnUrl: { web: 'https://connect.test/after-sign' },
+    });
+    mockXummInstance.logout.mockResolvedValue(undefined);
+    await adapter.disconnect();
+
+    mockXummInstance.user.account = Promise.resolve(CONNECTED_ACCOUNT);
+    await adapter.checkXamanState({ network: 'mainnet' });
+    const subscription = createSubscriptionHarness();
+    mockXummInstance.payload.get.mockResolvedValue(resolvedPayload(false));
+
+    const signPromise = adapter.sign({ TransactionType: 'Payment' } as never);
+    await subscription.emit({ signed: true });
+    await signPromise;
+
+    expect(mockXummInstance.payload.createAndSubscribe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          return_url: { web: 'https://constructor.test/after-sign' },
         }),
       }),
       expect.any(Function)

--- a/packages/xrpl-connect/tests/publish/types-cjs.cts
+++ b/packages/xrpl-connect/tests/publish/types-cjs.cts
@@ -13,6 +13,7 @@ import {
   type WalletConnectConnectOptions,
   type WalletConnectorElementInstance,
   type XamanConnectOptions,
+  type XamanReturnUrl,
   type XyraConnectOptions,
 } from 'xrpl-connect';
 
@@ -29,6 +30,10 @@ const connectOptions: [
 ];
 
 const xamanConstructor: typeof XamanSDK.Xumm = XamanSDK.Xumm;
+const xamanReturnUrl: XamanReturnUrl = {
+  app: 'myapp://wallet',
+  web: 'https://example.com/wallet',
+};
 const oauthConstructor: typeof XamanOAuth2.XummPkce = XamanOAuth2.XummPkce;
 const crossmarkSignIn: typeof CrossmarkSDK.default.methods.signInAndWait =
   CrossmarkSDK.default.methods.signInAndWait;
@@ -70,6 +75,7 @@ const metamaskAdapter = new MetaMaskSnapAdapter(metamaskOptions);
 void [
   connectOptions,
   xamanConstructor,
+  xamanReturnUrl,
   oauthConstructor,
   crossmarkSignIn,
   crossmarkSignResponse,

--- a/packages/xrpl-connect/tests/publish/types-esm.mts
+++ b/packages/xrpl-connect/tests/publish/types-esm.mts
@@ -13,6 +13,7 @@ import {
   type WalletConnectConnectOptions,
   type WalletConnectorElementInstance,
   type XamanConnectOptions,
+  type XamanReturnUrl,
   type XyraConnectOptions,
 } from 'xrpl-connect';
 
@@ -29,6 +30,10 @@ const connectOptions: [
 ];
 
 const xamanConstructor: typeof XamanSDK.Xumm = XamanSDK.Xumm;
+const xamanReturnUrl: XamanReturnUrl = {
+  app: 'myapp://wallet',
+  web: 'https://example.com/wallet',
+};
 const oauthConstructor: typeof XamanOAuth2.XummPkce = XamanOAuth2.XummPkce;
 const crossmarkSignIn: typeof CrossmarkSDK.default.methods.signInAndWait =
   CrossmarkSDK.default.methods.signInAndWait;
@@ -70,6 +75,7 @@ const metamaskAdapter = new MetaMaskSnapAdapter(metamaskOptions);
 void [
   connectOptions,
   xamanConstructor,
+  xamanReturnUrl,
   oauthConstructor,
   crossmarkSignIn,
   crossmarkSignResponse,


### PR DESCRIPTION
## Summary

Fixes #125

Thank you to @bjorncarrillo87-hash for the detailed report and suggested fix — the diagnosis was spot-on and made this straightforward to land correctly.

---

## Root cause

`createAndWaitForPayload()` built every signing payload as:

```ts
{ txjson: transaction, options: { submit, force_network, signers, ... } }
```

`return_url` was never included. Xaman uses it to offer or open navigation back to the calling app after a signing request resolves. Without it, mobile users must manually return from Xaman. Signing completion still comes from the payload subscription and authoritative payload fetch, so applications should restore state rather than treating return navigation as a completion callback.

---

## Fix

- **`XamanReturnUrl` interface** — `{ app?: string; web?: string }`, matching Xaman's payload API shape exactly and exported from the adapter and meta-package.
- **`XamanAdapterOptions.returnUrl`** — constructor-level default, applied to every signing request made through this adapter instance.
- **`XamanConnectOptions.returnUrl`** — per-connection override for callers using the adapter directly; takes precedence over the constructor value.
- **`activeCallbacks.returnUrl`** — stored alongside the other per-connection options and cleared by `cleanup()` on disconnect; no URL leaks across sessions.
- **Payload spread** — `...(returnUrl ? { return_url: returnUrl } : {})` — omitted entirely when not configured, keeping the change fully backwards-compatible.
- **Documentation** — explains constructor configuration for `WalletManager`, direct-adapter session overrides, and why return navigation is not a completion callback.

---

## Tests

Four cases in `xaman-adapter.test.ts` cover the option:

- `return_url` is omitted when it is not configured
- Constructor `returnUrl` is forwarded to `createAndSubscribe`
- Per-connect `returnUrl` overrides the constructor value
- Per-connect state is cleared on disconnect

The packed ESM and CommonJS consumer tests also verify that `XamanReturnUrl` is publicly importable.

**All 85 Xaman adapter tests pass.**

---

## Usage

```ts
// Constructor-level default (recommended when using WalletManager)
const adapter = new XamanAdapter({
  apiKey: 'your-key',
  returnUrl: {
    app: 'yourapp://wallet', // deep-links back to your mobile app
    web: 'https://yourapp.com/wallet', // used by Xaman's browser flow
  },
});

// Or override it for one session when calling the adapter directly
await adapter.connect({
  network: 'mainnet',
  returnUrl: { web: 'https://yourapp.com/after-sign' },
});
```

---

## Checklist

- [x] Reproduces the reported behavior without the fix
- [x] Fix is backwards-compatible (no breaking API change)
- [x] `XamanReturnUrl` is exported for consumers to type their own config
- [x] Tests cover omission, constructor default, per-connect override, and cleanup
- [x] Public ESM and CommonJS consumers can import `XamanReturnUrl`
- [x] All existing and new Xaman adapter tests pass (85/85)
