### PR TITLE
fix: validate WalletConnect session accounts

### DIFF
--- a/docs/guide/wallets.md
+++ b/docs/guide/wallets.md
@@ -64,7 +64,7 @@ Connect-time options can override supported adapter settings. Keep the Xaman API
 
 ## Networks
 
-Pass `mainnet`, `testnet`, `devnet`, or a supported `NetworkConfig` to `WalletManager`. Adapters validate the selected network and reject contradictory wallet responses. Start development on testnet and display the active network beside every signing action.
+Pass `mainnet`, `testnet`, `devnet`, or a supported `NetworkConfig` to `WalletManager`. Adapters validate the selected network and reject contradictory wallet responses. In particular, WalletConnect accepts only a well-formed CAIP-10 account with a valid XRPL classic address on the requested chain; malformed responses or sessions without a matching chain are disconnected and rejected. Start development on testnet and display the active network beside every signing action.
 
 ## Availability and ordering
 

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -313,7 +313,7 @@ WalletConnect is a multi-wallet connection protocol supporting dozens of mobile 
 - ✅ QR code-based pairing
 - ✅ Mobile-first design
 - ✅ Pre-initialization for faster loading
-- ✅ Supports XRPL and other blockchains
+- ✅ Supports XRPL mainnet, testnet, devnet, and custom XRPL networks
 
 #### Constructor
 
@@ -355,7 +355,7 @@ For improved user experience, pre-initialize WalletConnect before the user inter
 
 ```typescript
 // Initialize during app load, not on first user click
-await wcAdapter.preInitialize('your-project-id', 'mainnet');
+await wcAdapter.preInitialize('mainnet');
 ```
 
 This eagerly initializes the WalletConnect infrastructure, reducing latency when the user first clicks "Connect".
@@ -366,6 +366,7 @@ This eagerly initializes the WalletConnect infrastructure, reducing latency when
 - **connect()**: Generates QR code and waits for wallet connection
 - **Multi-wallet**: Shows wallet selection after QR scan
 - **Namespace**: Uses `xrpl` namespace for XRPL networks
+- **Validation**: Accepts only a valid XRPL classic address whose CAIP-10 chain matches the requested network; invalid approved sessions are disconnected
 
 ---
 

