### PR TITLE
test: verify packed React consumers

### DIFF
--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -1,9 +1,9 @@
 import { useCallback } from 'react';
 import type {
   Transaction,
-  SignedTransaction,
+  ManagedSignedTransaction,
   SubmittedTransaction,
-  SignedMessage,
+  ManagedSignedMessage,
 } from '@xrpl-connect/core';
 import { useXrplConnectContext } from './provider';
 
@@ -34,7 +34,7 @@ export function useSigner() {
   const { manager } = useXrplConnectContext();
 
   const sign = useCallback(
-    (transaction: Transaction): Promise<SignedTransaction> => manager.sign(transaction),
+    (transaction: Transaction): Promise<ManagedSignedTransaction> => manager.sign(transaction),
     [manager]
   );
   const signAndSubmit = useCallback(
@@ -42,7 +42,7 @@ export function useSigner() {
     [manager]
   );
   const signMessage = useCallback(
-    (message: string | Uint8Array): Promise<SignedMessage> => manager.signMessage(message),
+    (message: string | Uint8Array): Promise<ManagedSignedMessage> => manager.signMessage(message),
     [manager]
   );
 

--- a/packages/react/tests/publish/runtime-ssr.mjs
+++ b/packages/react/tests/publish/runtime-ssr.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { createElement } from 'react';
+import { renderToString } from 'react-dom/server';
+import * as reactEsm from '@xrpl-connect/react';
+
+const require = createRequire(import.meta.url);
+const reactCjs = require('@xrpl-connect/react');
+const publicExports = [
+  'XrplConnectProvider',
+  'WalletConnector',
+  'useWallet',
+  'useSigner',
+  'useWalletModal',
+];
+
+for (const api of [reactEsm, reactCjs]) {
+  for (const exportName of publicExports) {
+    assert.equal(typeof api[exportName], 'function', `React package is missing ${exportName}`);
+  }
+
+  const html = renderToString(
+    createElement(
+      api.XrplConnectProvider,
+      { config: { adapters: [] } },
+      createElement('main', null, 'XRPL Connect SSR')
+    )
+  );
+  assert.match(html, /XRPL Connect SSR/);
+}
+
+require('./runtime-env.cjs');
+const umbrella = await import('xrpl-connect');
+const error = new umbrella.WalletError(
+  umbrella.WalletErrorCode.SIGN_REJECTED,
+  'Signing was rejected'
+);
+
+for (const api of [reactEsm, reactCjs]) {
+  assert.equal(api.isWalletError(error), true, 'React did not recognize an umbrella WalletError');
+  assert.equal(
+    error instanceof api.WalletError,
+    true,
+    'WalletError failed cross-bundle instanceof'
+  );
+
+  const reactError = new api.WalletError(api.WalletErrorCode.SIGN_REJECTED, 'Signing was rejected');
+  assert.equal(
+    umbrella.isWalletError(reactError),
+    true,
+    'Umbrella package did not recognize a React WalletError'
+  );
+  assert.equal(
+    reactError instanceof umbrella.WalletError,
+    true,
+    'React WalletError failed umbrella instanceof'
+  );
+}

--- a/packages/react/tests/publish/tsconfig.react.json
+++ b/packages/react/tests/publish/tsconfig.react.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node", "react", "react-dom"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": false
+  },
+  "files": ["types-react-esm.mts", "types-react-cjs.cts"]
+}

--- a/packages/react/tests/publish/types-react-cjs.cts
+++ b/packages/react/tests/publish/types-react-cjs.cts
@@ -1,0 +1,25 @@
+import type { ComponentProps, ComponentType } from 'react';
+import {
+  WalletConnector,
+  XrplConnectProvider,
+  isWalletError,
+  useSigner,
+  useWallet,
+  useWalletModal,
+  type WalletConnectorProps,
+} from '@xrpl-connect/react';
+import type {
+  ManagedSignedMessage,
+  ManagedSignedTransaction,
+  Transaction,
+  WalletError,
+} from 'xrpl-connect';
+
+const provider: ComponentType<ComponentProps<typeof XrplConnectProvider>> = XrplConnectProvider;
+const connector: ComponentType<WalletConnectorProps> = WalletConnector;
+const signer = null as unknown as ReturnType<typeof useSigner>;
+const signedTransaction: Promise<ManagedSignedTransaction> = signer.sign({} as Transaction);
+const signedMessage: Promise<ManagedSignedMessage> = signer.signMessage('message');
+const errorGuard: (error: unknown) => error is WalletError = isWalletError;
+
+void [provider, connector, signedTransaction, signedMessage, errorGuard, useWallet, useWalletModal];

