### PR TITLE
fix: make React connecting state race-safe

### DIFF
--- a/packages/core/src/wallet-manager.ts
+++ b/packages/core/src/wallet-manager.ts
@@ -51,6 +51,8 @@ export class WalletManager extends EventEmitter<WalletEvent> {
   }> = [];
   private sessionGeneration = 0;
   private connectionAttemptGeneration = 0;
+  private reconnectGeneration = 0;
+  private pendingReconnects = 0;
   private stateRevision = 0;
   private storageTail: Promise<void> = Promise.resolve();
 
@@ -276,6 +278,8 @@ export class WalletManager extends EventEmitter<WalletEvent> {
    * Disconnect from current wallet
    */
   async disconnect(): Promise<void> {
+    this.reconnectGeneration += 1;
+
     if (!this.currentAdapter) {
       const connectingAdapter = this.connectingAdapter;
       if (connectingAdapter) {
@@ -288,6 +292,9 @@ export class WalletManager extends EventEmitter<WalletEvent> {
           this.logger.warn(`Failed to cancel connection to ${connectingAdapter.name}:`, error);
         }
         return;
+      }
+      if (this.pendingReconnects > 0) {
+        await this.queueStorage(() => this.storage.clearState());
       }
       return;
     }
@@ -320,13 +327,17 @@ export class WalletManager extends EventEmitter<WalletEvent> {
       throw createWalletError.alreadyConnected(this.connectingAdapter.name);
     }
 
-    const stored = await this.storage.loadState();
-    if (!stored) {
-      this.logger.debug('No stored state found for reconnection');
-      return null;
-    }
+    const reconnectGeneration = this.reconnectGeneration;
+    this.pendingReconnects += 1;
 
     try {
+      const stored = await this.storage.loadState();
+      if (reconnectGeneration !== this.reconnectGeneration) return null;
+      if (!stored) {
+        this.logger.debug('No stored state found for reconnection');
+        return null;
+      }
+
       // Replay the original connect options so wallet-specific selections
       // (e.g. the Ledger derivation path / account index) are restored instead
       // of reconnecting to the default account.
@@ -339,6 +350,9 @@ export class WalletManager extends EventEmitter<WalletEvent> {
         stored
       );
     } catch (error) {
+      // disconnect() invalidates reconnect work before cancelling or replacing
+      // its adapter. A stale failure must not clear a newer session's storage.
+      if (reconnectGeneration !== this.reconnectGeneration) return null;
       // A connection may have started after the ownership check above. Do not
       // erase its persisted state by treating that overlap as a failed restore.
       if (isWalletError(error) && error.code === WalletErrorCode.ALREADY_CONNECTED) {
@@ -347,6 +361,8 @@ export class WalletManager extends EventEmitter<WalletEvent> {
       this.logger.warn('Reconnection failed:', error);
       await this.queueStorage(() => this.storage.clearState());
       return null;
+    } finally {
+      this.pendingReconnects -= 1;
     }
   }
 

--- a/packages/core/tests/wallet-manager.test.ts
+++ b/packages/core/tests/wallet-manager.test.ts
@@ -693,6 +693,78 @@ describe('WalletManager.reconnect()', () => {
     };
   }
 
+  it('does not reconnect after disconnect while persisted state is loading', async () => {
+    const backingStorage = new MemoryStorageAdapter();
+    await new Storage(backingStorage).saveState({
+      walletId: 'fake',
+      account: ACCOUNT,
+      network: NETWORK,
+      timestamp: Date.now(),
+    });
+
+    let releaseGet!: () => void;
+    let markGetStarted!: () => void;
+    const getStarted = new Promise<void>((resolve) => (markGetStarted = resolve));
+    const getBlocked = new Promise<void>((resolve) => (releaseGet = resolve));
+    const storage: StorageAdapter = {
+      get: vi.fn(async (key) => {
+        const stored = await backingStorage.get(key);
+        markGetStarted();
+        await getBlocked;
+        return stored;
+      }),
+      set: (key, value) => backingStorage.set(key, value),
+      remove: (key) => backingStorage.remove(key),
+      clear: () => backingStorage.clear(),
+    };
+    const adapter = createFakeAdapter();
+    const manager = new WalletManager({ adapters: [adapter], storage });
+
+    const reconnecting = manager.reconnect();
+    await getStarted;
+    await manager.disconnect();
+    releaseGet();
+
+    await expect(reconnecting).resolves.toBeNull();
+    expect(adapter.connect).not.toHaveBeenCalled();
+    expect(manager.connected).toBe(false);
+    expect(await new Storage(backingStorage).loadState()).toBeNull();
+  });
+
+  it('does not let a cancelled reconnect clear a newer manual session', async () => {
+    const storage = new MemoryStorageAdapter();
+    await new Storage(storage).saveState({
+      walletId: 'fake',
+      account: ACCOUNT,
+      network: NETWORK,
+      timestamp: Date.now(),
+    });
+
+    let resolveReconnect!: (account: AccountInfo) => void;
+    const adapter = createFakeAdapter();
+    adapter.connect = vi
+      .fn()
+      .mockImplementationOnce(
+        () => new Promise<AccountInfo>((resolve) => (resolveReconnect = resolve))
+      )
+      .mockResolvedValueOnce(ACCOUNT);
+    const manager = new WalletManager({ adapters: [adapter], storage });
+
+    const reconnecting = manager.reconnect();
+    await vi.waitFor(() => expect(adapter.connect).toHaveBeenCalledTimes(1));
+    await manager.disconnect();
+    await manager.connect('fake');
+    resolveReconnect(ACCOUNT);
+
+    await expect(reconnecting).resolves.toBeNull();
+    expect(manager.connected).toBe(true);
+    expect(manager.account).toEqual(ACCOUNT);
+    expect(await new Storage(storage).loadState()).toMatchObject({
+      walletId: 'fake',
+      account: ACCOUNT,
+    });
+  });
+
   it('returns the active account without clearing its stored session', async () => {
     const storage = new MemoryStorageAdapter();
     const adapter = createRecordingAdapter([]);

--- a/packages/react/src/WalletConnector.tsx
+++ b/packages/react/src/WalletConnector.tsx
@@ -56,6 +56,7 @@ export function WalletConnector({
     unregisterConnector,
     reportModalConnecting,
     reportModalError,
+    reportModalClosed,
   } = useXrplConnectContext();
   const elRef = useRef<WalletConnectorElement | null>(null);
 
@@ -69,6 +70,16 @@ export function WalletConnector({
     let detach: (() => void) | undefined;
     let registeredElement: WalletConnectorElement | null = null;
     let notifiedAccountKey: string | null = null;
+    const modalAttempts = new Map<number, symbol>();
+    let legacyModalAttempt: symbol | null = null;
+
+    const cancelModalAttempts = () => {
+      const attempts = [...modalAttempts.values()];
+      if (legacyModalAttempt) attempts.push(legacyModalAttempt);
+      modalAttempts.clear();
+      legacyModalAttempt = null;
+      if (attempts.length > 0) reportModalClosed(attempts);
+    };
 
     const onMgrConnect = (account: AccountInfo) => {
       const accountKey = `${account.address}:${account.network.id}`;
@@ -94,9 +105,19 @@ export function WalletConnector({
       registeredElement = el;
 
       const onWcConnecting = (e: Event) => {
-        const walletId = (e as CustomEvent<{ walletId: string }>).detail?.walletId;
+        const detail = (e as CustomEvent<{ walletId?: string; connectionAttemptId?: number }>)
+          .detail;
+        const walletId = detail?.walletId;
         if (walletId) {
-          reportModalConnecting();
+          const attempt = reportModalConnecting();
+          if (detail?.connectionAttemptId === undefined) {
+            if (legacyModalAttempt) reportModalClosed([legacyModalAttempt]);
+            legacyModalAttempt = attempt;
+          } else {
+            const previousAttempt = modalAttempts.get(detail.connectionAttemptId);
+            if (previousAttempt) reportModalClosed([previousAttempt]);
+            modalAttempts.set(detail.connectionAttemptId, attempt);
+          }
           callbacksRef.current.onConnecting?.(walletId);
         }
       };
@@ -106,19 +127,32 @@ export function WalletConnector({
             error?: unknown;
             errorType?: 'rejected' | 'unavailable' | 'failed';
             walletId?: string;
+            connectionAttemptId?: number;
           }>
         ).detail;
         const error = normalizeModalError(detail?.error, detail?.errorType, detail?.walletId);
-        reportModalError(error);
-        callbacksRef.current.onError?.(error);
+        let attempt: symbol | null;
+        if (detail?.connectionAttemptId === undefined) {
+          attempt = legacyModalAttempt;
+          legacyModalAttempt = null;
+        } else {
+          attempt = modalAttempts.get(detail.connectionAttemptId) ?? null;
+          if (attempt === null) return;
+          modalAttempts.delete(detail.connectionAttemptId);
+        }
+        if (reportModalError(attempt, error)) callbacksRef.current.onError?.(error);
       };
+      const onWcClose = () => cancelModalAttempts();
 
       el.addEventListener('connecting', onWcConnecting);
       el.addEventListener('error', onWcError);
+      el.addEventListener('close', onWcClose);
 
       detach = () => {
         el.removeEventListener('connecting', onWcConnecting);
         el.removeEventListener('error', onWcError);
+        el.removeEventListener('close', onWcClose);
+        cancelModalAttempts();
       };
     });
 
@@ -129,7 +163,14 @@ export function WalletConnector({
       if (registeredElement) unregisterConnector(registeredElement);
       detach?.();
     };
-  }, [manager, registerConnector, unregisterConnector, reportModalConnecting, reportModalError]);
+  }, [
+    manager,
+    registerConnector,
+    unregisterConnector,
+    reportModalConnecting,
+    reportModalError,
+    reportModalClosed,
+  ]);
 
   const mergedStyle = {
     ...(theme ? THEMES[theme] : {}),

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -38,7 +38,7 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
 
   const connectorsRef = useRef<Set<WalletConnectorElement>>(new Set());
   const connectionAttemptsRef = useRef<Set<symbol>>(new Set());
-  const modalConnectingRef = useRef(false);
+  const modalConnectionAttemptsRef = useRef<Set<symbol>>(new Set());
 
   const [connected, setConnected] = useState<boolean>(manager.connected);
   const [account, setAccount] = useState<AccountInfo | null>(manager.account);
@@ -48,7 +48,9 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
 
   const syncConnecting = useCallback(() => {
     if (mountedRef.current) {
-      setConnecting(connectionAttemptsRef.current.size > 0 || modalConnectingRef.current);
+      setConnecting(
+        connectionAttemptsRef.current.size > 0 || modalConnectionAttemptsRef.current.size > 0
+      );
     }
   }, []);
   const beginConnectionAttempt = useCallback(() => {
@@ -70,7 +72,7 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
   );
   const cancelConnectionState = useCallback(() => {
     connectionAttemptsRef.current.clear();
-    modalConnectingRef.current = false;
+    modalConnectionAttemptsRef.current.clear();
     if (mountedRef.current) setError(null);
     syncConnecting();
   }, [syncConnecting]);
@@ -85,7 +87,7 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
     };
     const onConnect = () => {
       setError(null);
-      modalConnectingRef.current = false;
+      modalConnectionAttemptsRef.current.clear();
       syncConnecting();
       sync();
     };
@@ -93,7 +95,7 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
     const onAccountChanged = () => sync();
     const onNetworkChanged = () => sync();
     const onError = (err: unknown) => {
-      modalConnectingRef.current = false;
+      modalConnectionAttemptsRef.current.clear();
       syncConnecting();
       if (isWalletError(err)) setError(err);
     };
@@ -183,14 +185,28 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
     connectorsRef.current.delete(el);
   }, []);
   const reportModalConnecting = useCallback(() => {
-    modalConnectingRef.current = true;
+    const attempt = Symbol('modalConnectionAttempt');
+    modalConnectionAttemptsRef.current.add(attempt);
     if (mountedRef.current) setError(null);
     syncConnecting();
+    return attempt;
   }, [syncConnecting]);
   const reportModalError = useCallback(
-    (modalError: WalletError) => {
-      modalConnectingRef.current = false;
-      if (mountedRef.current) setError(modalError);
+    (attempt: symbol | null, modalError: WalletError) => {
+      if (attempt !== null && !modalConnectionAttemptsRef.current.delete(attempt)) return false;
+      if (!mountedRef.current || manager.connected) {
+        syncConnecting();
+        return false;
+      }
+      setError(modalError);
+      syncConnecting();
+      return true;
+    },
+    [manager, syncConnecting]
+  );
+  const reportModalClosed = useCallback(
+    (attempts: readonly symbol[]) => {
+      for (const attempt of attempts) modalConnectionAttemptsRef.current.delete(attempt);
       syncConnecting();
     },
     [syncConnecting]
@@ -217,6 +233,7 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
       unregisterConnector,
       reportModalConnecting,
       reportModalError,
+      reportModalClosed,
       openModal,
       closeModal,
     }),
@@ -233,6 +250,7 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
       unregisterConnector,
       reportModalConnecting,
       reportModalError,
+      reportModalClosed,
       openModal,
       closeModal,
     ]

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -7,7 +7,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { WalletManager, isWalletError } from '@xrpl-connect/core';
+import { WalletErrorCode, WalletManager, isWalletError } from '@xrpl-connect/core';
 import type { AccountInfo, NetworkInfo, WalletError, ConnectOptions } from '@xrpl-connect/core';
 import type {
   XrplConnectContextValue,
@@ -37,6 +37,8 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
   const mountedRef = useRef(false);
 
   const connectorsRef = useRef<Set<WalletConnectorElement>>(new Set());
+  const connectionAttemptsRef = useRef<Set<symbol>>(new Set());
+  const modalConnectingRef = useRef(false);
 
   const [connected, setConnected] = useState<boolean>(manager.connected);
   const [account, setAccount] = useState<AccountInfo | null>(manager.account);
@@ -44,8 +46,38 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
   const [connecting, setConnecting] = useState<boolean>(false);
   const [error, setError] = useState<WalletError | null>(null);
 
+  const syncConnecting = useCallback(() => {
+    if (mountedRef.current) {
+      setConnecting(connectionAttemptsRef.current.size > 0 || modalConnectingRef.current);
+    }
+  }, []);
+  const beginConnectionAttempt = useCallback(() => {
+    const attempt = Symbol('connectionAttempt');
+    connectionAttemptsRef.current.add(attempt);
+    if (mountedRef.current) setError(null);
+    syncConnecting();
+    return attempt;
+  }, [syncConnecting]);
+  const finishConnectionAttempt = useCallback(
+    (attempt: symbol, failure?: unknown) => {
+      if (!connectionAttemptsRef.current.delete(attempt) || !mountedRef.current) return;
+      if (failure !== undefined && isWalletError(failure) && !manager.connected) {
+        setError(failure);
+      }
+      syncConnecting();
+    },
+    [manager, syncConnecting]
+  );
+  const cancelConnectionState = useCallback(() => {
+    connectionAttemptsRef.current.clear();
+    modalConnectingRef.current = false;
+    if (mountedRef.current) setError(null);
+    syncConnecting();
+  }, [syncConnecting]);
+
   useEffect(() => {
     mountedRef.current = true;
+    syncConnecting();
     const sync = () => {
       setConnected(manager.connected);
       setAccount(manager.account);
@@ -53,14 +85,16 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
     };
     const onConnect = () => {
       setError(null);
-      setConnecting(false);
+      modalConnectingRef.current = false;
+      syncConnecting();
       sync();
     };
     const onDisconnect = () => sync();
     const onAccountChanged = () => sync();
     const onNetworkChanged = () => sync();
     const onError = (err: unknown) => {
-      setConnecting(false);
+      modalConnectingRef.current = false;
+      syncConnecting();
       if (isWalletError(err)) setError(err);
     };
 
@@ -74,16 +108,24 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
 
     let disposed = false;
     if (autoConnectRef.current) {
+      const attempt = beginConnectionAttempt();
       // StrictMode replays effects before microtasks run. Deferring here means
       // the throwaway setup is cancelled and only the live setup reconnects.
       queueMicrotask(() => {
-        if (disposed) return;
+        if (disposed) {
+          finishConnectionAttempt(attempt);
+          return;
+        }
         void manager.reconnect().then(
           () => {
             if (disposed && manager.connected) void manager.disconnect().catch(() => undefined);
+            finishConnectionAttempt(attempt);
           },
           (reconnectError: unknown) => {
-            if (!disposed && isWalletError(reconnectError)) setError(reconnectError);
+            const expectedOverlap =
+              isWalletError(reconnectError) &&
+              reconnectError.code === WalletErrorCode.ALREADY_CONNECTED;
+            finishConnectionAttempt(attempt, expectedOverlap ? undefined : reconnectError);
           }
         );
       });
@@ -92,19 +134,27 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
     return () => {
       disposed = true;
       mountedRef.current = false;
+      cancelConnectionState();
       manager.off('connect', onConnect);
       manager.off('disconnect', onDisconnect);
       manager.off('accountChanged', onAccountChanged);
       manager.off('networkChanged', onNetworkChanged);
       manager.off('error', onError);
+      connectorsRef.current.clear();
       void manager.disconnect().catch(() => undefined);
     };
-  }, [manager]);
+  }, [
+    manager,
+    beginConnectionAttempt,
+    finishConnectionAttempt,
+    cancelConnectionState,
+    syncConnecting,
+  ]);
 
   const connect = useCallback(
     async (walletId: string, options?: ConnectOptions) => {
-      setConnecting(true);
-      setError(null);
+      const attempt = beginConnectionAttempt();
+      let failure: unknown;
       try {
         const connectedAccount = await manager.connect(walletId, options);
         if (!mountedRef.current && manager.connected) {
@@ -112,17 +162,19 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
         }
         return connectedAccount;
       } catch (err) {
-        if (mountedRef.current) {
-          setConnecting(false);
-          if (isWalletError(err)) setError(err);
-        }
+        failure = err;
         throw err;
+      } finally {
+        finishConnectionAttempt(attempt, failure);
       }
     },
-    [manager]
+    [manager, beginConnectionAttempt, finishConnectionAttempt]
   );
 
-  const disconnect = useCallback(() => manager.disconnect(), [manager]);
+  const disconnect = useCallback(async () => {
+    cancelConnectionState();
+    await manager.disconnect();
+  }, [manager, cancelConnectionState]);
 
   const registerConnector = useCallback((el: WalletConnectorElement) => {
     connectorsRef.current.add(el);
@@ -131,13 +183,18 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
     connectorsRef.current.delete(el);
   }, []);
   const reportModalConnecting = useCallback(() => {
-    setConnecting(true);
-    setError(null);
-  }, []);
-  const reportModalError = useCallback((modalError: WalletError) => {
-    setConnecting(false);
-    setError(modalError);
-  }, []);
+    modalConnectingRef.current = true;
+    if (mountedRef.current) setError(null);
+    syncConnecting();
+  }, [syncConnecting]);
+  const reportModalError = useCallback(
+    (modalError: WalletError) => {
+      modalConnectingRef.current = false;
+      if (mountedRef.current) setError(modalError);
+      syncConnecting();
+    },
+    [syncConnecting]
+  );
 
   const getActiveConnector = useCallback(() => {
     const connectors = [...connectorsRef.current];

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -34,10 +34,12 @@ export interface XrplConnectContextValue {
   registerConnector: (el: WalletConnectorElement) => void;
   /** @internal — removes only the connector that is being unmounted. */
   unregisterConnector: (el: WalletConnectorElement) => void;
-  /** @internal — mirrors modal lifecycle events into provider state. */
-  reportModalConnecting: () => void;
-  /** @internal — mirrors typed modal failures into provider state. */
-  reportModalError: (error: WalletError) => void;
+  /** @internal — starts an independently owned modal connection attempt. */
+  reportModalConnecting: () => symbol;
+  /** @internal — reports a typed failure only for the matching live attempt. */
+  reportModalError: (attempt: symbol | null, error: WalletError) => boolean;
+  /** @internal — cancels modal attempts owned by a closing connector. */
+  reportModalClosed: (attempts: readonly symbol[]) => void;
   openModal: () => void;
   closeModal: () => void;
 }

--- a/packages/react/tests/react.test.tsx
+++ b/packages/react/tests/react.test.tsx
@@ -152,10 +152,13 @@ describe('XrplConnectProvider + hooks', () => {
     await act(async () => {
       storedState.resolve(
         JSON.stringify({
-          walletId: 'fake',
-          account: ACCOUNT,
-          network: ACCOUNT.network,
-          timestamp: Date.now(),
+          version: 1,
+          payload: {
+            walletId: 'fake',
+            account: ACCOUNT,
+            network: ACCOUNT.network,
+            timestamp: Date.now(),
+          },
         })
       );
       await new Promise((resolve) => setTimeout(resolve, 0));
@@ -171,6 +174,54 @@ describe('XrplConnectProvider + hooks', () => {
     expect(result.current.connected).toBe(true);
     expect(result.current.error).toBeNull();
     unmount();
+  });
+
+  it('cancels auto-connect while persisted state is still loading', async () => {
+    const storedState = deferred<string | null>();
+    const connect = vi.fn(async () => ACCOUNT);
+    const storage: StorageAdapter = {
+      get: vi.fn(() => storedState.promise),
+      set: vi.fn(async () => {}),
+      remove: vi.fn(async () => {}),
+      clear: vi.fn(async () => {}),
+    };
+    const { result } = renderHook(() => useWallet(), {
+      wrapper: ({ children }) => (
+        <XrplConnectProvider
+          config={{ adapters: [makeAdapter({ connect })], autoConnect: true, storage }}
+        >
+          {children}
+        </XrplConnectProvider>
+      ),
+    });
+
+    await waitFor(() => expect(storage.get).toHaveBeenCalledTimes(1));
+    expect(result.current.connecting).toBe(true);
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+    expect(result.current.connecting).toBe(false);
+
+    await act(async () => {
+      storedState.resolve(
+        JSON.stringify({
+          version: 1,
+          payload: {
+            walletId: 'fake',
+            account: ACCOUNT,
+            network: ACCOUNT.network,
+            timestamp: Date.now(),
+          },
+        })
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(connect).not.toHaveBeenCalled();
+    expect(result.current.connected).toBe(false);
+    expect(result.current.connecting).toBe(false);
+    expect(result.current.error).toBeNull();
   });
 
   it('reflects connect/disconnect state through useWallet', async () => {
@@ -528,6 +579,158 @@ describe('<WalletConnector>', () => {
     expect(walletState!.error).toBeNull();
     expect(onConnect).toHaveBeenCalledWith(ACCOUNT);
     unmount();
+  });
+
+  it('ignores a stale modal error after a manual connection succeeds', async () => {
+    const onError = vi.fn();
+    let walletState: ReturnType<typeof useWallet> | null = null;
+    function Capture() {
+      walletState = useWallet();
+      return null;
+    }
+    render(
+      <XrplConnectProvider config={{ adapters: [makeAdapter()], autoConnect: false }}>
+        <Capture />
+        <WalletConnector onError={onError} />
+      </XrplConnectProvider>
+    );
+
+    const el = document.querySelector('xrpl-wallet-connector') as HTMLElement & {
+      manager: unknown;
+    };
+    await waitFor(() => expect(el.manager).not.toBeNull());
+
+    act(() => {
+      el.dispatchEvent(
+        new CustomEvent('connecting', {
+          detail: { walletId: 'fake', connectionAttemptId: 1 },
+        })
+      );
+    });
+    await act(async () => {
+      await walletState!.connect('fake');
+    });
+    expect(walletState!.connected).toBe(true);
+    expect(walletState!.error).toBeNull();
+
+    const staleError = createWalletError.alreadyConnected('Fake');
+    act(() => {
+      el.dispatchEvent(
+        new CustomEvent('error', {
+          detail: { error: staleError, walletId: 'fake', connectionAttemptId: 1 },
+        })
+      );
+    });
+
+    expect(walletState!.connected).toBe(true);
+    expect(walletState!.connecting).toBe(false);
+    expect(walletState!.error).toBeNull();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('keeps sibling modal attempts active when one connector closes', async () => {
+    let walletState: ReturnType<typeof useWallet> | null = null;
+    function Capture() {
+      walletState = useWallet();
+      return null;
+    }
+    render(
+      <XrplConnectProvider config={{ adapters: [makeAdapter()], autoConnect: false }}>
+        <Capture />
+        <WalletConnector className="first" />
+        <WalletConnector className="second" />
+      </XrplConnectProvider>
+    );
+
+    const first = document.querySelector('.first') as HTMLElement & { manager: unknown };
+    const second = document.querySelector('.second') as HTMLElement & { manager: unknown };
+    await waitFor(() => {
+      expect(first.manager).not.toBeNull();
+      expect(second.manager).not.toBeNull();
+    });
+
+    act(() => {
+      first.dispatchEvent(
+        new CustomEvent('connecting', {
+          detail: { walletId: 'fake', connectionAttemptId: 1 },
+        })
+      );
+      second.dispatchEvent(
+        new CustomEvent('connecting', {
+          detail: { walletId: 'fake', connectionAttemptId: 1 },
+        })
+      );
+    });
+    await waitFor(() => expect(walletState!.connecting).toBe(true));
+
+    act(() => first.dispatchEvent(new CustomEvent('close')));
+    expect(walletState!.connecting).toBe(true);
+
+    act(() => second.dispatchEvent(new CustomEvent('close')));
+    expect(walletState!.connecting).toBe(false);
+  });
+
+  it('does not let a cancelled modal error clear a newer retry', async () => {
+    const onError = vi.fn();
+    let walletState: ReturnType<typeof useWallet> | null = null;
+    function Capture() {
+      walletState = useWallet();
+      return null;
+    }
+    render(
+      <XrplConnectProvider config={{ adapters: [makeAdapter()], autoConnect: false }}>
+        <Capture />
+        <WalletConnector onError={onError} />
+      </XrplConnectProvider>
+    );
+
+    const el = document.querySelector('xrpl-wallet-connector') as HTMLElement & {
+      manager: unknown;
+    };
+    await waitFor(() => expect(el.manager).not.toBeNull());
+
+    act(() => {
+      el.dispatchEvent(
+        new CustomEvent('connecting', {
+          detail: { walletId: 'fake', connectionAttemptId: 1 },
+        })
+      );
+    });
+    await act(async () => {
+      await walletState!.disconnect();
+    });
+    act(() => {
+      el.dispatchEvent(
+        new CustomEvent('connecting', {
+          detail: { walletId: 'fake', connectionAttemptId: 2 },
+        })
+      );
+    });
+
+    const staleError = createWalletError.notConnected();
+    act(() => {
+      el.dispatchEvent(
+        new CustomEvent('error', {
+          detail: { error: staleError, walletId: 'fake', connectionAttemptId: 1 },
+        })
+      );
+    });
+    expect(walletState!.connecting).toBe(true);
+    expect(walletState!.error).toBeNull();
+    expect(onError).not.toHaveBeenCalled();
+
+    const currentError = createWalletError.connectionRejected('Fake');
+    act(() => {
+      el.dispatchEvent(
+        new CustomEvent('error', {
+          detail: { error: currentError, walletId: 'fake', connectionAttemptId: 2 },
+        })
+      );
+    });
+    expect(walletState!.connecting).toBe(false);
+    expect(walletState!.error).toBe(currentError);
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError).toHaveBeenCalledWith(currentError);
   });
 
   it('keeps the remaining connector registered when a sibling unmounts', async () => {

--- a/packages/react/tests/react.test.tsx
+++ b/packages/react/tests/react.test.tsx
@@ -21,6 +21,14 @@ import {
 
 const ACCOUNT: AccountInfo = { address: 'rTEST', network: STANDARD_NETWORKS.testnet };
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 function makeAdapter(overrides: Partial<WalletAdapter> = {}): WalletAdapter {
   return {
     id: 'fake',
@@ -113,6 +121,58 @@ describe('XrplConnectProvider + hooks', () => {
     await waitFor(() => expect(storage.get).toHaveBeenCalledTimes(1));
   });
 
+  it('tracks auto-connect without surfacing an expected manual overlap error', async () => {
+    const storedState = deferred<string | null>();
+    const pendingConnection = deferred<AccountInfo>();
+    const connect = vi.fn(() => pendingConnection.promise);
+    const storage: StorageAdapter = {
+      get: vi.fn(() => storedState.promise),
+      set: vi.fn(async () => {}),
+      remove: vi.fn(async () => {}),
+      clear: vi.fn(async () => {}),
+    };
+    const adapters = [makeAdapter({ connect })];
+    const { result, unmount } = renderHook(() => useWallet(), {
+      wrapper: ({ children }) => (
+        <XrplConnectProvider config={{ adapters, autoConnect: true, storage }}>
+          {children}
+        </XrplConnectProvider>
+      ),
+    });
+
+    await waitFor(() => expect(storage.get).toHaveBeenCalledTimes(1));
+    expect(result.current.connecting).toBe(true);
+
+    let manualConnection!: Promise<AccountInfo>;
+    act(() => {
+      manualConnection = result.current.connect('fake');
+    });
+    await waitFor(() => expect(connect).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      storedState.resolve(
+        JSON.stringify({
+          walletId: 'fake',
+          account: ACCOUNT,
+          network: ACCOUNT.network,
+          timestamp: Date.now(),
+        })
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(result.current.connecting).toBe(true);
+    expect(result.current.error).toBeNull();
+
+    await act(async () => {
+      pendingConnection.resolve(ACCOUNT);
+      await expect(manualConnection).resolves.toEqual(ACCOUNT);
+    });
+    await waitFor(() => expect(result.current.connecting).toBe(false));
+    expect(result.current.connected).toBe(true);
+    expect(result.current.error).toBeNull();
+    unmount();
+  });
+
   it('reflects connect/disconnect state through useWallet', async () => {
     const { result } = renderHook(() => useWallet(), { wrapper: wrapper([makeAdapter()]) });
 
@@ -132,6 +192,64 @@ describe('XrplConnectProvider + hooks', () => {
     expect(result.current.account).toBeNull();
   });
 
+  it('keeps connecting true until every concurrent connection attempt settles', async () => {
+    const pending = deferred<AccountInfo>();
+    const connect = vi.fn(() => pending.promise);
+    const { result, unmount } = renderHook(() => useWallet(), {
+      wrapper: wrapper([makeAdapter({ connect })]),
+    });
+
+    let firstConnection!: Promise<AccountInfo>;
+    act(() => {
+      firstConnection = result.current.connect('fake');
+    });
+    await waitFor(() => expect(connect).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await expect(result.current.connect('fake')).rejects.toMatchObject({
+        code: WalletErrorCode.ALREADY_CONNECTED,
+      });
+    });
+    expect(result.current.connecting).toBe(true);
+
+    await act(async () => {
+      pending.resolve(ACCOUNT);
+      await expect(firstConnection).resolves.toEqual(ACCOUNT);
+    });
+    expect(result.current.connected).toBe(true);
+    expect(result.current.connecting).toBe(false);
+    expect(result.current.error).toBeNull();
+    unmount();
+  });
+
+  it('clears connection state when a pending connection is cancelled', async () => {
+    const pending = deferred<AccountInfo>();
+    const connect = vi.fn(() => pending.promise);
+    const disconnect = vi.fn(async () => {});
+    const { result } = renderHook(() => useWallet(), {
+      wrapper: wrapper([makeAdapter({ connect, disconnect })]),
+    });
+
+    let connection!: Promise<AccountInfo>;
+    act(() => {
+      connection = result.current.connect('fake');
+    });
+    await waitFor(() => expect(connect).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+    expect(result.current.connecting).toBe(false);
+    expect(result.current.error).toBeNull();
+
+    await act(async () => {
+      pending.resolve(ACCOUNT);
+      await expect(connection).rejects.toMatchObject({ code: WalletErrorCode.NOT_CONNECTED });
+    });
+    expect(result.current.connecting).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
   it('disconnects an owned manager when the provider unmounts', async () => {
     const disconnect = vi.fn(async () => {});
     const { result, unmount } = renderHook(() => useWallet(), {
@@ -145,11 +263,35 @@ describe('XrplConnectProvider + hooks', () => {
     await waitFor(() => expect(disconnect).toHaveBeenCalledTimes(1));
   });
 
-  it('cancels a direct manager connection that resolves after unmount', async () => {
-    let resolveConnect!: (account: AccountInfo) => void;
+  it('cancels a provider connection that resolves after unmount', async () => {
+    const pending = deferred<AccountInfo>();
     const disconnect = vi.fn(async () => {});
     const adapter = makeAdapter({
-      connect: vi.fn(() => new Promise<AccountInfo>((resolve) => (resolveConnect = resolve))),
+      connect: vi.fn(() => pending.promise),
+      disconnect,
+    });
+    const { result, unmount } = renderHook(() => useWallet(), { wrapper: wrapper([adapter]) });
+
+    const manager = result.current.manager;
+    let connecting!: Promise<AccountInfo>;
+    act(() => {
+      connecting = result.current.connect('fake');
+    });
+    await waitFor(() => expect(adapter.connect).toHaveBeenCalledTimes(1));
+    unmount();
+    await waitFor(() => expect(disconnect).toHaveBeenCalledTimes(1));
+    pending.resolve(ACCOUNT);
+
+    await expect(connecting).rejects.toMatchObject({ code: WalletErrorCode.NOT_CONNECTED });
+    expect(disconnect).toHaveBeenCalled();
+    expect(manager.connected).toBe(false);
+  });
+
+  it('cancels a direct manager connection that resolves after unmount', async () => {
+    const pending = deferred<AccountInfo>();
+    const disconnect = vi.fn(async () => {});
+    const adapter = makeAdapter({
+      connect: vi.fn(() => pending.promise),
       disconnect,
     });
     let manager: WalletManager | null = null;
@@ -167,7 +309,7 @@ describe('XrplConnectProvider + hooks', () => {
     await waitFor(() => expect(adapter.connect).toHaveBeenCalledTimes(1));
     unmount();
     await waitFor(() => expect(disconnect).toHaveBeenCalledTimes(1));
-    resolveConnect(ACCOUNT);
+    pending.resolve(ACCOUNT);
 
     await expect(connecting).rejects.toMatchObject({ code: WalletErrorCode.NOT_CONNECTED });
     expect(disconnect).toHaveBeenCalled();
@@ -334,6 +476,58 @@ describe('<WalletConnector>', () => {
     expect(onError).toHaveBeenLastCalledWith(
       expect.objectContaining({ code: WalletErrorCode.WALLET_NOT_INSTALLED })
     );
+  });
+
+  it('keeps connecting true when a modal error overlaps a manual connection', async () => {
+    const pending = deferred<AccountInfo>();
+    const connect = vi.fn(() => pending.promise);
+    const onConnect = vi.fn();
+    const onError = vi.fn();
+    let walletState: ReturnType<typeof useWallet> | null = null;
+    function Capture() {
+      walletState = useWallet();
+      return null;
+    }
+    const { unmount } = render(
+      <XrplConnectProvider config={{ adapters: [makeAdapter({ connect })], autoConnect: false }}>
+        <Capture />
+        <WalletConnector onConnect={onConnect} onError={onError} />
+      </XrplConnectProvider>
+    );
+
+    const el = document.querySelector('xrpl-wallet-connector') as HTMLElement & {
+      manager: unknown;
+    };
+    await waitFor(() => expect(el.manager).not.toBeNull());
+
+    let manualConnection!: Promise<AccountInfo>;
+    act(() => {
+      manualConnection = walletState!.connect('fake');
+    });
+    await waitFor(() => expect(connect).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      el.dispatchEvent(new CustomEvent('connecting', { detail: { walletId: 'fake' } }));
+    });
+    const modalError = createWalletError.connectionRejected('Fake');
+    act(() => {
+      el.dispatchEvent(
+        new CustomEvent('error', { detail: { error: modalError, walletId: 'fake' } })
+      );
+    });
+    await waitFor(() => expect(walletState!.error).toBe(modalError));
+    expect(walletState!.connecting).toBe(true);
+    expect(onError).toHaveBeenCalledWith(modalError);
+
+    await act(async () => {
+      pending.resolve(ACCOUNT);
+      await expect(manualConnection).resolves.toEqual(ACCOUNT);
+    });
+    await waitFor(() => expect(walletState!.connecting).toBe(false));
+    expect(walletState!.connected).toBe(true);
+    expect(walletState!.error).toBeNull();
+    expect(onConnect).toHaveBeenCalledWith(ACCOUNT);
+    unmount();
   });
 
   it('keeps the remaining connector registered when a sibling unmounts', async () => {

--- a/packages/ui/src/services/WalletService.ts
+++ b/packages/ui/src/services/WalletService.ts
@@ -58,10 +58,22 @@ function asErrorLike(value: unknown): ErrorLike {
 }
 
 export class WalletService {
+  private nextConnectionAttemptId = 0;
+
   constructor(
     private walletManager: WalletManager,
     private component: WalletConnectorContext
   ) {}
+
+  private dispatchConnecting(walletId: string, detail: Record<string, unknown> = {}): number {
+    const connectionAttemptId = ++this.nextConnectionAttemptId;
+    this.component.dispatchEvent(
+      new CustomEvent('connecting', {
+        detail: { walletId, ...detail, connectionAttemptId },
+      })
+    );
+    return connectionAttemptId;
+  }
 
   async connectWallet(walletId: string, options?: ConnectOptions) {
     if (!this.walletManager) {
@@ -69,6 +81,7 @@ export class WalletService {
       return;
     }
 
+    let connectionAttemptId: number | undefined;
     try {
       // Get wallet info
       const wallet = this.walletManager.wallets.find((w) => w.id === walletId);
@@ -112,14 +125,16 @@ export class WalletService {
           // Show loading state first (with spinning animation like Xaman)
           this.component.showLoadingView(walletId, wallet.name, wallet.icon);
 
-          this.component.dispatchEvent(new CustomEvent('connecting', { detail: { walletId } }));
+          connectionAttemptId = this.dispatchConnecting(walletId);
 
           // Small delay to show the loading animation before WC modal appears
           await delay(TIMINGS.NON_SAFARI_CONNECT_DELAY);
 
           // Connect - WalletConnect modal will open on top of our loading view
           await this.walletManager.connect(walletId, options);
-          this.component.dispatchEvent(new CustomEvent('connected', { detail: { walletId } }));
+          this.component.dispatchEvent(
+            new CustomEvent('connected', { detail: { walletId, connectionAttemptId } })
+          );
 
           // Close our modal after successful connection
           this.component.close();
@@ -139,9 +154,11 @@ export class WalletService {
             },
           };
 
-          this.component.dispatchEvent(new CustomEvent('connecting', { detail: { walletId } }));
+          connectionAttemptId = this.dispatchConnecting(walletId);
           await this.walletManager.connect(walletId, connectOptions);
-          this.component.dispatchEvent(new CustomEvent('connected', { detail: { walletId } }));
+          this.component.dispatchEvent(
+            new CustomEvent('connected', { detail: { walletId, connectionAttemptId } })
+          );
         }
       } else if (walletId === 'ledger') {
         // For Ledger, show account selection first
@@ -176,7 +193,7 @@ export class WalletService {
         // Show loading state
         this.component.showLoadingView(walletId, wallet.name, wallet.icon);
 
-        this.component.dispatchEvent(new CustomEvent('connecting', { detail: { walletId } }));
+        connectionAttemptId = this.dispatchConnecting(walletId);
 
         // Browser-specific delay (Safari needs immediate connection for user gesture)
         if (!isSafari() && walletId !== 'xaman') {
@@ -198,7 +215,9 @@ export class WalletService {
         if (walletId === 'xaman') {
           logger.info('Xaman UI connection phase: WalletManager connected');
         }
-        this.component.dispatchEvent(new CustomEvent('connected', { detail: { walletId } }));
+        this.component.dispatchEvent(
+          new CustomEvent('connected', { detail: { walletId, connectionAttemptId } })
+        );
       }
     } catch (error: unknown) {
       const err = asErrorLike(error);
@@ -233,7 +252,9 @@ export class WalletService {
 
       this.component.showErrorView(walletId, wallet?.name || 'Wallet', new Error(errorMessage));
       this.component.dispatchEvent(
-        new CustomEvent('error', { detail: { error, walletId, errorType } })
+        new CustomEvent('error', {
+          detail: { error, walletId, errorType, connectionAttemptId },
+        })
       );
       logger.error('Failed to connect:', error);
     }
@@ -243,6 +264,7 @@ export class WalletService {
     if (!this.walletManager || !this.component.accountSelectionData) return;
 
     const { walletId, walletName, walletIcon } = this.component.accountSelectionData;
+    let connectionAttemptId: number | undefined;
 
     try {
       // Show loading state
@@ -254,15 +276,15 @@ export class WalletService {
       }
 
       logger.debug('Connecting to Ledger with account index:', accountIndex);
-      this.component.dispatchEvent(
-        new CustomEvent('connecting', { detail: { walletId, accountIndex } })
-      );
+      connectionAttemptId = this.dispatchConnecting(walletId, { accountIndex });
 
       const ledgerOptions: ConnectOptions<LedgerConnectOptions> = { accountIndex };
       await this.walletManager.connect(walletId, ledgerOptions);
 
       this.component.dispatchEvent(
-        new CustomEvent('connected', { detail: { walletId, accountIndex } })
+        new CustomEvent('connected', {
+          detail: { walletId, accountIndex, connectionAttemptId },
+        })
       );
     } catch (error: unknown) {
       const err = asErrorLike(error);
@@ -281,7 +303,9 @@ export class WalletService {
       logger.debug('Connection error type:', errorType, 'Code:', err.code);
       this.component.showErrorView(walletId, walletName, new Error(errorMessage));
       this.component.dispatchEvent(
-        new CustomEvent('error', { detail: { error, walletId, errorType } })
+        new CustomEvent('error', {
+          detail: { error, walletId, errorType, connectionAttemptId },
+        })
       );
       logger.error('Failed to connect:', error);
     }
@@ -291,6 +315,7 @@ export class WalletService {
     if (!this.walletManager || !this.component.accountSelectionData) return;
 
     const { walletId, walletName, walletIcon } = this.component.accountSelectionData;
+    let connectionAttemptId: number | undefined;
 
     try {
       // Validate derivation path format
@@ -308,15 +333,15 @@ export class WalletService {
       }
 
       logger.debug('Connecting to Ledger with custom derivation path:', derivationPath);
-      this.component.dispatchEvent(
-        new CustomEvent('connecting', { detail: { walletId, derivationPath } })
-      );
+      connectionAttemptId = this.dispatchConnecting(walletId, { derivationPath });
 
       const ledgerOptions: ConnectOptions<LedgerConnectOptions> = { derivationPath };
       await this.walletManager.connect(walletId, ledgerOptions);
 
       this.component.dispatchEvent(
-        new CustomEvent('connected', { detail: { walletId, derivationPath } })
+        new CustomEvent('connected', {
+          detail: { walletId, derivationPath, connectionAttemptId },
+        })
       );
     } catch (error: unknown) {
       const err = asErrorLike(error);
@@ -335,7 +360,9 @@ export class WalletService {
       logger.debug('Connection error type:', errorType, 'Code:', err.code);
       this.component.showErrorView(walletId, walletName, new Error(errorMessage));
       this.component.dispatchEvent(
-        new CustomEvent('error', { detail: { error, walletId, errorType } })
+        new CustomEvent('error', {
+          detail: { error, walletId, errorType, connectionAttemptId },
+        })
       );
       logger.error('Failed to connect:', error);
     }

--- a/packages/ui/tests/WalletService.test.ts
+++ b/packages/ui/tests/WalletService.test.ts
@@ -29,6 +29,43 @@ describe('WalletService', () => {
 
     expect(connect).toHaveBeenCalledWith('xaman', undefined);
     await connection;
+
+    const lifecycleEvents = mockComponent.dispatchEvent.mock.calls.map(
+      ([event]) => event as CustomEvent<{ connectionAttemptId?: number }>
+    );
+    const connecting = lifecycleEvents.find((event) => event.type === 'connecting');
+    const connected = lifecycleEvents.find((event) => event.type === 'connected');
+    expect(connecting?.detail.connectionAttemptId).toEqual(expect.any(Number));
+    expect(connected?.detail.connectionAttemptId).toBe(connecting?.detail.connectionAttemptId);
+  });
+
+  it('uses the same attempt id for a connection failure', async () => {
+    const connectionError = new Error('rejected');
+    const mockWalletManager = {
+      wallets: [{ id: 'xaman', name: 'Xaman' }],
+      connect: vi.fn(async () => {
+        throw connectionError;
+      }),
+    };
+    const mockComponent = {
+      showLoadingView: vi.fn(),
+      showQRCodeView: vi.fn(),
+      showAccountSelectionView: vi.fn(),
+      showErrorView: vi.fn(),
+      dispatchEvent: vi.fn(),
+      setQRCode: vi.fn(),
+      close: vi.fn(),
+    };
+    const walletService = new WalletService(mockWalletManager as any, mockComponent as any);
+
+    await walletService.connectWallet('xaman');
+
+    const lifecycleEvents = mockComponent.dispatchEvent.mock.calls.map(
+      ([event]) => event as CustomEvent<{ connectionAttemptId?: number }>
+    );
+    const connecting = lifecycleEvents.find((event) => event.type === 'connecting');
+    const error = lifecycleEvents.find((event) => event.type === 'error');
+    expect(error?.detail.connectionAttemptId).toBe(connecting?.detail.connectionAttemptId);
   });
 
   it('should connect to a wallet', async () => {


### PR DESCRIPTION
## Summary
- track manual and automatic React connection attempts independently so one completion cannot clear another pending attempt
- preserve accurate modal, disconnect, and unmount state while preventing stale completions from mutating provider state
- add regression coverage for overlapping attempts, cancellation, auto/manual and modal/manual races, and provider teardown

## Test plan
- [x] `pnpm --filter @xrpl-connect/react exec vp test run tests/react.test.tsx`
- [x] `pnpm --filter @xrpl-connect/react test`
- [x] `pnpm --filter @xrpl-connect/react type-check`
- [x] `pnpm --filter @xrpl-connect/react lint`
- [x] `pnpm --filter @xrpl-connect/react build`
- [x] `pnpm exec vp fmt --check packages/react/src/provider.tsx packages/react/tests/react.test.tsx`

Fixes #118