--- a/packages/adapters/walletconnect/src/constants.ts
+++ b/packages/adapters/walletconnect/src/constants.ts
@@ -30,13 +30,6 @@ export const LOGGING = {
 } as const;
 
 /**
- * Account parsing configuration
- */
-export const ACCOUNT_FORMAT = {
-  ADDRESS_INDEX: 2, // Index of address in "xrpl:chainId:rAddress" format
-} as const;
-
-/**
  * XRPL WalletConnect namespace configuration
  */
 export const XRPL_NAMESPACE = {

--- a/packages/adapters/walletconnect/src/walletconnect-adapter.ts
+++ b/packages/adapters/walletconnect/src/walletconnect-adapter.ts
@@ -5,6 +5,7 @@
 import SignClient from '@walletconnect/sign-client';
 import { WalletConnectModal } from '@walletconnect/modal';
 import type { SignClientTypes, SessionTypes } from '@walletconnect/types';
+import { parseUri } from '@walletconnect/utils';
 import { isValidClassicAddress } from 'xrpl';
 import type {
   WalletAdapter,
@@ -46,6 +47,21 @@ export enum XRPLMethod {
  * alongside the standard XRPL transaction fields.
  */
 type WalletConnectSignedTxJson = Transaction & { hash?: string };
+
+type ConnectionProposal = {
+  uri?: string;
+  approval: () => Promise<SessionTypes.Struct>;
+  approvalPromise?: Promise<SessionTypes.Struct>;
+  cancellationPromise: Promise<void>;
+  cancel: () => void;
+  chainId: string;
+  projectId: string;
+  client: SignClient;
+};
+
+type PendingConnection = ConnectionProposal & { uri: string };
+
+type SessionLifecycleEvent = { topic: string };
 
 function isValidXrplChainId(chainId: string): boolean {
   const match = chainId.match(/^xrpl:(0|[1-9]\d*)$/);
@@ -142,15 +158,131 @@ export class WalletConnectAdapter
   private currentAccount: AccountInfo | null = null;
   private options: WalletConnectAdapterOptions;
   private initializationPromise: Promise<SignClient> | null = null;
+  private initializationProjectId: string | null = null;
+  private clientProjectId: string | null = null;
   private connectionAttemptGeneration = 0;
-  private pendingConnection: { uri: string; approval: () => Promise<SessionTypes.Struct> } | null =
-    null;
+  private pendingConnection: PendingConnection | null = null;
+  private activeConnectionProposals = new Map<number, ConnectionProposal>();
+  private closedConnectionProposals = new WeakSet<ConnectionProposal>();
   private modal: WalletConnectModal | null = null;
-  private sessionDeleteHandler: (() => void) | null = null;
-  private sessionExpireHandler: (() => void) | null = null;
+  private eventListenerClient: SignClient | null = null;
+  private sessionDeleteHandler: ((event: SessionLifecycleEvent) => void) | null = null;
+  private sessionExpireHandler: ((event: SessionLifecycleEvent) => void) | null = null;
 
   constructor(options: WalletConnectAdapterOptions = {}) {
     this.options = options;
+  }
+
+  private async getOrInitializeClient(projectId: string): Promise<SignClient> {
+    if (this.client) {
+      if (this.clientProjectId !== projectId) {
+        throw new Error('Cannot change WalletConnect project ID after initialization');
+      }
+      return this.client;
+    }
+
+    let initialization = this.initializationPromise;
+    if (initialization && this.initializationProjectId !== projectId) {
+      throw new Error('Cannot change WalletConnect project ID while initialization is pending');
+    }
+    if (!initialization) {
+      initialization = SignClient.init({
+        projectId,
+        metadata: this.options.metadata || {
+          name: DEFAULT_METADATA.NAME,
+          description: DEFAULT_METADATA.DESCRIPTION,
+          url:
+            typeof window !== 'undefined' ? window.location.origin : DEFAULT_METADATA.DEFAULT_URL,
+          icons: [DEFAULT_METADATA.DEFAULT_ICON],
+        },
+      });
+      this.initializationPromise = initialization;
+      this.initializationProjectId = projectId;
+    }
+
+    try {
+      const client = await initialization;
+      if (this.initializationPromise === initialization) {
+        this.client = client;
+        this.clientProjectId = projectId;
+      }
+      return client;
+    } catch (error) {
+      if (this.initializationPromise === initialization) {
+        this.initializationPromise = null;
+        this.initializationProjectId = null;
+      }
+      throw error;
+    }
+  }
+
+  private async closeConnectionProposal(proposal: ConnectionProposal): Promise<void> {
+    if (this.closedConnectionProposals.has(proposal)) {
+      return;
+    }
+    this.closedConnectionProposals.add(proposal);
+    proposal.cancel();
+
+    void this.approveConnectionProposal(proposal)
+      .then((session) =>
+        proposal.client.disconnect({
+          topic: session.topic,
+          reason: DISCONNECT_REASONS.USER_DISCONNECTED,
+        })
+      )
+      .catch((error) => {
+        logger.debug('Unused WalletConnect proposal ended:', error);
+      });
+
+    if (proposal.uri) {
+      try {
+        await proposal.client.core.pairing.disconnect({ topic: parseUri(proposal.uri).topic });
+      } catch (error) {
+        logger.warn('Failed to close unused WalletConnect proposal:', error);
+      }
+    }
+  }
+
+  private approveConnectionProposal(proposal: ConnectionProposal): Promise<SessionTypes.Struct> {
+    proposal.approvalPromise ??= Promise.resolve().then(() => proposal.approval());
+    return proposal.approvalPromise;
+  }
+
+  private waitForConnectionProposal(proposal: ConnectionProposal): Promise<SessionTypes.Struct> {
+    return Promise.race([
+      this.approveConnectionProposal(proposal),
+      proposal.cancellationPromise.then(() => {
+        throw new Error('WalletConnect connection was cancelled');
+      }),
+    ]);
+  }
+
+  private createConnectionProposal(
+    client: SignClient,
+    chainId: string,
+    projectId: string,
+    result: { uri?: string; approval: () => Promise<SessionTypes.Struct> }
+  ): ConnectionProposal {
+    let cancel!: () => void;
+    const cancellationPromise = new Promise<void>((resolve) => {
+      cancel = resolve;
+    });
+    return { ...result, cancellationPromise, cancel, chainId, projectId, client };
+  }
+
+  private async closeActiveConnectionProposals(): Promise<void> {
+    const proposals = [...this.activeConnectionProposals.values()];
+    this.activeConnectionProposals.clear();
+    await Promise.all(proposals.map((proposal) => this.closeConnectionProposal(proposal)));
+  }
+
+  private releaseActiveConnectionProposal(
+    connectionAttempt: number,
+    proposal: ConnectionProposal
+  ): void {
+    if (this.activeConnectionProposals.get(connectionAttempt) === proposal) {
+      this.activeConnectionProposals.delete(connectionAttempt);
+    }
   }
 
   /**
@@ -206,6 +338,7 @@ export class WalletConnectAdapter
    */
   async preInitialize(network?: NetworkConfig, onQRCode?: (uri: string) => void): Promise<void> {
     const pid = this.options.projectId;
+    let proposal: ConnectionProposal | null = null;
 
     if (!pid) {
       logger.warn('Cannot pre-initialize without project ID');
@@ -217,37 +350,34 @@ export class WalletConnectAdapter
       this.options.onQRCode = onQRCode;
     }
 
-    if (this.pendingConnection) {
-      logger.debug('Already has pending connection, skipping pre-init');
-      return;
-    }
-
-    const preInitializationAttempt = ++this.connectionAttemptGeneration;
-    logger.debug('Pre-initializing connection session...');
-
     try {
       const networkInfo = resolveNetwork(network);
       const requestedChainId = getXrplChainId(networkInfo);
+      const existingPending = this.pendingConnection;
 
-      // Initialize SignClient if not already done
-      if (!this.client) {
-        if (!this.initializationPromise) {
-          this.initializationPromise = SignClient.init({
-            projectId: pid,
-            metadata: this.options.metadata || {
-              name: DEFAULT_METADATA.NAME,
-              description: DEFAULT_METADATA.DESCRIPTION,
-              url:
-                typeof window !== 'undefined'
-                  ? window.location.origin
-                  : DEFAULT_METADATA.DEFAULT_URL,
-              icons: [DEFAULT_METADATA.DEFAULT_ICON],
-            },
-          });
-        }
-        this.client = await this.initializationPromise;
-        logger.debug('SignClient initialized');
+      if (existingPending?.chainId === requestedChainId && existingPending.projectId === pid) {
+        logger.debug('Already has matching pending connection, skipping pre-init');
+        return;
       }
+
+      const preInitializationAttempt = ++this.connectionAttemptGeneration;
+      logger.debug('Pre-initializing connection session...');
+
+      if (this.activeConnectionProposals.size > 0) {
+        await this.closeActiveConnectionProposals();
+      }
+
+      if (existingPending && this.pendingConnection === existingPending) {
+        this.pendingConnection = null;
+        await this.closeConnectionProposal(existingPending);
+      }
+
+      if (preInitializationAttempt !== this.connectionAttemptGeneration) {
+        return;
+      }
+
+      const client = await this.getOrInitializeClient(pid);
+      logger.debug('SignClient initialized');
 
       if (preInitializationAttempt !== this.connectionAttemptGeneration) {
         return;
@@ -266,36 +396,41 @@ export class WalletConnectAdapter
         },
       };
 
-      const { uri, approval } = await this.client.connect({
+      const result = await client.connect({
         requiredNamespaces,
       });
+      proposal = this.createConnectionProposal(client, requestedChainId, pid, result);
 
-      if (preInitializationAttempt !== this.connectionAttemptGeneration) {
-        return;
-      }
-
-      if (!uri) {
+      if (!proposal.uri) {
         throw new Error('Failed to generate WalletConnect URI during pre-initialization');
       }
 
+      if (preInitializationAttempt !== this.connectionAttemptGeneration) {
+        await this.closeConnectionProposal(proposal);
+        proposal = null;
+        return;
+      }
+
       // Store the pending connection
-      this.pendingConnection = { uri, approval };
+      this.pendingConnection = proposal as PendingConnection;
 
       logger.debug(
         'QR code URI pre-generated:',
-        uri.substring(0, LOGGING.URI_PREVIEW_LENGTH) + '...'
+        proposal.uri.substring(0, LOGGING.URI_PREVIEW_LENGTH) + '...'
       );
 
       if (this.options.onQRCode) {
         logger.debug('Calling onQRCode callback during pre-init');
-        this.options.onQRCode(uri);
+        this.options.onQRCode(proposal.uri);
       }
     } catch (error) {
-      logger.error('Pre-initialization failed:', error);
-      if (preInitializationAttempt === this.connectionAttemptGeneration) {
-        this.initializationPromise = null;
-        this.pendingConnection = null;
+      if (proposal) {
+        if (this.pendingConnection === proposal) {
+          this.pendingConnection = null;
+        }
+        await this.closeConnectionProposal(proposal);
       }
+      logger.error('Pre-initialization failed:', error);
     }
   }
 
@@ -303,7 +438,6 @@ export class WalletConnectAdapter
    * Connect to WalletConnect
    */
   async connect(options?: ConnectOptions<WalletConnectConnectOptions>): Promise<AccountInfo> {
-    const connectionAttempt = ++this.connectionAttemptGeneration;
     const projectId = options?.projectId || this.options.projectId;
 
     if (!projectId) {
@@ -313,6 +447,41 @@ export class WalletConnectAdapter
           'WalletConnect project ID is required. Get one from https://cloud.walletconnect.com or https://dashboard.reown.com'
         )
       );
+    }
+
+    if (this.client && this.clientProjectId !== projectId) {
+      const pending = this.pendingConnection;
+      this.pendingConnection = null;
+      if (pending) {
+        await this.closeConnectionProposal(pending);
+      }
+      throw createWalletError.connectionFailed(
+        this.name,
+        new Error('Cannot change WalletConnect project ID after initialization')
+      );
+    }
+
+    let network: NetworkInfo;
+    let requestedChainId: string;
+    try {
+      network = resolveNetwork(options?.network);
+      requestedChainId = getXrplChainId(network);
+    } catch (error) {
+      throw createWalletError.connectionFailed(this.name, error as Error);
+    }
+
+    const connectionAttempt = ++this.connectionAttemptGeneration;
+    const replacedClient = this.client;
+    const replacedSession = this.session;
+    let proposal: ConnectionProposal | null = null;
+
+    // A direct connect() while already connected is a replacement. Detach the
+    // old handlers synchronously so a late lifecycle event cannot clear the
+    // client while the new approval is pending.
+    if (replacedClient && replacedSession) {
+      this.removeEventListeners();
+      this.session = null;
+      this.currentAccount = null;
     }
 
     // Merge runtime options with constructor options (runtime takes precedence)
@@ -325,30 +494,23 @@ export class WalletConnectAdapter
       useModal && (modalMode === 'always' || (modalMode === 'mobile-only' && isMobile()));
 
     try {
-      // Determine network
-      const network = resolveNetwork(options?.network);
-      const requestedChainId = getXrplChainId(network);
+      if (this.activeConnectionProposals.size > 0) {
+        await this.closeActiveConnectionProposals();
+      }
+      if (replacedClient && replacedSession) {
+        await this.disconnectSession(
+          replacedClient,
+          replacedSession,
+          'Failed to disconnect replaced WalletConnect session:'
+        );
+      }
+      if (connectionAttempt !== this.connectionAttemptGeneration) {
+        throw new Error('WalletConnect connection was cancelled');
+      }
 
-      // Initialize SignClient if needed
-      if (!this.client) {
-        if (this.initializationPromise) {
-          logger.debug('Using pre-initialized SignClient');
-          this.client = await this.initializationPromise;
-        } else {
-          logger.debug('Initializing SignClient');
-          this.client = await SignClient.init({
-            projectId,
-            metadata: this.options.metadata || {
-              name: DEFAULT_METADATA.NAME,
-              description: DEFAULT_METADATA.DESCRIPTION,
-              url:
-                typeof window !== 'undefined'
-                  ? window.location.origin
-                  : DEFAULT_METADATA.DEFAULT_URL,
-              icons: [DEFAULT_METADATA.DEFAULT_ICON],
-            },
-          });
-        }
+      const client = await this.getOrInitializeClient(projectId);
+      if (connectionAttempt !== this.connectionAttemptGeneration) {
+        throw new Error('WalletConnect connection was cancelled');
       }
 
       // Prepare namespace for XRPL
@@ -367,6 +529,12 @@ export class WalletConnectAdapter
       let session: SessionTypes.Struct;
 
       if (shouldUseModal) {
+        const pending = this.pendingConnection;
+        this.pendingConnection = null;
+        if (pending) {
+          await this.closeConnectionProposal(pending);
+        }
+
         // ===== MODAL FLOW (Mobile deeplinks) =====
         logger.debug('Using WalletConnect modal for connection (mobile deeplink mode)');
 
@@ -374,18 +542,32 @@ export class WalletConnectAdapter
         await this.initializeModal(projectId);
 
         // Connect and get URI
-        const { uri, approval } = await this.client.connect({
+        const result = await client.connect({
           requiredNamespaces,
         });
+        proposal = this.createConnectionProposal(client, requestedChainId, projectId, result);
 
-        if (uri && this.modal) {
+        if (connectionAttempt !== this.connectionAttemptGeneration) {
+          await this.closeConnectionProposal(proposal);
+          proposal = null;
+          throw new Error('WalletConnect connection was cancelled');
+        }
+        this.activeConnectionProposals.set(connectionAttempt, proposal);
+
+        if (!proposal.uri) {
+          throw new Error('Failed to generate WalletConnect URI');
+        }
+
+        if (this.modal) {
           // Open modal with the URI - modal handles deeplinks automatically
-          this.modal.openModal({ uri });
+          this.modal.openModal({ uri: proposal.uri });
           logger.debug('WalletConnect modal opened with URI');
         }
 
         // Wait for user to connect via modal
-        session = await approval();
+        session = await this.waitForConnectionProposal(proposal);
+        this.releaseActiveConnectionProposal(connectionAttempt, proposal);
+        proposal = null;
 
         // Close modal after successful connection
         if (this.modal) {
@@ -397,7 +579,6 @@ export class WalletConnectAdapter
         logger.debug('Using custom QR code for connection (desktop mode)');
 
         let uri: string;
-        let approval: () => Promise<SessionTypes.Struct>;
 
         // Check if we have a pending connection from pre-initialization.
         // Consume it immediately so a retry after this connect() fails (or a
@@ -405,29 +586,44 @@ export class WalletConnectAdapter
         const pending = this.pendingConnection;
         this.pendingConnection = null;
 
-        if (pending) {
+        if (
+          pending?.chainId === requestedChainId &&
+          pending.projectId === projectId &&
+          pending.client === client
+        ) {
           logger.debug('Using pre-generated connection');
           uri = pending.uri;
-          approval = pending.approval;
+          proposal = pending;
+          this.activeConnectionProposals.set(connectionAttempt, proposal);
 
           if (onQRCode) {
             logger.debug('Calling onQRCode callback with pre-generated URI');
             onQRCode(uri);
           }
         } else {
+          if (pending) {
+            await this.closeConnectionProposal(pending);
+          }
           logger.debug('No pre-generated connection, creating now');
 
           // Connect and get URI
-          const result = await this.client.connect({
+          const result = await client.connect({
             requiredNamespaces,
           });
+          proposal = this.createConnectionProposal(client, requestedChainId, projectId, result);
 
-          if (!result.uri) {
+          if (connectionAttempt !== this.connectionAttemptGeneration) {
+            await this.closeConnectionProposal(proposal);
+            proposal = null;
+            throw new Error('WalletConnect connection was cancelled');
+          }
+          this.activeConnectionProposals.set(connectionAttempt, proposal);
+
+          if (!proposal.uri) {
             throw new Error('Failed to generate WalletConnect URI');
           }
 
-          uri = result.uri;
-          approval = result.approval;
+          uri = proposal.uri;
 
           logger.debug('Generated URI:', uri.substring(0, LOGGING.URI_PREVIEW_LENGTH) + '...');
 
@@ -438,17 +634,20 @@ export class WalletConnectAdapter
         }
 
         // Wait for approval
-        session = await approval();
+        session = await this.waitForConnectionProposal(proposal);
+        this.releaseActiveConnectionProposal(connectionAttempt, proposal);
+        proposal = null;
       }
 
       // Approval cannot be aborted by SignClient. If the UI cancelled this
       // attempt while approval was pending, immediately close the late session
       // instead of exposing it as an orphaned WalletConnect connection.
       if (connectionAttempt !== this.connectionAttemptGeneration) {
-        await this.client.disconnect({
-          topic: session.topic,
-          reason: DISCONNECT_REASONS.USER_DISCONNECTED,
-        });
+        await this.disconnectSession(
+          client,
+          session,
+          'Failed to disconnect stale WalletConnect session:'
+        );
         throw new Error('WalletConnect connection was cancelled');
       }
 
@@ -456,7 +655,7 @@ export class WalletConnectAdapter
       try {
         address = selectAccountForChain(session.namespaces.xrpl?.accounts || [], requestedChainId);
       } catch (error) {
-        await this.closeApprovedSession(session, connectionAttempt);
+        await this.closeApprovedSession(client, session, connectionAttempt);
         throw error;
       }
 
@@ -472,12 +671,20 @@ export class WalletConnectAdapter
 
       return this.currentAccount;
     } catch (error) {
+      if (proposal) {
+        this.releaseActiveConnectionProposal(connectionAttempt, proposal);
+        await this.closeConnectionProposal(proposal);
+      }
       // A stale attempt must not close or clear resources owned by a newer one.
       if (connectionAttempt === this.connectionAttemptGeneration) {
         if (this.modal) {
           this.modal.closeModal();
         }
+        const pending = this.pendingConnection;
         this.pendingConnection = null;
+        if (pending) {
+          await this.closeConnectionProposal(pending);
+        }
       }
       throw createWalletError.connectionFailed(this.name, error as Error);
     }
@@ -487,26 +694,70 @@ export class WalletConnectAdapter
    * Disconnect from WalletConnect
    */
   async disconnect(): Promise<void> {
-    this.connectionAttemptGeneration += 1;
+    const disconnectAttempt = ++this.connectionAttemptGeneration;
+    const initialization = this.initializationPromise;
+    const pending = this.pendingConnection;
+    const client = this.client;
+    const session = this.session;
     this.pendingConnection = null;
+
+    if (initialization && this.initializationPromise === initialization) {
+      this.initializationPromise = null;
+      this.initializationProjectId = null;
+    }
 
     if (this.modal) {
       this.modal.closeModal();
     }
 
-    if (!this.client || !this.session) {
+    if (pending) {
+      await this.closeConnectionProposal(pending);
+    }
+    await this.closeActiveConnectionProposals();
+
+    if (disconnectAttempt !== this.connectionAttemptGeneration) {
+      return;
+    }
+
+    if (!client || !session) {
+      this.cleanup();
       return;
     }
 
     try {
-      await this.client.disconnect({
-        topic: this.session.topic,
+      await client.disconnect({
+        topic: session.topic,
         reason: DISCONNECT_REASONS.USER_DISCONNECTED,
       });
-      this.cleanup();
     } catch (error) {
       // Disconnect might fail if already disconnected, that's okay
-      this.cleanup();
+    } finally {
+      if (
+        disconnectAttempt === this.connectionAttemptGeneration &&
+        this.client === client &&
+        this.session === session
+      ) {
+        this.cleanup();
+      }
+    }
+  }
+
+  /**
+   * Disconnect an approved session without allowing relay cleanup failures to
+   * replace the connection result that caused the cleanup.
+   */
+  private async disconnectSession(
+    client: SignClient,
+    session: SessionTypes.Struct,
+    warning: string
+  ): Promise<void> {
+    try {
+      await client.disconnect({
+        topic: session.topic,
+        reason: DISCONNECT_REASONS.USER_DISCONNECTED,
+      });
+    } catch (error) {
+      logger.warn(warning, error);
     }
   }
 
@@ -516,16 +767,16 @@ export class WalletConnectAdapter
    * with the wallet or relay.
    */
   private async closeApprovedSession(
+    client: SignClient,
     session: SessionTypes.Struct,
     connectionAttempt: number
   ): Promise<void> {
     try {
-      await this.client?.disconnect({
-        topic: session.topic,
-        reason: DISCONNECT_REASONS.USER_DISCONNECTED,
-      });
-    } catch (error) {
-      logger.warn('Failed to disconnect unusable WalletConnect session:', error);
+      await this.disconnectSession(
+        client,
+        session,
+        'Failed to disconnect unusable WalletConnect session:'
+      );
     } finally {
       // Do not let an older failed approval clear a newer connection attempt.
       if (connectionAttempt === this.connectionAttemptGeneration) {
@@ -647,28 +898,38 @@ export class WalletConnectAdapter
    * Setup event listeners for session
    */
   private setupEventListeners(): void {
-    if (!this.client) return;
+    if (!this.client || !this.session) return;
 
     // Tear down any handlers from a previous session before re-binding, so
     // listeners don't accumulate across connect/disconnect cycles.
     this.removeEventListeners();
 
-    this.sessionDeleteHandler = () => this.cleanup();
-    this.sessionExpireHandler = () => this.cleanup();
+    const client = this.client;
+    const session = this.session;
+    const cleanupSession = (event: SessionLifecycleEvent): void => {
+      if (event.topic === session.topic && this.client === client && this.session === session) {
+        this.cleanup();
+      }
+    };
 
-    this.client.on('session_delete', this.sessionDeleteHandler);
-    this.client.on('session_expire', this.sessionExpireHandler);
+    this.eventListenerClient = client;
+    this.sessionDeleteHandler = cleanupSession;
+    this.sessionExpireHandler = cleanupSession;
+
+    client.on('session_delete', this.sessionDeleteHandler);
+    client.on('session_expire', this.sessionExpireHandler);
   }
 
   private removeEventListeners(): void {
-    if (this.client) {
+    if (this.eventListenerClient) {
       if (this.sessionDeleteHandler) {
-        this.client.off('session_delete', this.sessionDeleteHandler);
+        this.eventListenerClient.off('session_delete', this.sessionDeleteHandler);
       }
       if (this.sessionExpireHandler) {
-        this.client.off('session_expire', this.sessionExpireHandler);
+        this.eventListenerClient.off('session_expire', this.sessionExpireHandler);
       }
     }
+    this.eventListenerClient = null;
     this.sessionDeleteHandler = null;
     this.sessionExpireHandler = null;
   }
@@ -678,6 +939,12 @@ export class WalletConnectAdapter
    */
   private cleanup(): void {
     this.removeEventListeners();
+    const pending = this.pendingConnection;
+    this.pendingConnection = null;
+    if (pending) {
+      void this.closeConnectionProposal(pending);
+    }
+    void this.closeActiveConnectionProposals();
 
     // Close and cleanup modal
     if (this.modal) {
@@ -689,7 +956,8 @@ export class WalletConnectAdapter
     this.session = null;
     this.currentAccount = null;
     this.initializationPromise = null;
-    this.pendingConnection = null;
+    this.initializationProjectId = null;
+    this.clientProjectId = null;
   }
 
   /**

--- a/packages/adapters/walletconnect/src/walletconnect-adapter.ts
+++ b/packages/adapters/walletconnect/src/walletconnect-adapter.ts
@@ -5,6 +5,7 @@
 import SignClient from '@walletconnect/sign-client';
 import { WalletConnectModal } from '@walletconnect/modal';
 import type { SignClientTypes, SessionTypes } from '@walletconnect/types';
+import { isValidClassicAddress } from 'xrpl';
 import type {
   WalletAdapter,
   AccountInfo,
@@ -21,15 +22,10 @@ import type {
 } from '@xrpl-connect/core';
 import { createWalletError, resolveNetwork, createLogger, isMobile } from '@xrpl-connect/core';
 import iconSvg from './assets/icon.svg';
-import {
-  DISCONNECT_REASONS,
-  DEFAULT_METADATA,
-  LOGGING,
-  ACCOUNT_FORMAT,
-  XRPL_NAMESPACE,
-} from './constants';
+import { DISCONNECT_REASONS, DEFAULT_METADATA, LOGGING, XRPL_NAMESPACE } from './constants';
 
 const ICON_DATA_URL = `data:image/svg+xml,${encodeURIComponent(iconSvg)}`;
+const MAX_XRPL_NETWORK_ID = 0xffff_ffff;
 
 /**
  * Logger instance for WalletConnect adapter
@@ -50,6 +46,62 @@ export enum XRPLMethod {
  * alongside the standard XRPL transaction fields.
  */
 type WalletConnectSignedTxJson = Transaction & { hash?: string };
+
+function isValidXrplChainId(chainId: string): boolean {
+  const match = chainId.match(/^xrpl:(0|[1-9]\d*)$/);
+  if (!match) return false;
+
+  const networkId = Number(match[1]);
+  return Number.isSafeInteger(networkId) && networkId <= MAX_XRPL_NETWORK_ID;
+}
+
+function getXrplChainId(network: NetworkInfo): string {
+  const chainId = network.walletConnectId ?? `xrpl:${network.id}`;
+  if (!isValidXrplChainId(chainId)) {
+    throw new Error(`Invalid WalletConnect XRPL chain ID: ${chainId}`);
+  }
+  return chainId;
+}
+
+function selectAccountForChain(accounts: string[], requestedChainId: string): string {
+  if (accounts.length === 0) {
+    throw new Error('No accounts returned from WalletConnect session');
+  }
+
+  const parsedAccounts = accounts.map((account) => {
+    const parts = account.split(':');
+    if (
+      parts.length !== 3 ||
+      parts[0] !== XRPL_NAMESPACE.KEY ||
+      parts[1].length === 0 ||
+      parts[2].length === 0
+    ) {
+      throw new Error('WalletConnect returned a malformed XRPL CAIP-10 account');
+    }
+
+    const chainId = `${parts[0]}:${parts[1]}`;
+    if (!isValidXrplChainId(chainId)) {
+      throw new Error('WalletConnect returned an invalid XRPL CAIP-10 chain reference');
+    }
+
+    const address = parts[2];
+    if (!isValidClassicAddress(address)) {
+      throw new Error('WalletConnect returned an invalid XRPL classic address');
+    }
+
+    return {
+      chainId,
+      address,
+    };
+  });
+
+  const matchingAccount = parsedAccounts.find((account) => account.chainId === requestedChainId);
+  if (!matchingAccount) {
+    throw new Error(`WalletConnect did not return an account for ${requestedChainId}`);
+  }
+
+  return matchingAccount.address;
+}
 
 /**
  * WalletConnect adapter options
@@ -170,9 +222,13 @@ export class WalletConnectAdapter
       return;
     }
 
+    const preInitializationAttempt = ++this.connectionAttemptGeneration;
     logger.debug('Pre-initializing connection session...');
 
     try {
+      const networkInfo = resolveNetwork(network);
+      const requestedChainId = getXrplChainId(networkInfo);
+
       // Initialize SignClient if not already done
       if (!this.client) {
         if (!this.initializationPromise) {
@@ -193,13 +249,14 @@ export class WalletConnectAdapter
         logger.debug('SignClient initialized');
       }
 
-      // Determine network for pre-initialization
-      const networkInfo = resolveNetwork(network);
+      if (preInitializationAttempt !== this.connectionAttemptGeneration) {
+        return;
+      }
 
       // Start connection to generate URI (ConnectKit pattern)
       const requiredNamespaces = {
         [XRPL_NAMESPACE.KEY]: {
-          chains: [networkInfo.walletConnectId || `xrpl:${networkInfo.id}`],
+          chains: [requestedChainId],
           methods: [
             XRPLMethod.SIGN_TRANSACTION,
             XRPLMethod.SIGN_TRANSACTION_FOR,
@@ -212,6 +269,10 @@ export class WalletConnectAdapter
       const { uri, approval } = await this.client.connect({
         requiredNamespaces,
       });
+
+      if (preInitializationAttempt !== this.connectionAttemptGeneration) {
+        return;
+      }
 
       if (!uri) {
         throw new Error('Failed to generate WalletConnect URI during pre-initialization');
@@ -231,8 +292,10 @@ export class WalletConnectAdapter
       }
     } catch (error) {
       logger.error('Pre-initialization failed:', error);
-      this.initializationPromise = null;
-      this.pendingConnection = null;
+      if (preInitializationAttempt === this.connectionAttemptGeneration) {
+        this.initializationPromise = null;
+        this.pendingConnection = null;
+      }
     }
   }
 
@@ -264,6 +327,7 @@ export class WalletConnectAdapter
     try {
       // Determine network
       const network = resolveNetwork(options?.network);
+      const requestedChainId = getXrplChainId(network);
 
       // Initialize SignClient if needed
       if (!this.client) {
@@ -290,7 +354,7 @@ export class WalletConnectAdapter
       // Prepare namespace for XRPL
       const requiredNamespaces = {
         [XRPL_NAMESPACE.KEY]: {
-          chains: [network.walletConnectId || `xrpl:${network.id}`],
+          chains: [requestedChainId],
           methods: [
             XRPLMethod.SIGN_TRANSACTION,
             XRPLMethod.SIGN_TRANSACTION_FOR,
@@ -388,19 +452,16 @@ export class WalletConnectAdapter
         throw new Error('WalletConnect connection was cancelled');
       }
 
-      // Store session
-      this.session = session;
-
-      // Extract account info from session
-      const accounts = this.session.namespaces.xrpl?.accounts || [];
-      if (accounts.length === 0) {
-        throw new Error('No accounts returned from WalletConnect session');
+      let address: string;
+      try {
+        address = selectAccountForChain(session.namespaces.xrpl?.accounts || [], requestedChainId);
+      } catch (error) {
+        await this.closeApprovedSession(session, connectionAttempt);
+        throw error;
       }
 
-      // Parse account (format: "xrpl:chainId:rAddress")
-      const accountString = accounts[0];
-      const address = accountString.split(':')[ACCOUNT_FORMAT.ADDRESS_INDEX];
-
+      // Commit approved session state only after its account and chain are valid.
+      this.session = session;
       this.currentAccount = {
         address,
         network,
@@ -411,12 +472,13 @@ export class WalletConnectAdapter
 
       return this.currentAccount;
     } catch (error) {
-      // Close modal on error
-      if (this.modal) {
-        this.modal.closeModal();
+      // A stale attempt must not close or clear resources owned by a newer one.
+      if (connectionAttempt === this.connectionAttemptGeneration) {
+        if (this.modal) {
+          this.modal.closeModal();
+        }
+        this.pendingConnection = null;
       }
-      // Drop any stale pending connection so the next connect() starts fresh
-      this.pendingConnection = null;
       throw createWalletError.connectionFailed(this.name, error as Error);
     }
   }
@@ -445,6 +507,30 @@ export class WalletConnectAdapter
     } catch (error) {
       // Disconnect might fail if already disconnected, that's okay
       this.cleanup();
+    }
+  }
+
+  /**
+   * Close a session that was approved but cannot be used by this connection
+   * attempt. Cleanup must complete even if the remote disconnect already raced
+   * with the wallet or relay.
+   */
+  private async closeApprovedSession(
+    session: SessionTypes.Struct,
+    connectionAttempt: number
+  ): Promise<void> {
+    try {
+      await this.client?.disconnect({
+        topic: session.topic,
+        reason: DISCONNECT_REASONS.USER_DISCONNECTED,
+      });
+    } catch (error) {
+      logger.warn('Failed to disconnect unusable WalletConnect session:', error);
+    } finally {
+      // Do not let an older failed approval clear a newer connection attempt.
+      if (connectionAttempt === this.connectionAttemptGeneration) {
+        this.cleanup();
+      }
     }
   }
 

--- a/packages/adapters/walletconnect/tests/walletconnect-adapter.test.ts
+++ b/packages/adapters/walletconnect/tests/walletconnect-adapter.test.ts
@@ -21,11 +21,14 @@ import SignClient from '@walletconnect/sign-client';
 import { WalletConnectAdapter } from '../src/walletconnect-adapter';
 
 const SignClientMock = SignClient as unknown as { init: ReturnType<typeof vi.fn> };
+const MAINNET_ADDRESS = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh';
+const TESTNET_ADDRESS = 'rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH';
 
 beforeEach(() => {
   SignClientMock.init.mockReset();
   mockClient.connect.mockReset();
   mockClient.disconnect.mockReset();
+  mockClient.disconnect.mockResolvedValue(undefined);
   mockClient.request.mockReset();
   mockClient.on.mockReset();
   mockClient.off.mockReset();
@@ -51,15 +54,249 @@ describe('WalletConnectAdapter.connect', () => {
       uri: 'wc:example',
       approval: vi.fn().mockResolvedValue({
         topic: 'topic-1',
-        namespaces: { xrpl: { accounts: ['xrpl:0:rWCAddress'] } },
+        namespaces: { xrpl: { accounts: [`xrpl:0:${MAINNET_ADDRESS}`] } },
       }),
     });
 
     const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
     const account = await adapter.connect();
 
-    expect(account.address).toBe('rWCAddress');
+    expect(account.address).toBe(MAINNET_ADDRESS);
     expect(account.network.id).toBe('mainnet');
+  });
+
+  it('selects the account whose CAIP-10 chain matches the requested network', async () => {
+    mockClient.connect.mockResolvedValue({
+      uri: 'wc:example',
+      approval: vi.fn().mockResolvedValue({
+        topic: 'topic-multiple',
+        namespaces: {
+          xrpl: {
+            accounts: [`xrpl:1:${TESTNET_ADDRESS}`, `xrpl:0:${MAINNET_ADDRESS}`],
+          },
+        },
+      }),
+    });
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    const account = await adapter.connect({ network: 'mainnet' });
+
+    expect(account).toMatchObject({ address: MAINNET_ADDRESS, network: { id: 'mainnet' } });
+    expect(mockClient.disconnect).not.toHaveBeenCalled();
+  });
+
+  it.each(['21338', '4294967295'])(
+    'matches an account against custom XRPL network ID %s',
+    async (networkId) => {
+      mockClient.connect.mockResolvedValue({
+        uri: 'wc:example',
+        approval: vi.fn().mockResolvedValue({
+          topic: 'topic-custom',
+          namespaces: { xrpl: { accounts: [`xrpl:${networkId}:${MAINNET_ADDRESS}`] } },
+        }),
+      });
+
+      const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+      const account = await adapter.connect({
+        network: {
+          id: 'custom',
+          name: 'Custom',
+          wss: 'wss://example.com',
+          walletConnectId: `xrpl:${networkId}`,
+        },
+      });
+
+      expect(account).toMatchObject({ address: MAINNET_ADDRESS, network: { id: 'custom' } });
+    }
+  );
+
+  it.each(['', 'xrpl:01', 'xrpl:not-a-network', 'xrpl:4294967296', 'eip155:1'])(
+    'rejects invalid requested XRPL chain ID %s before connecting',
+    async (walletConnectId) => {
+      const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+
+      await expect(
+        adapter.connect({
+          network: {
+            id: 'custom',
+            name: 'Custom',
+            wss: 'wss://example.com',
+            walletConnectId,
+          },
+        })
+      ).rejects.toMatchObject({ code: WalletErrorCode.CONNECTION_FAILED });
+
+      expect(SignClientMock.init).not.toHaveBeenCalled();
+      expect(mockClient.connect).not.toHaveBeenCalled();
+    }
+  );
+
+  it('preserves a newer pre-initialized connection when older validation cleanup finishes', async () => {
+    let finishDisconnect!: () => void;
+    const disconnect = new Promise<void>((resolve) => {
+      finishDisconnect = resolve;
+    });
+
+    mockClient.connect
+      .mockResolvedValueOnce({
+        uri: 'wc:invalid',
+        approval: vi.fn().mockResolvedValue({
+          topic: 'topic-invalid',
+          namespaces: { xrpl: { accounts: [`xrpl:1:${TESTNET_ADDRESS}`] } },
+        }),
+      })
+      .mockResolvedValueOnce({
+        uri: 'wc:newer',
+        approval: vi.fn().mockResolvedValue({
+          topic: 'topic-newer',
+          namespaces: { xrpl: { accounts: [`xrpl:0:${MAINNET_ADDRESS}`] } },
+        }),
+      });
+    mockClient.disconnect.mockReturnValue(disconnect);
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    const invalidConnection = adapter.connect();
+    await vi.waitFor(() => expect(mockClient.disconnect).toHaveBeenCalledOnce());
+
+    await adapter.preInitialize('mainnet');
+    finishDisconnect();
+    await expect(invalidConnection).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+    });
+
+    const account = await adapter.connect();
+    expect(account.address).toBe(MAINNET_ADDRESS);
+    expect(mockClient.connect).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not create a stale pre-initialized proposal after connect takes ownership', async () => {
+    let finishInitialization!: () => void;
+    const initialization = new Promise<typeof mockClient>((resolve) => {
+      finishInitialization = () => resolve(mockClient);
+    });
+    SignClientMock.init.mockReturnValue(initialization);
+    mockClient.connect.mockResolvedValue({
+      uri: 'wc:current',
+      approval: vi.fn().mockResolvedValue({
+        topic: 'topic-current',
+        namespaces: { xrpl: { accounts: [`xrpl:0:${MAINNET_ADDRESS}`] } },
+      }),
+    });
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    const preInitialization = adapter.preInitialize('mainnet');
+    await vi.waitFor(() => expect(SignClientMock.init).toHaveBeenCalledOnce());
+
+    const connection = adapter.connect();
+    finishInitialization();
+
+    await preInitialization;
+    await expect(connection).resolves.toMatchObject({ address: MAINNET_ADDRESS });
+    expect(mockClient.connect).toHaveBeenCalledOnce();
+  });
+
+  it('does not accept a custom chain by its network name without a numeric walletConnectId', async () => {
+    mockClient.connect.mockResolvedValue({
+      uri: 'wc:example',
+      approval: vi.fn().mockResolvedValue({
+        topic: 'topic-custom',
+        namespaces: { xrpl: { accounts: [`xrpl:0:${MAINNET_ADDRESS}`] } },
+      }),
+    });
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    await expect(
+      adapter.connect({ network: { id: 'custom', name: 'Custom', wss: 'wss://example.com' } })
+    ).rejects.toMatchObject({ code: WalletErrorCode.CONNECTION_FAILED });
+    expect(mockClient.connect).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['missing address', 'xrpl:0'],
+    ['empty address', 'xrpl:0:'],
+    ['extra component', `xrpl:0:${MAINNET_ADDRESS}:extra`],
+    ['wrong namespace', `eip155:0:${MAINNET_ADDRESS}`],
+    ['non-canonical chain reference', `xrpl:01:${MAINNET_ADDRESS}`],
+    ['out-of-range chain reference', `xrpl:4294967296:${MAINNET_ADDRESS}`],
+    ['invalid classic address', 'xrpl:0:rNotAValidClassicAddress'],
+  ])('rejects and cleans up a malformed approved account (%s)', async (_case, account) => {
+    mockClient.connect.mockResolvedValue({
+      uri: 'wc:example',
+      approval: vi.fn().mockResolvedValue({
+        topic: 'topic-malformed',
+        namespaces: { xrpl: { accounts: [account] } },
+      }),
+    });
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+
+    await expect(adapter.connect()).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+    });
+    expect(mockClient.disconnect).toHaveBeenCalledWith(
+      expect.objectContaining({ topic: 'topic-malformed' })
+    );
+    expect(await adapter.getAccount()).toBeNull();
+    await expect(adapter.getNetwork()).rejects.toMatchObject({
+      code: WalletErrorCode.NOT_CONNECTED,
+    });
+  });
+
+  it.each([
+    ['no XRPL accounts', []],
+    ['only an account on another chain', [`xrpl:1:${TESTNET_ADDRESS}`]],
+  ])('rejects and cleans up an approved session with %s', async (_case, accounts) => {
+    mockClient.connect.mockResolvedValue({
+      uri: 'wc:example',
+      approval: vi.fn().mockResolvedValue({
+        topic: 'topic-wrong-chain',
+        namespaces: { xrpl: { accounts } },
+      }),
+    });
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+
+    await expect(adapter.connect({ network: 'mainnet' })).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+    });
+    expect(mockClient.disconnect).toHaveBeenCalledWith(
+      expect.objectContaining({ topic: 'topic-wrong-chain' })
+    );
+    expect(await adapter.getAccount()).toBeNull();
+  });
+
+  it('clears local state when disconnecting an invalid approved session fails', async () => {
+    mockClient.connect.mockResolvedValue({
+      uri: 'wc:example',
+      approval: vi.fn().mockResolvedValue({
+        topic: 'topic-disconnect-failure',
+        namespaces: { xrpl: { accounts: [`xrpl:1:${TESTNET_ADDRESS}`] } },
+      }),
+    });
+    mockClient.disconnect.mockRejectedValue(new Error('Relay unavailable'));
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+
+    await expect(adapter.connect()).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+      originalError: {
+        message: 'WalletConnect did not return an account for xrpl:0',
+      },
+    });
+    expect(await adapter.getAccount()).toBeNull();
+
+    mockClient.disconnect.mockResolvedValue(undefined);
+    mockClient.connect.mockResolvedValue({
+      uri: 'wc:retry',
+      approval: vi.fn().mockResolvedValue({
+        topic: 'topic-retry',
+        namespaces: { xrpl: { accounts: [`xrpl:0:${MAINNET_ADDRESS}`] } },
+      }),
+    });
+
+    await expect(adapter.connect()).resolves.toMatchObject({ address: MAINNET_ADDRESS });
+    expect(SignClientMock.init).toHaveBeenCalledTimes(2);
+    expect(mockClient.disconnect).toHaveBeenCalledOnce();
   });
 
   it('throws a wrapped error when no project ID is provided', async () => {
@@ -88,7 +325,7 @@ describe('WalletConnectAdapter.sign', () => {
       uri: 'wc:example',
       approval: vi.fn().mockResolvedValue({
         topic: 'topic-1',
-        namespaces: { xrpl: { accounts: ['xrpl:0:rWCAddress'] } },
+        namespaces: { xrpl: { accounts: [`xrpl:0:${MAINNET_ADDRESS}`] } },
       }),
     });
     const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
@@ -146,7 +383,7 @@ describe('WalletConnectAdapter.signAndSubmit', () => {
       uri: 'wc:example',
       approval: vi.fn().mockResolvedValue({
         topic: 'topic-1',
-        namespaces: { xrpl: { accounts: ['xrpl:0:rWCAddress'] } },
+        namespaces: { xrpl: { accounts: [`xrpl:0:${MAINNET_ADDRESS}`] } },
       }),
     });
     const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
@@ -212,7 +449,7 @@ describe('WalletConnectAdapter.disconnect', () => {
     await adapter.disconnect();
     approve({
       topic: 'late-topic',
-      namespaces: { xrpl: { accounts: ['xrpl:0:rLateAddress'] } },
+      namespaces: { xrpl: { accounts: [`xrpl:0:${MAINNET_ADDRESS}`] } },
     });
 
     await expect(connection).rejects.toMatchObject({ code: WalletErrorCode.CONNECTION_FAILED });
@@ -227,7 +464,7 @@ describe('WalletConnectAdapter.disconnect', () => {
       uri: 'wc:example',
       approval: vi.fn().mockResolvedValue({
         topic: 'topic-1',
-        namespaces: { xrpl: { accounts: ['xrpl:0:rWCAddress'] } },
+        namespaces: { xrpl: { accounts: [`xrpl:0:${MAINNET_ADDRESS}`] } },
       }),
     });
     mockClient.disconnect.mockResolvedValue(undefined);

--- a/packages/adapters/walletconnect/tests/walletconnect-adapter.test.ts
+++ b/packages/adapters/walletconnect/tests/walletconnect-adapter.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, expectTypeOf, vi, beforeEach } from 'vite-plus/te
 import { WalletErrorCode, type Transaction } from '@xrpl-connect/core';
 
 const mockClient = {
+  core: { pairing: { disconnect: vi.fn() } },
   connect: vi.fn(),
   disconnect: vi.fn(),
   request: vi.fn(),
@@ -23,10 +24,18 @@ import { WalletConnectAdapter } from '../src/walletconnect-adapter';
 const SignClientMock = SignClient as unknown as { init: ReturnType<typeof vi.fn> };
 const MAINNET_ADDRESS = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh';
 const TESTNET_ADDRESS = 'rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH';
+const PAIRING_TOPIC = 'a'.repeat(64);
+const OTHER_PAIRING_TOPIC = 'b'.repeat(64);
+
+function walletConnectUri(topic: string): string {
+  return `wc:${topic}@2?relay-protocol=irn&symKey=${'c'.repeat(64)}`;
+}
 
 beforeEach(() => {
   SignClientMock.init.mockReset();
   mockClient.connect.mockReset();
+  mockClient.core.pairing.disconnect.mockReset();
+  mockClient.core.pairing.disconnect.mockResolvedValue(undefined);
   mockClient.disconnect.mockReset();
   mockClient.disconnect.mockResolvedValue(undefined);
   mockClient.request.mockReset();
@@ -193,6 +202,407 @@ describe('WalletConnectAdapter.connect', () => {
     await preInitialization;
     await expect(connection).resolves.toMatchObject({ address: MAINNET_ADDRESS });
     expect(mockClient.connect).toHaveBeenCalledOnce();
+  });
+
+  it('closes a pre-initialized proposal that becomes stale while it is being created', async () => {
+    let finishPreInitialization!: (connection: {
+      uri: string;
+      approval: () => Promise<never>;
+    }) => void;
+    const preInitializedProposal = new Promise<{
+      uri: string;
+      approval: () => Promise<never>;
+    }>((resolve) => {
+      finishPreInitialization = resolve;
+    });
+
+    mockClient.connect.mockReturnValueOnce(preInitializedProposal).mockResolvedValueOnce({
+      uri: walletConnectUri(OTHER_PAIRING_TOPIC),
+      approval: vi.fn().mockResolvedValue({
+        topic: 'topic-current',
+        namespaces: { xrpl: { accounts: [`xrpl:0:${MAINNET_ADDRESS}`] } },
+      }),
+    });
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    const preInitialization = adapter.preInitialize('mainnet');
+    await vi.waitFor(() => expect(mockClient.connect).toHaveBeenCalledOnce());
+
+    const connection = adapter.connect({ network: 'mainnet' });
+    await expect(connection).resolves.toMatchObject({ address: MAINNET_ADDRESS });
+
+    finishPreInitialization({
+      uri: walletConnectUri(PAIRING_TOPIC),
+      approval: vi.fn().mockRejectedValue(new Error('Proposal cancelled')),
+    });
+    await preInitialization;
+
+    expect(mockClient.core.pairing.disconnect).toHaveBeenCalledWith(
+      expect.objectContaining({ topic: PAIRING_TOPIC })
+    );
+  });
+
+  it('closes a pre-initialized proposal when publishing its QR code fails', async () => {
+    mockClient.connect.mockResolvedValue({
+      uri: walletConnectUri(PAIRING_TOPIC),
+      approval: vi.fn().mockRejectedValue(new Error('Proposal cancelled')),
+    });
+
+    const adapter = new WalletConnectAdapter({
+      projectId: 'proj-id',
+      onQRCode: () => {
+        throw new Error('QR renderer unavailable');
+      },
+    });
+
+    await adapter.preInitialize('mainnet');
+
+    expect(mockClient.core.pairing.disconnect).toHaveBeenCalledWith(
+      expect.objectContaining({ topic: PAIRING_TOPIC })
+    );
+  });
+
+  it('closes a new proposal when publishing its QR code fails during connect', async () => {
+    mockClient.connect.mockResolvedValue({
+      uri: walletConnectUri(PAIRING_TOPIC),
+      approval: vi.fn().mockRejectedValue(new Error('Proposal cancelled')),
+    });
+
+    const adapter = new WalletConnectAdapter({
+      projectId: 'proj-id',
+      onQRCode: () => {
+        throw new Error('QR renderer unavailable');
+      },
+    });
+
+    await expect(adapter.connect()).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+      originalError: { message: 'QR renderer unavailable' },
+    });
+    expect(mockClient.core.pairing.disconnect).toHaveBeenCalledWith(
+      expect.objectContaining({ topic: PAIRING_TOPIC })
+    );
+  });
+
+  it('cancels a connection while SignClient initialization is still pending', async () => {
+    let finishInitialization!: () => void;
+    const initialization = new Promise<typeof mockClient>((resolve) => {
+      finishInitialization = () => resolve(mockClient);
+    });
+    SignClientMock.init.mockReturnValueOnce(initialization).mockResolvedValueOnce(mockClient);
+    mockClient.connect.mockResolvedValue({
+      uri: 'wc:retry',
+      approval: vi.fn().mockResolvedValue({
+        topic: 'topic-retry',
+        namespaces: { xrpl: { accounts: [`xrpl:0:${MAINNET_ADDRESS}`] } },
+      }),
+    });
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    const connection = adapter.connect();
+    await vi.waitFor(() => expect(SignClientMock.init).toHaveBeenCalledOnce());
+
+    await adapter.disconnect();
+    finishInitialization();
+
+    await expect(connection).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+      originalError: { message: 'WalletConnect connection was cancelled' },
+    });
+    expect(mockClient.connect).not.toHaveBeenCalled();
+
+    await expect(adapter.connect()).resolves.toMatchObject({ address: MAINNET_ADDRESS });
+    expect(SignClientMock.init).toHaveBeenCalledTimes(2);
+  });
+
+  it('closes an active proposal immediately when disconnect cancels its approval', async () => {
+    const approvalPromise = new Promise<never>(() => {});
+    const approval = vi.fn(() => approvalPromise);
+    mockClient.connect.mockResolvedValue({
+      uri: walletConnectUri(PAIRING_TOPIC),
+      approval,
+    });
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    const connection = adapter.connect();
+    await vi.waitFor(() => expect(approval).toHaveBeenCalledOnce());
+
+    await adapter.disconnect();
+
+    expect(mockClient.core.pairing.disconnect).toHaveBeenCalledWith(
+      expect.objectContaining({ topic: PAIRING_TOPIC })
+    );
+    await expect(connection).rejects.toMatchObject({ code: WalletErrorCode.CONNECTION_FAILED });
+  });
+
+  it('closes an active proposal when a newer connection supersedes it', async () => {
+    const firstApprovalPromise = new Promise<never>(() => {});
+    const firstApproval = vi.fn(() => firstApprovalPromise);
+    mockClient.connect
+      .mockResolvedValueOnce({
+        uri: walletConnectUri(PAIRING_TOPIC),
+        approval: firstApproval,
+      })
+      .mockResolvedValueOnce({
+        uri: walletConnectUri(OTHER_PAIRING_TOPIC),
+        approval: vi.fn().mockResolvedValue({
+          topic: 'topic-current',
+          namespaces: { xrpl: { accounts: [`xrpl:0:${MAINNET_ADDRESS}`] } },
+        }),
+      });
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    const firstConnection = adapter.connect();
+    await vi.waitFor(() => expect(firstApproval).toHaveBeenCalledOnce());
+
+    await expect(adapter.connect()).resolves.toMatchObject({ address: MAINNET_ADDRESS });
+    expect(mockClient.core.pairing.disconnect).toHaveBeenCalledWith(
+      expect.objectContaining({ topic: PAIRING_TOPIC })
+    );
+    await expect(firstConnection).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+    });
+  });
+
+  it('can retry after shared pre-initialization rejects during connect', async () => {
+    let rejectInitialization!: (error: Error) => void;
+    const initialization = new Promise<typeof mockClient>((_resolve, reject) => {
+      rejectInitialization = reject;
+    });
+    SignClientMock.init.mockReturnValueOnce(initialization).mockResolvedValueOnce(mockClient);
+    mockClient.connect.mockResolvedValue({
+      uri: 'wc:retry',
+      approval: vi.fn().mockResolvedValue({
+        topic: 'topic-retry',
+        namespaces: { xrpl: { accounts: [`xrpl:0:${MAINNET_ADDRESS}`] } },
+      }),
+    });
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    const preInitialization = adapter.preInitialize('mainnet');
+    await vi.waitFor(() => expect(SignClientMock.init).toHaveBeenCalledOnce());
+    const concurrentConnection = adapter.connect();
+
+    rejectInitialization(new Error('SignClient initialization failed'));
+    await preInitialization;
+    await expect(concurrentConnection).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+    });
+
+    await expect(adapter.connect()).resolves.toMatchObject({ address: MAINNET_ADDRESS });
+    expect(SignClientMock.init).toHaveBeenCalledTimes(2);
+  });
+
+  it('disconnects an older late approval after a newer invalid attempt clears adapter state', async () => {
+    let approveFirst!: (session: {
+      topic: string;
+      namespaces: { xrpl: { accounts: string[] } };
+    }) => void;
+    const firstApproval = new Promise<{
+      topic: string;
+      namespaces: { xrpl: { accounts: string[] } };
+    }>((resolve) => {
+      approveFirst = resolve;
+    });
+
+    mockClient.connect
+      .mockResolvedValueOnce({ uri: 'wc:first', approval: () => firstApproval })
+      .mockResolvedValueOnce({
+        uri: 'wc:second',
+        approval: vi.fn().mockResolvedValue({
+          topic: 'topic-invalid',
+          namespaces: { xrpl: { accounts: [`xrpl:1:${TESTNET_ADDRESS}`] } },
+        }),
+      });
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    const firstConnection = adapter.connect({ network: 'mainnet' });
+    await vi.waitFor(() => expect(mockClient.connect).toHaveBeenCalledOnce());
+
+    await expect(adapter.connect({ network: 'mainnet' })).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+    });
+
+    approveFirst({
+      topic: 'topic-first',
+      namespaces: { xrpl: { accounts: [`xrpl:0:${MAINNET_ADDRESS}`] } },
+    });
+    await expect(firstConnection).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+    });
+
+    expect(mockClient.disconnect).toHaveBeenCalledWith(
+      expect.objectContaining({ topic: 'topic-invalid' })
+    );
+    expect(mockClient.disconnect).toHaveBeenCalledWith(
+      expect.objectContaining({ topic: 'topic-first' })
+    );
+  });
+
+  it('replaces a pre-initialized proposal when connect requests another chain', async () => {
+    mockClient.connect
+      .mockResolvedValueOnce({
+        uri: walletConnectUri(PAIRING_TOPIC),
+        approval: vi.fn().mockResolvedValue({
+          topic: 'topic-mainnet',
+          namespaces: { xrpl: { accounts: [`xrpl:0:${MAINNET_ADDRESS}`] } },
+        }),
+      })
+      .mockResolvedValueOnce({
+        uri: walletConnectUri(OTHER_PAIRING_TOPIC),
+        approval: vi.fn().mockResolvedValue({
+          topic: 'topic-testnet',
+          namespaces: { xrpl: { accounts: [`xrpl:1:${TESTNET_ADDRESS}`] } },
+        }),
+      });
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    await adapter.preInitialize('mainnet');
+
+    await expect(adapter.connect({ network: 'testnet' })).resolves.toMatchObject({
+      address: TESTNET_ADDRESS,
+      network: { id: 'testnet' },
+    });
+    expect(mockClient.core.pairing.disconnect).toHaveBeenCalledWith(
+      expect.objectContaining({ topic: PAIRING_TOPIC })
+    );
+    await vi.waitFor(() =>
+      expect(mockClient.disconnect).toHaveBeenCalledWith(
+        expect.objectContaining({ topic: 'topic-mainnet' })
+      )
+    );
+    expect(mockClient.connect).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        requiredNamespaces: expect.objectContaining({
+          xrpl: expect.objectContaining({ chains: ['xrpl:1'] }),
+        }),
+      })
+    );
+  });
+
+  it('replaces an existing pre-initialized proposal when pre-initializing another chain', async () => {
+    mockClient.connect
+      .mockResolvedValueOnce({
+        uri: walletConnectUri(PAIRING_TOPIC),
+        approval: vi.fn().mockRejectedValue(new Error('Proposal cancelled')),
+      })
+      .mockResolvedValueOnce({
+        uri: walletConnectUri(OTHER_PAIRING_TOPIC),
+        approval: vi.fn().mockResolvedValue({
+          topic: 'topic-testnet',
+          namespaces: { xrpl: { accounts: [`xrpl:1:${TESTNET_ADDRESS}`] } },
+        }),
+      });
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    await adapter.preInitialize('mainnet');
+    await adapter.preInitialize('testnet');
+
+    await expect(adapter.connect({ network: 'testnet' })).resolves.toMatchObject({
+      address: TESTNET_ADDRESS,
+    });
+    expect(mockClient.connect).toHaveBeenCalledTimes(2);
+    expect(mockClient.core.pairing.disconnect).toHaveBeenCalledWith(
+      expect.objectContaining({ topic: PAIRING_TOPIC })
+    );
+  });
+
+  it('does not reuse a pre-initialized client for another project ID', async () => {
+    mockClient.connect.mockResolvedValueOnce({
+      uri: walletConnectUri(PAIRING_TOPIC),
+      approval: vi.fn().mockRejectedValue(new Error('Proposal cancelled')),
+    });
+
+    const adapter = new WalletConnectAdapter({ projectId: 'project-a' });
+    await adapter.preInitialize('mainnet');
+
+    await expect(adapter.connect({ projectId: 'project-b' })).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+      originalError: {
+        message: 'Cannot change WalletConnect project ID after initialization',
+      },
+    });
+    expect(mockClient.connect).toHaveBeenCalledOnce();
+    expect(mockClient.core.pairing.disconnect).toHaveBeenCalledWith(
+      expect.objectContaining({ topic: PAIRING_TOPIC })
+    );
+  });
+
+  it('ignores a late session event from a superseded session', async () => {
+    mockClient.connect
+      .mockResolvedValueOnce({
+        uri: 'wc:first',
+        approval: vi.fn().mockResolvedValue({
+          topic: 'topic-first',
+          namespaces: { xrpl: { accounts: [`xrpl:0:${MAINNET_ADDRESS}`] } },
+        }),
+      })
+      .mockResolvedValueOnce({
+        uri: 'wc:second',
+        approval: vi.fn().mockResolvedValue({
+          topic: 'topic-second',
+          namespaces: { xrpl: { accounts: [`xrpl:1:${TESTNET_ADDRESS}`] } },
+        }),
+      });
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    await adapter.connect({ network: 'mainnet' });
+    const firstSessionDeleteHandler = mockClient.on.mock.calls[0]?.[1] as
+      | ((event: { topic: string }) => void)
+      | undefined;
+
+    await adapter.connect({ network: 'testnet' });
+    firstSessionDeleteHandler?.({ topic: 'topic-first' });
+
+    expect(await adapter.getAccount()).toMatchObject({
+      address: TESTNET_ADDRESS,
+      network: { id: 'testnet' },
+    });
+  });
+
+  it('ignores the replaced session event while its replacement approval is pending', async () => {
+    let approveReplacement!: (session: {
+      topic: string;
+      namespaces: { xrpl: { accounts: string[] } };
+    }) => void;
+    const replacementApproval = new Promise<{
+      topic: string;
+      namespaces: { xrpl: { accounts: string[] } };
+    }>((resolve) => {
+      approveReplacement = resolve;
+    });
+    mockClient.connect
+      .mockResolvedValueOnce({
+        uri: 'wc:first',
+        approval: vi.fn().mockResolvedValue({
+          topic: 'topic-first',
+          namespaces: { xrpl: { accounts: [`xrpl:0:${MAINNET_ADDRESS}`] } },
+        }),
+      })
+      .mockResolvedValueOnce({
+        uri: walletConnectUri(PAIRING_TOPIC),
+        approval: vi.fn(() => replacementApproval),
+      });
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    await adapter.connect({ network: 'mainnet' });
+    const firstSessionDeleteHandler = mockClient.on.mock.calls[0]?.[1] as
+      | ((event: { topic: string }) => void)
+      | undefined;
+
+    const replacement = adapter.connect({ network: 'testnet' });
+    await vi.waitFor(() => expect(mockClient.connect).toHaveBeenCalledTimes(2));
+    firstSessionDeleteHandler?.({ topic: 'topic-first' });
+    approveReplacement({
+      topic: 'topic-second',
+      namespaces: { xrpl: { accounts: [`xrpl:1:${TESTNET_ADDRESS}`] } },
+    });
+
+    await expect(replacement).resolves.toMatchObject({
+      address: TESTNET_ADDRESS,
+      network: { id: 'testnet' },
+    });
   });
 
   it('does not accept a custom chain by its network name without a numeric walletConnectId', async () => {
@@ -459,6 +869,39 @@ describe('WalletConnectAdapter.disconnect', () => {
     expect(await adapter.getAccount()).toBeNull();
   });
 
+  it('preserves the cancellation error when disconnecting a late session fails', async () => {
+    let approve!: (session: {
+      topic: string;
+      namespaces: { xrpl: { accounts: string[] } };
+    }) => void;
+    const approval = new Promise<{
+      topic: string;
+      namespaces: { xrpl: { accounts: string[] } };
+    }>((resolve) => {
+      approve = resolve;
+    });
+    mockClient.connect.mockResolvedValue({
+      uri: 'wc:example',
+      approval: vi.fn(() => approval),
+    });
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    const connection = adapter.connect();
+    await vi.waitFor(() => expect(mockClient.connect).toHaveBeenCalledOnce());
+    await adapter.disconnect();
+
+    mockClient.disconnect.mockRejectedValue(new Error('Relay unavailable'));
+    approve({
+      topic: 'late-topic',
+      namespaces: { xrpl: { accounts: [`xrpl:0:${MAINNET_ADDRESS}`] } },
+    });
+
+    await expect(connection).rejects.toMatchObject({
+      code: WalletErrorCode.CONNECTION_FAILED,
+      originalError: { message: 'WalletConnect connection was cancelled' },
+    });
+  });
+
   it('clears the session and account after a successful disconnect', async () => {
     mockClient.connect.mockResolvedValue({
       uri: 'wc:example',
@@ -479,6 +922,42 @@ describe('WalletConnectAdapter.disconnect', () => {
       expect.objectContaining({ topic: 'topic-1' })
     );
     expect(await adapter.getAccount()).toBeNull();
+  });
+
+  it('does not let an older disconnect clear a newer connected session', async () => {
+    mockClient.connect.mockResolvedValueOnce({
+      uri: 'wc:first',
+      approval: vi.fn().mockResolvedValue({
+        topic: 'topic-first',
+        namespaces: { xrpl: { accounts: [`xrpl:0:${MAINNET_ADDRESS}`] } },
+      }),
+    });
+
+    const adapter = new WalletConnectAdapter({ projectId: 'proj-id' });
+    await adapter.connect();
+
+    let finishDisconnect!: () => void;
+    mockClient.disconnect.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishDisconnect = resolve;
+      })
+    );
+    const disconnection = adapter.disconnect();
+    await vi.waitFor(() => expect(mockClient.disconnect).toHaveBeenCalledOnce());
+
+    mockClient.connect.mockResolvedValueOnce({
+      uri: 'wc:second',
+      approval: vi.fn().mockResolvedValue({
+        topic: 'topic-second',
+        namespaces: { xrpl: { accounts: [`xrpl:0:${MAINNET_ADDRESS}`] } },
+      }),
+    });
+    await expect(adapter.connect()).resolves.toMatchObject({ address: MAINNET_ADDRESS });
+
+    finishDisconnect();
+    await disconnection;
+
+    expect(await adapter.getAccount()).toMatchObject({ address: MAINNET_ADDRESS });
   });
 
   it('is a no-op when no session exists', async () => {


### PR DESCRIPTION
## Summary
- validate approved WalletConnect CAIP-10 accounts, XRPL network IDs, and classic addresses before exposing session state
- select the account matching the requested chain and disconnect/clear invalid approved sessions without disrupting newer attempts
- document strict WalletConnect network handling and add malformed, mismatched, cleanup-failure, and concurrency coverage

## Test plan
- [x] `pnpm --filter @xrpl-connect/adapter-walletconnect test -- tests/walletconnect-adapter.test.ts` (34 tests)
- [x] `pnpm exec vp check`
- [x] `pnpm build`
- [x] `pnpm exec vp run -F './packages/**' --ignore-depends-on --concurrency-limit 2 test -- --passWithNoTests`
- [x] `pnpm exec vp run -F xrpl-connect test:publish`

Fixes #122