--- a/packages/react/tests/publish/types-react-esm.mts
+++ b/packages/react/tests/publish/types-react-esm.mts
@@ -1,0 +1,25 @@
+import type { ComponentProps, ComponentType } from 'react';
+import {
+  WalletConnector,
+  XrplConnectProvider,
+  isWalletError,
+  useSigner,
+  useWallet,
+  useWalletModal,
+  type WalletConnectorProps,
+} from '@xrpl-connect/react';
+import type {
+  ManagedSignedMessage,
+  ManagedSignedTransaction,
+  Transaction,
+  WalletError,
+} from 'xrpl-connect';
+
+const provider: ComponentType<ComponentProps<typeof XrplConnectProvider>> = XrplConnectProvider;
+const connector: ComponentType<WalletConnectorProps> = WalletConnector;
+const signer = null as unknown as ReturnType<typeof useSigner>;
+const signedTransaction: Promise<ManagedSignedTransaction> = signer.sign({} as Transaction);
+const signedMessage: Promise<ManagedSignedMessage> = signer.signMessage('message');
+const errorGuard: (error: unknown) => error is WalletError = isWalletError;
+
+void [provider, connector, signedTransaction, signedMessage, errorGuard, useWallet, useWalletModal];

--- a/packages/xrpl-connect/package.json
+++ b/packages/xrpl-connect/package.json
@@ -48,9 +48,9 @@
   "scripts": {
     "build": "vp pack",
     "dev": "vp pack --watch",
-    "publish:build": "vp run -F '{.}^...' --no-cache build && vp build -c vite.config.ts && node scripts/build-types.mjs && node scripts/prepare-publish.mjs",
+    "publish:build": "vp run -F '{.}^...' --no-cache build && vp pack && vp build -c vite.config.ts && node scripts/build-types.mjs && node scripts/prepare-publish.mjs",
     "test": "node scripts/run-command.test.mjs",
-    "test:publish": "pnpm publish:build && node scripts/test-publish.mjs",
+    "test:publish": "pnpm publish:build && pnpm --filter @xrpl-connect/react build && node scripts/test-publish.mjs",
     "clean": "rm -rf dist dist-publish"
   },
   "dependencies": {

--- a/packages/xrpl-connect/scripts/test-publish.mjs
+++ b/packages/xrpl-connect/scripts/test-publish.mjs
@@ -10,30 +10,44 @@ const projectFolder = path.join(__dirname, '..');
 const repositoryRoot = path.join(projectFolder, '..', '..');
 const publishFolder = path.join(projectFolder, 'dist-publish');
 const fixturesFolder = path.join(projectFolder, 'tests', 'publish');
+const reactFolder = path.join(repositoryRoot, 'packages', 'react');
+const reactFixturesFolder = path.join(reactFolder, 'tests', 'publish');
 const temporaryRoot = mkdtempSync(path.join(os.tmpdir(), 'xrpl-connect-publish-'));
 
 const runOptions = { env: { npm_config_cache: path.join(temporaryRoot, '.npm-cache') } };
 
-try {
+function packPackage(packageFolder, requiredFiles) {
   const packOutput = run('npm', ['pack', '--json', '--pack-destination', temporaryRoot], {
     ...runOptions,
-    cwd: publishFolder,
+    cwd: packageFolder,
     capture: true,
   });
   const [packMetadata] = JSON.parse(packOutput);
   const packedFiles = new Set(packMetadata.files.map((file) => file.path));
 
-  for (const requiredFile of [
+  for (const requiredFile of requiredFiles) {
+    assert(packedFiles.has(requiredFile), `${packMetadata.name} is missing ${requiredFile}`);
+  }
+
+  return path.join(temporaryRoot, packMetadata.filename);
+}
+
+try {
+  const tarballPath = packPackage(publishFolder, [
     'package.json',
     'README.md',
     'index.d.ts',
     'xrpl-connect.mjs',
     'xrpl-connect.umd.js',
-  ]) {
-    assert(packedFiles.has(requiredFile), `Packed package is missing ${requiredFile}`);
-  }
-
-  const tarballPath = path.join(temporaryRoot, packMetadata.filename);
+  ]);
+  const reactTarballPath = packPackage(reactFolder, [
+    'package.json',
+    'README.md',
+    'dist/index.d.ts',
+    'dist/index.d.mts',
+    'dist/index.js',
+    'dist/index.mjs',
+  ]);
   const consumerFolder = path.join(temporaryRoot, 'consumer');
   mkdirSync(consumerFolder);
   writeFileSync(
@@ -54,6 +68,11 @@ try {
       '--no-fund',
       '--package-lock=false',
       tarballPath,
+      reactTarballPath,
+      'react@^18.3.1',
+      'react-dom@^18.3.1',
+      '@types/react@^18.3.0',
+      '@types/react-dom@^18.3.0',
       'xrpl@^4.0.0',
       'jsdom@^22.1.0',
     ],
@@ -80,6 +99,15 @@ try {
     );
   }
 
+  const installedReactFolder = path.join(consumerFolder, 'node_modules', '@xrpl-connect', 'react');
+  for (const declaration of ['dist/index.d.ts', 'dist/index.d.mts']) {
+    const contents = readFileSync(path.join(installedReactFolder, declaration), 'utf-8');
+    assert(
+      !contents.includes('@xrpl-connect/core'),
+      `${declaration} leaks the development-only @xrpl-connect/core package`
+    );
+  }
+
   const fixtures = [
     'runtime-env.cjs',
     'runtime-esm.mjs',
@@ -91,6 +119,14 @@ try {
   ];
   for (const fixture of fixtures) {
     copyFileSync(path.join(fixturesFolder, fixture), path.join(consumerFolder, fixture));
+  }
+  for (const fixture of [
+    'runtime-ssr.mjs',
+    'types-react-esm.mts',
+    'types-react-cjs.cts',
+    'tsconfig.react.json',
+  ]) {
+    copyFileSync(path.join(reactFixturesFolder, fixture), path.join(consumerFolder, fixture));
   }
 
   const tscPath = path.join(repositoryRoot, 'node_modules', 'typescript', 'bin', 'tsc');
@@ -104,12 +140,19 @@ try {
     ...runOptions,
     cwd: consumerFolder,
   });
+  console.log('→ Type-checking packed React ESM and CommonJS consumers');
+  run(process.execPath, [tscPath, '--project', 'tsconfig.react.json'], {
+    ...runOptions,
+    cwd: consumerFolder,
+  });
   console.log('→ Loading packed ESM runtime');
   run(process.execPath, ['runtime-esm.mjs'], { ...runOptions, cwd: consumerFolder });
   console.log('→ Loading packed CommonJS runtime');
   run(process.execPath, ['runtime-cjs.cjs'], { ...runOptions, cwd: consumerFolder });
+  console.log('→ Loading packed React ESM and CommonJS entries in SSR');
+  run(process.execPath, ['runtime-ssr.mjs'], { ...runOptions, cwd: consumerFolder });
 
-  console.log('✓ Packed xrpl-connect package passed ESM, CommonJS, and TypeScript consumer tests');
+  console.log('✓ Packed xrpl-connect and React packages passed consumer tests');
 } finally {
   rmSync(temporaryRoot, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary

- Extend the existing packed-consumer workflow to build, pack, and install the real `xrpl-connect` and `@xrpl-connect/react` npm artifacts in one empty consumer.
- Verify strict ESM/CommonJS React types, browser-free SSR loading, public exports, managed signer results, cross-package `WalletError` recognition, and declaration hygiene.
- Make the umbrella publish build self-contained on a clean checkout by producing its declaration input before rolling published types.

## Test plan

- [x] `node_modules/.bin/vp run -F xrpl-connect test:publish`
- [x] `pnpm --filter @xrpl-connect/react type-check`
- [x] `pnpm --filter @xrpl-connect/react test`
- [x] `node_modules/.bin/vp check`
- [x] `node_modules/.bin/vp run -r build`
- [x] `node_modules/.bin/vp run -F './packages/**' --ignore-depends-on --concurrency-limit 2 test -- --passWithNoTests`

Fixes #123
