### PR TITLE
fix: preserve React signer result types

### DIFF
--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -1,9 +1,9 @@
 import { useCallback } from 'react';
 import type {
+  ManagedSignedMessage,
+  ManagedSignedTransaction,
   Transaction,
-  SignedTransaction,
   SubmittedTransaction,
-  SignedMessage,
 } from '@xrpl-connect/core';
 import { useXrplConnectContext } from './provider';
 
@@ -34,7 +34,7 @@ export function useSigner() {
   const { manager } = useXrplConnectContext();
 
   const sign = useCallback(
-    (transaction: Transaction): Promise<SignedTransaction> => manager.sign(transaction),
+    (transaction: Transaction): Promise<ManagedSignedTransaction> => manager.sign(transaction),
     [manager]
   );
   const signAndSubmit = useCallback(
@@ -42,7 +42,7 @@ export function useSigner() {
     [manager]
   );
   const signMessage = useCallback(
-    (message: string | Uint8Array): Promise<SignedMessage> => manager.signMessage(message),
+    (message: string | Uint8Array): Promise<ManagedSignedMessage> => manager.signMessage(message),
     [manager]
   );
 

--- a/packages/react/tests/react.test.tsx
+++ b/packages/react/tests/react.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, vi } from 'vite-plus/test';
+import { describe, it, expect, expectTypeOf, beforeAll, vi } from 'vite-plus/test';
 import { render, act, waitFor, renderHook } from '@testing-library/react';
 import { StrictMode, useRef } from 'react';
 import { renderToString } from 'react-dom/server';
@@ -190,6 +190,23 @@ describe('XrplConnectProvider + hooks', () => {
     await expect(
       result.current.signer.sign({ TransactionType: 'Payment' } as never)
     ).rejects.toMatchObject({ code: WalletErrorCode.SIGN_REJECTED, category: expect.any(String) });
+  });
+
+  it('useSigner preserves managed signer result types', async () => {
+    const { result } = renderHook(() => ({ wallet: useWallet(), signer: useSigner() }), {
+      wrapper: wrapper([makeAdapter()]),
+    });
+    await act(async () => {
+      await result.current.wallet.connect('fake');
+    });
+
+    const signed = await result.current.signer.sign({ TransactionType: 'Payment' } as never);
+    const signedMessage = await result.current.signer.signMessage('hello');
+
+    expectTypeOf(signed.signerAddress).toEqualTypeOf<string>();
+    expectTypeOf(signedMessage.signerAddress).toEqualTypeOf<string>();
+    expect(signed).toMatchObject({ hash: 'H', signerAddress: ACCOUNT.address });
+    expect(signedMessage).toMatchObject({ signature: 's', signerAddress: ACCOUNT.address });
   });
 });
 

--- a/packages/react/tests/react.test.tsx
+++ b/packages/react/tests/react.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, expectTypeOf, beforeAll, vi } from 'vite-plus/test';
+import { describe, it, expect, beforeAll, vi } from 'vite-plus/test';
 import { render, act, waitFor, renderHook } from '@testing-library/react';
 import { StrictMode, useRef } from 'react';
 import { renderToString } from 'react-dom/server';
@@ -192,7 +192,7 @@ describe('XrplConnectProvider + hooks', () => {
     ).rejects.toMatchObject({ code: WalletErrorCode.SIGN_REJECTED, category: expect.any(String) });
   });
 
-  it('useSigner preserves managed signer result types', async () => {
+  it('useSigner returns the connected signer address with signing results', async () => {
     const { result } = renderHook(() => ({ wallet: useWallet(), signer: useSigner() }), {
       wrapper: wrapper([makeAdapter()]),
     });
@@ -203,8 +203,6 @@ describe('XrplConnectProvider + hooks', () => {
     const signed = await result.current.signer.sign({ TransactionType: 'Payment' } as never);
     const signedMessage = await result.current.signer.signMessage('hello');
 
-    expectTypeOf(signed.signerAddress).toEqualTypeOf<string>();
-    expectTypeOf(signedMessage.signerAddress).toEqualTypeOf<string>();
     expect(signed).toMatchObject({ hash: 'H', signerAddress: ACCOUNT.address });
     expect(signedMessage).toMatchObject({ signature: 's', signerAddress: ACCOUNT.address });
   });


### PR DESCRIPTION
## Summary
- align React `useSigner()` return types with `WalletManager` so transaction and message results preserve their required `signerAddress`
- add focused type and runtime coverage for both managed signing results

## Test plan
- [x] `./node_modules/.bin/vp run -r build`
- [x] `./node_modules/.bin/vp check`
- [x] `./node_modules/.bin/vp run -F './packages/**' --ignore-depends-on --concurrency-limit 2 test -- --passWithNoTests`
- [x] `./node_modules/.bin/vp run -F '@xrpl-connect/react' type-check`
- [x] compile a strict TypeScript consumer against the rolled React declaration

Fixes #117
