### PR TITLE
fix: align React connector element type

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -43,7 +43,8 @@
     "dev": "vp pack --watch",
     "lint": "vp lint src",
     "type-check": "tsc --noEmit",
-    "test": "node tests/ssr-smoke.mjs && vp test run",
+    "test": "pnpm test:types && node tests/ssr-smoke.mjs && vp test run",
+    "test:types": "tsc -p tests/tsconfig.types.json",
     "test:watch": "vp test",
     "clean": "rm -rf dist"
   },

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -43,13 +43,15 @@ export interface XrplConnectContextValue {
 }
 
 /**
- * Minimal typed surface of the `<xrpl-wallet-connector>` custom element that the
- * React layer drives.
+ * Public API exposed by the `<xrpl-wallet-connector>` custom element. Mirrors
+ * `WalletConnectorElementInstance` from `@xrpl-connect/ui`.
  */
 export interface WalletConnectorElement extends HTMLElement {
   setWalletManager(manager: WalletManager): void;
-  open(): void;
+  open(): Promise<void>;
+  openAndWait(): Promise<AccountInfo>;
   close(): void;
+  toggle(): void;
 }
 
 export interface XrplConnectProviderProps {

--- a/packages/react/tests/public-api.types.ts
+++ b/packages/react/tests/public-api.types.ts
@@ -1,0 +1,23 @@
+import type { AccountInfo } from '@xrpl-connect/core';
+import type { WalletConnectorElement } from '../dist/index';
+
+declare const connector: WalletConnectorElement;
+declare const manager: Parameters<WalletConnectorElement['setWalletManager']>[0];
+
+const managerResult: void = connector.setWalletManager(manager);
+const openResult: Promise<void> = connector.open();
+const accountResult: Promise<AccountInfo> = connector.openAndWait();
+const closeResult: void = connector.close();
+const toggleResult: void = connector.toggle();
+
+// Implementation details must not leak into the public element contract.
+// @ts-expect-error openAccountModal is internal to the web component implementation.
+connector.openAccountModal();
+// @ts-expect-error closeAccountModal is internal to the web component implementation.
+connector.closeAccountModal();
+
+void managerResult;
+void openResult;
+void accountResult;
+void closeResult;
+void toggleResult;

--- a/packages/react/tests/tsconfig.types.json
+++ b/packages/react/tests/tsconfig.types.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "..",
+    "strict": true,
+    "skipLibCheck": false
+  },
+  "files": ["public-api.types.ts"]
+}


### PR DESCRIPTION
## Summary
- align React's `WalletConnectorElement` with the runtime UI contract, including the asynchronous `open`, `openAndWait`, and `toggle` methods
- add a strict type test against the generated React declaration that covers every public imperative method and keeps implementation-only modal methods private

## Test plan
- [x] `pnpm --filter @xrpl-connect/react build`
- [x] `pnpm --filter @xrpl-connect/react test`
- [x] `pnpm --filter @xrpl-connect/react type-check`
- [x] `pnpm --filter @xrpl-connect/vue build`
- [x] `pnpm --filter @xrpl-connect/vue test`
- [x] `pnpm exec vp check`

Fixes #121
