### PR TITLE
fix: publish bindings under XRPL Commons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- New package `@xrpl-connect/react`: official React bindings so consumers no longer hand-roll a context/hooks layer. Provides `<XrplConnectProvider config={…}>` (owns a single `WalletManager`, configured once), the hooks `useWallet`, `useSigner`, `useWalletModal`, and a themeable `<WalletConnector>` modal component with typed props and typed-`WalletError` callbacks (`onError(err) → err.code`/`err.category`). Ships its own tests (#33).
+- New package `@xrpl-commons/xrpl-connect-react`: official React bindings so consumers no longer hand-roll a context/hooks layer. Provides `<XrplConnectProvider config={…}>` (owns a single `WalletManager`, configured once), the hooks `useWallet`, `useSigner`, `useWalletModal`, and a themeable `<WalletConnector>` modal component with typed props and typed-`WalletError` callbacks (`onError(err) → err.code`/`err.category`). Ships its own tests (#33).
 - New adapter `@xrpl-connect/adapter-metamask-snap`: connect XRPL through MetaMask via the `xrpl-snap` Snap (provider RPC, no extra npm dependency). Wired into the `xrpl-connect` meta-package (`MetaMaskSnapAdapter`, `Adapters.MetaMaskSnap`). Adapter authored by @LeJamon; modernised to current conventions (shared tsup config, SVG icon asset, typed EIP-1193 provider) with added Vitest coverage (#46).
 - UI: optional `show-unavailable` attribute on `<xrpl-wallet-connector>`. By default the modal hides wallets that aren't installed (unchanged). With `show-unavailable` set, those wallets are listed with an "Install" label that opens the wallet's download page (`url`) instead of attempting to connect. Mirrors Stellar Wallets Kit's `hideUnsupportedWallets` / install-label option.
 - Core: add declarative signing capabilities through `WalletAdapter.capabilities`, `WalletManager.supports()`, `adapterSupports()`, and `CAPABILITY_DEFAULTS`. Undeclared `sign`, `signAndSubmit`, and `signMessage` flags default to `true` for compatibility; explicitly unsupported manager operations fail with typed `UNSUPPORTED_METHOD` before the adapter is called. Xaman and WalletConnect now declare arbitrary message signing unsupported.
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Release: prepare `xrpl-connect`, `@xrpl-connect/react`, and `@xrpl-connect/vue` as `1.0.0-rc.0` with RC-compatible peers, guarded `rc` publishing defaults, and combined packed-artifact verification (#119).
+- Release: prepare `xrpl-connect`, `@xrpl-commons/xrpl-connect-react`, and `@xrpl-commons/xrpl-connect-vue` as `1.0.0-rc.0` with RC-compatible peers, guarded `rc` publishing defaults, and combined packed-artifact verification (#119).
 - Release tooling: reject dirty worktrees and non-npm registries, verify ownership of the unscoped package, and safely restore missing `rc` tags after interrupted publishes.
 - DevEx: test all supported Node.js release lines in CI with frozen installs, ship an MIT license in every candidate artifact, and align release, framework, and RC documentation.
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -466,7 +466,7 @@ The umbrella also exposes the shared core types, error primitives, capability gu
 
 ## React API
 
-Install `@xrpl-connect/react` alongside `xrpl-connect` when using React.
+Install `@xrpl-commons/xrpl-connect-react` alongside `xrpl-connect` when using React.
 
 ### XrplConnectProvider
 
@@ -492,7 +492,7 @@ and `onError`. See the [React guide](/guide/frameworks/react) for a complete set
 
 ## Vue API
 
-Install `@xrpl-connect/vue` alongside `xrpl-connect` for Vue 3 and Nuxt applications.
+Install `@xrpl-commons/xrpl-connect-vue` alongside `xrpl-connect` for Vue 3 and Nuxt applications.
 
 ### createXrplConnect
 

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -11,7 +11,7 @@ Real-world examples and pre-built theme configurations.
 The React example application demonstrates the recommended v1 integration, including:
 
 - Multiple wallet adapters
-- The official provider and hooks from `@xrpl-connect/react`
+- The official provider and hooks from `@xrpl-commons/xrpl-connect-react`
 - Capability-aware transaction and message signing
 - Dynamic theme customization
 - Real-time event logging

--- a/docs/guide/frameworks/nuxt.md
+++ b/docs/guide/frameworks/nuxt.md
@@ -5,13 +5,13 @@ description: Integrate XRPL-Connect into Nuxt with the first-party Vue bindings.
 # Nuxt
 
 XRPL Connect's modal is a browser custom element. In Nuxt, register it and install the
-`@xrpl-connect/vue` plugin from a client-only Nuxt plugin. Components that call the injected
+`@xrpl-commons/xrpl-connect-vue` plugin from a client-only Nuxt plugin. Components that call the injected
 Vue composables must also run only on the client.
 
 ## Installation
 
 ```bash
-npm install @xrpl-connect/vue@rc xrpl-connect@rc xrpl vue
+npm install @xrpl-commons/xrpl-connect-vue@rc xrpl-connect@rc xrpl vue
 ```
 
 ## Client plugin
@@ -20,7 +20,7 @@ Create `plugins/xrpl-connect.client.ts`:
 
 ```ts
 import { CrossmarkAdapter, XamanAdapter } from 'xrpl-connect';
-import { createXrplConnect } from '@xrpl-connect/vue';
+import { createXrplConnect } from '@xrpl-commons/xrpl-connect-vue';
 
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.use(
@@ -56,7 +56,7 @@ secrets in `runtimeConfig.public`.
 The `.client.ts` suffix prevents wallet adapters, plugin installation, and custom-element
 registration from running during server rendering. The named `xrpl-connect` import evaluates
 the package entry and registers the custom element, so a separate side-effect import is not
-needed. `@xrpl-connect/vue` itself remains safe to import in universal modules.
+needed. `@xrpl-commons/xrpl-connect-vue` itself remains safe to import in universal modules.
 
 ## Wallet component
 
@@ -66,7 +66,7 @@ the template.
 
 ```vue
 <script setup lang="ts">
-import { WalletConnector, useWallet, useWalletModal } from '@xrpl-connect/vue';
+import { WalletConnector, useWallet, useWalletModal } from '@xrpl-commons/xrpl-connect-vue';
 
 const { connected, account, connecting, error, disconnect } = useWallet();
 const { open } = useWalletModal();
@@ -98,7 +98,12 @@ component, create `components/PaymentButton.client.vue`:
 
 ```vue
 <script setup lang="ts">
-import { isWalletError, useSigner, useWallet, WalletErrorCode } from '@xrpl-connect/vue';
+import {
+  isWalletError,
+  useSigner,
+  useWallet,
+  WalletErrorCode,
+} from '@xrpl-commons/xrpl-connect-vue';
 
 const { account, connected } = useWallet();
 const { signAndSubmit } = useSigner();

--- a/docs/guide/frameworks/react.md
+++ b/docs/guide/frameworks/react.md
@@ -9,7 +9,7 @@ Use the official React bindings instead of building a custom context around the 
 ## Install
 
 ```bash
-pnpm add xrpl-connect@rc @xrpl-connect/react@rc xrpl react react-dom
+pnpm add xrpl-connect@rc @xrpl-commons/xrpl-connect-react@rc xrpl react react-dom
 ```
 
 ## Configure the provider
@@ -17,7 +17,7 @@ pnpm add xrpl-connect@rc @xrpl-connect/react@rc xrpl react react-dom
 Create the adapter configuration once, outside component render. The provider snapshots its initial configuration and owns one manager; changing the object does not rebuild it. Give the provider a new React `key` only when you intentionally want to replace that manager. This Vite example uses client-visible `VITE_*` variables:
 
 ```tsx
-import { XrplConnectProvider, WalletConnector } from '@xrpl-connect/react';
+import { XrplConnectProvider, WalletConnector } from '@xrpl-commons/xrpl-connect-react';
 import {
   CrossmarkAdapter,
   MetaMaskSnapAdapter,
@@ -57,7 +57,7 @@ export function App() {
 `useWallet()` provides the stable manager, reactive state, and direct connect/disconnect actions.
 
 ```tsx
-import { useWallet, useWalletModal } from '@xrpl-connect/react';
+import { useWallet, useWalletModal } from '@xrpl-commons/xrpl-connect-react';
 
 function Header() {
   const { connected, connecting, account, network, error, disconnect } = useWallet();
@@ -88,7 +88,7 @@ The hook returns `manager`, `connected`, `account`, `network`, `connecting`, `er
 
 ```tsx
 import { WalletErrorCode, isWalletError } from 'xrpl-connect';
-import { useSigner, useWallet } from '@xrpl-connect/react';
+import { useSigner, useWallet } from '@xrpl-commons/xrpl-connect-react';
 
 function PaymentButton({ destination }: { destination: string }) {
   const { account } = useWallet();
@@ -137,7 +137,7 @@ The package is safe to import during server rendering. Provider and wallet UI us
 ```tsx
 'use client';
 
-import { XrplConnectProvider, WalletConnector } from '@xrpl-connect/react';
+import { XrplConnectProvider, WalletConnector } from '@xrpl-commons/xrpl-connect-react';
 import type { ReactNode } from 'react';
 import { WalletConnectAdapter, XamanAdapter } from 'xrpl-connect';
 

--- a/docs/guide/frameworks/vue.md
+++ b/docs/guide/frameworks/vue.md
@@ -4,14 +4,14 @@ description: Integrate XRPL-Connect into your Vue 3 application with first-party
 
 # Vue 3
 
-`@xrpl-connect/vue` provides a Vue plugin, reactive composables, and a typed wrapper for the
+`@xrpl-commons/xrpl-connect-vue` provides a Vue plugin, reactive composables, and a typed wrapper for the
 wallet connector modal. Configure the wallet manager once and consume the same state anywhere
 in the application.
 
 ## Installation
 
 ```bash
-npm install @xrpl-connect/vue@rc xrpl-connect@rc xrpl vue
+npm install @xrpl-commons/xrpl-connect-vue@rc xrpl-connect@rc xrpl vue
 ```
 
 ## Configure the plugin
@@ -24,7 +24,7 @@ the application:
 // main.ts
 import { createApp } from 'vue';
 import { CrossmarkAdapter, XamanAdapter } from 'xrpl-connect';
-import { createXrplConnect } from '@xrpl-connect/vue';
+import { createXrplConnect } from '@xrpl-commons/xrpl-connect-vue';
 import App from './App.vue';
 
 const app = createApp(App);
@@ -63,7 +63,7 @@ reactive listeners are ready.
 
 ```vue
 <script setup lang="ts">
-import { WalletConnector, useWallet, useWalletModal } from '@xrpl-connect/vue';
+import { WalletConnector, useWallet, useWalletModal } from '@xrpl-commons/xrpl-connect-vue';
 
 const { connected, account, connecting, error, disconnect } = useWallet();
 const { open } = useWalletModal();
@@ -96,7 +96,12 @@ Signing actions are bound to the injected manager and reject with typed `WalletE
 ```vue
 <script setup lang="ts">
 import { ref } from 'vue';
-import { isWalletError, useSigner, useWallet, WalletErrorCode } from '@xrpl-connect/vue';
+import {
+  isWalletError,
+  useSigner,
+  useWallet,
+  WalletErrorCode,
+} from '@xrpl-commons/xrpl-connect-vue';
 
 const { account, connected } = useWallet();
 const { signAndSubmit } = useSigner();

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -18,10 +18,10 @@ Add the official bindings for your framework:
 
 ```bash
 # React
-npm install @xrpl-connect/react@rc react react-dom
+npm install @xrpl-commons/xrpl-connect-react@rc react react-dom
 
 # Vue 3 or Nuxt
-npm install @xrpl-connect/vue@rc vue
+npm install @xrpl-commons/xrpl-connect-vue@rc vue
 ```
 
 ### Using pnpm

--- a/docs/guide/migration-v1.md
+++ b/docs/guide/migration-v1.md
@@ -19,20 +19,20 @@ Do not install both framework bindings. Upgrade the umbrella package and only th
 pnpm add xrpl-connect@rc xrpl
 
 # React
-pnpm add xrpl-connect@rc @xrpl-connect/react@rc xrpl react react-dom
+pnpm add xrpl-connect@rc @xrpl-commons/xrpl-connect-react@rc xrpl react react-dom
 
 # Vue 3 or Nuxt
-pnpm add xrpl-connect@rc @xrpl-connect/vue@rc xrpl vue
+pnpm add xrpl-connect@rc @xrpl-commons/xrpl-connect-vue@rc xrpl vue
 ```
 
 The coordinated release candidate contains these three artifacts:
 
-| Package                     | 0.8.2 line    | Current 1.0 candidate           |
-| --------------------------- | ------------- | ------------------------------- |
-| `xrpl-connect`              | `0.8.2`       | `1.0.0-rc.0`                    |
-| `@xrpl-connect/react`       | Not available | `1.0.0-rc.0` (new)              |
-| `@xrpl-connect/vue`         | Not available | `1.0.0-rc.0` (new)              |
-| Standalone core/UI/adapters | `0.8.2` line  | Not part of this coordinated RC |
+| Package                            | 0.8.2 line    | Current 1.0 candidate           |
+| ---------------------------------- | ------------- | ------------------------------- |
+| `xrpl-connect`                     | `0.8.2`       | `1.0.0-rc.0`                    |
+| `@xrpl-commons/xrpl-connect-react` | Not available | `1.0.0-rc.0` (new)              |
+| `@xrpl-commons/xrpl-connect-vue`   | Not available | `1.0.0-rc.0` (new)              |
+| Standalone core/UI/adapters        | `0.8.2` line  | Not part of this coordinated RC |
 
 If an application imports `@xrpl-connect/core`, `@xrpl-connect/ui`, or individual adapter packages directly, it can remain on the compatible 0.8.2 modular line. To adopt the complete 1.0 candidate, move those imports to the umbrella package:
 

--- a/docs/guide/production.md
+++ b/docs/guide/production.md
@@ -14,7 +14,7 @@ connector belong in client code.
 ```tsx
 'use client';
 
-import { XrplConnectProvider, WalletConnector } from '@xrpl-connect/react';
+import { XrplConnectProvider, WalletConnector } from '@xrpl-commons/xrpl-connect-react';
 ```
 
 For Nuxt, install `createXrplConnect()` from a `.client.ts` plugin. Components that call

--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -52,7 +52,7 @@ The monorepo uses workspace links. When copying this example into a standalone p
 the published release candidates explicitly:
 
 ```bash
-pnpm add @xrpl-connect/react@rc xrpl-connect@rc xrpl react react-dom
+pnpm add @xrpl-commons/xrpl-connect-react@rc xrpl-connect@rc xrpl react react-dom
 ```
 
 ### 4. Run Development Server
@@ -199,8 +199,8 @@ Ensure your WalletConnect Project ID is valid and your internet connection is st
 
 ### TypeScript errors
 
-Install both `@xrpl-connect/react@rc` and `xrpl-connect@rc`, and import the provider, hooks, and
-component from `@xrpl-connect/react`. The package supplies its own declarations; no custom JSX
+Install both `@xrpl-commons/xrpl-connect-react@rc` and `xrpl-connect@rc`, and import the provider, hooks, and
+component from `@xrpl-commons/xrpl-connect-react`. The package supplies its own declarations; no custom JSX
 declaration is required.
 
 ## Technologies Used

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -9,7 +9,7 @@
     "preview": "vp preview"
   },
   "dependencies": {
-    "@xrpl-connect/react": "workspace:*",
+    "@xrpl-commons/xrpl-connect-react": "workspace:*",
     "xrpl-connect": "workspace:*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -15,7 +15,7 @@ function App() {
       <header>
         <div className="header-content">
           <h1>🔗 XRPL Connect Demo - React</h1>
-          <p>Powered by @xrpl-connect/react — provider, hooks &amp; modal component</p>
+          <p>Powered by @xrpl-commons/xrpl-connect-react — provider, hooks &amp; modal component</p>
         </div>
       </header>
 

--- a/examples/react/src/components/AccountInfo.tsx
+++ b/examples/react/src/components/AccountInfo.tsx
@@ -1,4 +1,4 @@
-import { useWallet } from '@xrpl-connect/react';
+import { useWallet } from '@xrpl-commons/xrpl-connect-react';
 
 export function AccountInfo() {
   const { connected, account, network, manager } = useWallet();

--- a/examples/react/src/components/MessageSignForm.tsx
+++ b/examples/react/src/components/MessageSignForm.tsx
@@ -1,5 +1,5 @@
 import { useState, FormEvent } from 'react';
-import { useWallet, useSigner } from '@xrpl-connect/react';
+import { useWallet, useSigner } from '@xrpl-commons/xrpl-connect-react';
 import { useDemo } from '../context/DemoContext';
 
 export function MessageSignForm() {

--- a/examples/react/src/components/TransactionForm.tsx
+++ b/examples/react/src/components/TransactionForm.tsx
@@ -1,5 +1,5 @@
 import { useState, FormEvent } from 'react';
-import { useWallet, useSigner } from '@xrpl-connect/react';
+import { useWallet, useSigner } from '@xrpl-commons/xrpl-connect-react';
 import type { Transaction } from 'xrpl-connect';
 import { useDemo } from '../context/DemoContext';
 

--- a/examples/react/src/components/WalletConnector.tsx
+++ b/examples/react/src/components/WalletConnector.tsx
@@ -1,4 +1,4 @@
-import { WalletConnector as XrplWalletConnector } from '@xrpl-connect/react';
+import { WalletConnector as XrplWalletConnector } from '@xrpl-commons/xrpl-connect-react';
 import { useDemo } from '../context/DemoContext';
 
 export function WalletConnector() {

--- a/examples/react/src/context/DemoContext.tsx
+++ b/examples/react/src/context/DemoContext.tsx
@@ -4,7 +4,7 @@ import type { Event, StatusMessage } from '../types';
 /**
  * Demo-only UI state (activity log + transient status banner). This is NOT part
  * of the wallet layer — connection/account state now comes from
- * `@xrpl-connect/react`'s `useWallet()`. Kept here purely to power the example's
+ * `@xrpl-commons/xrpl-connect-react`'s `useWallet()`. Kept here purely to power the example's
  * event log and status messages.
  */
 interface DemoContextType {

--- a/examples/react/src/main.tsx
+++ b/examples/react/src/main.tsx
@@ -9,7 +9,7 @@ import {
   OtsuAdapter,
   MetaMaskSnapAdapter,
 } from 'xrpl-connect';
-import { XrplConnectProvider, type XrplConnectConfig } from '@xrpl-connect/react';
+import { XrplConnectProvider, type XrplConnectConfig } from '@xrpl-commons/xrpl-connect-react';
 import App from './App';
 import { DemoProvider } from './context/DemoContext';
 import './index.css';

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,4 +1,4 @@
-# @xrpl-connect/react
+# @xrpl-commons/xrpl-connect-react
 
 React bindings for [XRPL Connect](https://github.com/XRPL-Commons/xrpl-connect): a
 provider that owns a single `WalletManager`, hooks to use it, and a `<WalletConnector>`
@@ -7,7 +7,7 @@ modal component — so you configure your wallets once and never re-create objec
 ## Install
 
 ```bash
-npm install @xrpl-connect/react@rc xrpl-connect@rc xrpl react react-dom
+npm install @xrpl-commons/xrpl-connect-react@rc xrpl-connect@rc xrpl react react-dom
 ```
 
 > `react` / `react-dom` are peer dependencies. Importing any named export from
@@ -17,7 +17,7 @@ npm install @xrpl-connect/react@rc xrpl-connect@rc xrpl react react-dom
 
 ```tsx
 import { XamanAdapter, CrossmarkAdapter } from 'xrpl-connect';
-import { XrplConnectProvider } from '@xrpl-connect/react';
+import { XrplConnectProvider } from '@xrpl-commons/xrpl-connect-react';
 
 const config = {
   adapters: [new XamanAdapter({ apiKey: 'YOUR_KEY' }), new CrossmarkAdapter()],
@@ -34,7 +34,12 @@ createRoot(document.getElementById('root')!).render(
 
 ```tsx
 // App.tsx
-import { useWallet, useSigner, useWalletModal, WalletConnector } from '@xrpl-connect/react';
+import {
+  useWallet,
+  useSigner,
+  useWalletModal,
+  WalletConnector,
+} from '@xrpl-commons/xrpl-connect-react';
 
 export function App() {
   const { connected, account, disconnect, error } = useWallet();
@@ -103,7 +108,7 @@ Router, use them from a client component:
 
 ```tsx
 'use client';
-import { XrplConnectProvider } from '@xrpl-connect/react';
+import { XrplConnectProvider } from '@xrpl-commons/xrpl-connect-react';
 ```
 
 ## License

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@xrpl-connect/react",
+  "name": "@xrpl-commons/xrpl-connect-react",
   "version": "1.0.0-rc.0",
   "description": "React bindings (provider, hooks, modal component) for XRPL Connect",
   "author": "XRPL Connect Contributors",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @xrpl-connect/react
+ * @xrpl-commons/xrpl-connect-react
  * React bindings for XRPL Connect: a provider that owns a single WalletManager,
  * hooks to use it, and a `<WalletConnector>` modal component. (#33)
  *

--- a/packages/react/tests/publish/runtime-ssr.mjs
+++ b/packages/react/tests/publish/runtime-ssr.mjs
@@ -2,10 +2,10 @@ import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
 import { createElement } from 'react';
 import { renderToString } from 'react-dom/server';
-import * as reactEsm from '@xrpl-connect/react';
+import * as reactEsm from '@xrpl-commons/xrpl-connect-react';
 
 const require = createRequire(import.meta.url);
-const reactCjs = require('@xrpl-connect/react');
+const reactCjs = require('@xrpl-commons/xrpl-connect-react');
 const publicExports = [
   'XrplConnectProvider',
   'WalletConnector',

--- a/packages/react/tests/publish/types-react-cjs.cts
+++ b/packages/react/tests/publish/types-react-cjs.cts
@@ -7,7 +7,7 @@ import {
   useWallet,
   useWalletModal,
   type WalletConnectorProps,
-} from '@xrpl-connect/react';
+} from '@xrpl-commons/xrpl-connect-react';
 import type {
   ManagedSignedMessage,
   ManagedSignedTransaction,

--- a/packages/react/tests/publish/types-react-esm.mts
+++ b/packages/react/tests/publish/types-react-esm.mts
@@ -7,7 +7,7 @@ import {
   useWallet,
   useWalletModal,
   type WalletConnectorProps,
-} from '@xrpl-connect/react';
+} from '@xrpl-commons/xrpl-connect-react';
 import type {
   ManagedSignedMessage,
   ManagedSignedTransaction,

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,4 +1,4 @@
-# @xrpl-connect/vue
+# @xrpl-commons/xrpl-connect-vue
 
 Vue 3 bindings for XRPL Connect: an app plugin that owns a `WalletManager`, reactive
 composables, and a typed `<WalletConnector>` modal component.
@@ -6,7 +6,7 @@ composables, and a typed `<WalletConnector>` modal component.
 ## Install
 
 ```bash
-npm install @xrpl-connect/vue@rc xrpl-connect@rc xrpl vue
+npm install @xrpl-commons/xrpl-connect-vue@rc xrpl-connect@rc xrpl vue
 ```
 
 ## Usage
@@ -15,7 +15,7 @@ npm install @xrpl-connect/vue@rc xrpl-connect@rc xrpl vue
 // main.ts
 import { createApp } from 'vue';
 import { XamanAdapter, CrossmarkAdapter } from 'xrpl-connect';
-import { createXrplConnect } from '@xrpl-connect/vue';
+import { createXrplConnect } from '@xrpl-commons/xrpl-connect-vue';
 import App from './App.vue';
 
 const app = createApp(App);
@@ -31,7 +31,12 @@ app.mount('#app');
 
 ```vue
 <script setup lang="ts">
-import { WalletConnector, useSigner, useWallet, useWalletModal } from '@xrpl-connect/vue';
+import {
+  WalletConnector,
+  useSigner,
+  useWallet,
+  useWalletModal,
+} from '@xrpl-commons/xrpl-connect-vue';
 
 const { connected, account, error, disconnect } = useWallet();
 const { signAndSubmit } = useSigner();
@@ -57,7 +62,7 @@ const { open } = useWalletModal();
   `connecting`, `connect`, and typed `error` events.
 
 The named `xrpl-connect` import also registers the wallet connector custom element, so a separate
-side-effect import is not needed. Importing `@xrpl-connect/vue` is SSR-safe, but plugin
+side-effect import is not needed. Importing `@xrpl-commons/xrpl-connect-vue` is SSR-safe, but plugin
 installation, injected composable calls, and wallet UI rendering must stay on the client. In
 Nuxt, put composable consumers in `.client.vue` components or wholly below a client-only child
 boundary; wrapping only the template does not stop universal setup from running during SSR.

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@xrpl-connect/vue",
+  "name": "@xrpl-commons/xrpl-connect-vue",
   "version": "1.0.0-rc.0",
   "description": "Vue 3 bindings (plugin, composables, modal component) for XRPL Connect",
   "author": "XRPL Connect Contributors",

--- a/packages/vue/tests/publish/runtime-ssr.mjs
+++ b/packages/vue/tests/publish/runtime-ssr.mjs
@@ -8,8 +8,8 @@ delete globalThis.document;
 delete globalThis.customElements;
 
 const require = createRequire(import.meta.url);
-const esm = await import('@xrpl-connect/vue');
-const cjs = require('@xrpl-connect/vue');
+const esm = await import('@xrpl-commons/xrpl-connect-vue');
+const cjs = require('@xrpl-commons/xrpl-connect-vue');
 
 for (const api of [esm, cjs]) {
   assert.equal(typeof api.createXrplConnect, 'function');

--- a/packages/vue/tests/publish/types-vue-cjs.cts
+++ b/packages/vue/tests/publish/types-vue-cjs.cts
@@ -6,7 +6,7 @@ import {
   useSigner,
   useWallet,
   useWalletModal,
-} from '@xrpl-connect/vue';
+} from '@xrpl-commons/xrpl-connect-vue';
 import type {
   ManagedSignedMessage,
   ManagedSignedTransaction,

--- a/packages/vue/tests/publish/types-vue-esm.mts
+++ b/packages/vue/tests/publish/types-vue-esm.mts
@@ -6,7 +6,7 @@ import {
   useSigner,
   useWallet,
   useWalletModal,
-} from '@xrpl-connect/vue';
+} from '@xrpl-commons/xrpl-connect-vue';
 import type {
   ManagedSignedMessage,
   ManagedSignedTransaction,

--- a/packages/xrpl-connect/package.json
+++ b/packages/xrpl-connect/package.json
@@ -63,7 +63,7 @@
     "publish:build": "vp run -F \"{.}^...\" --no-cache build && vp pack && vp build -c vite.config.ts && node scripts/build-types.mjs && node scripts/prepare-publish.mjs",
     "publish:rc": "node scripts/publish-rc.mjs",
     "test": "node scripts/run-command.test.mjs",
-    "test:publish": "pnpm publish:build && vp run -F @xrpl-connect/react -F @xrpl-connect/vue --no-cache build && node scripts/test-publish.mjs",
+    "test:publish": "pnpm publish:build && vp run -F @xrpl-commons/xrpl-connect-react -F @xrpl-commons/xrpl-connect-vue --no-cache build && node scripts/test-publish.mjs",
     "verify:rc:access": "node scripts/test-publish.mjs --check-access",
     "verify:rc:preflight": "node scripts/test-publish.mjs --check-access --check-prepublish",
     "verify:rc:registry": "node scripts/test-publish.mjs --check-registry",

--- a/packages/xrpl-connect/scripts/publish-rc.mjs
+++ b/packages/xrpl-connect/scripts/publish-rc.mjs
@@ -11,6 +11,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectFolder = path.join(__dirname, '..');
 const repositoryRoot = path.join(projectFolder, '..', '..');
 const inheritedPnpmConfig = [
+  'npm_config_dir',
   'npm_config_peer_dependency_rules',
   'npm_config_recursive',
   'npm_config_verify_deps_before_run',
@@ -35,8 +36,11 @@ const publishRunOptions = {
 };
 const candidatePackages = [
   { name: 'xrpl-connect', folder: path.join(projectFolder, 'dist-publish') },
-  { name: '@xrpl-connect/react', folder: path.join(repositoryRoot, 'packages', 'react') },
-  { name: '@xrpl-connect/vue', folder: path.join(repositoryRoot, 'packages', 'vue') },
+  {
+    name: '@xrpl-commons/xrpl-connect-react',
+    folder: path.join(repositoryRoot, 'packages', 'react'),
+  },
+  { name: '@xrpl-commons/xrpl-connect-vue', folder: path.join(repositoryRoot, 'packages', 'vue') },
 ];
 
 export function assertSafePrepublishRegistryState(tagsByPackage) {
@@ -53,7 +57,10 @@ export function assertSafePrepublishRegistryState(tagsByPackage) {
     'xrpl-connect has unexpected dist-tags'
   );
 
-  for (const packageName of ['@xrpl-connect/react', '@xrpl-connect/vue']) {
+  for (const packageName of [
+    '@xrpl-commons/xrpl-connect-react',
+    '@xrpl-commons/xrpl-connect-vue',
+  ]) {
     const tags = tagsByPackage[packageName];
     if (tags === null) continue;
     const expectedTags = tags.rc === undefined ? {} : { rc: CANDIDATE_VERSION };

--- a/packages/xrpl-connect/scripts/run-command.test.mjs
+++ b/packages/xrpl-connect/scripts/run-command.test.mjs
@@ -83,22 +83,22 @@ test('RC publisher requires exact confirmation before running commands', () => {
 test('RC registry preflight accepts only fresh, partial, or complete candidate state', () => {
   const pristine = {
     'xrpl-connect': { latest: '0.8.2' },
-    '@xrpl-connect/react': null,
-    '@xrpl-connect/vue': null,
+    '@xrpl-commons/xrpl-connect-react': null,
+    '@xrpl-commons/xrpl-connect-vue': null,
   };
   const partial = {
     'xrpl-connect': { latest: '0.8.2', rc: CANDIDATE_VERSION },
-    '@xrpl-connect/react': { rc: CANDIDATE_VERSION },
-    '@xrpl-connect/vue': null,
+    '@xrpl-commons/xrpl-connect-react': { rc: CANDIDATE_VERSION },
+    '@xrpl-commons/xrpl-connect-vue': null,
   };
   const complete = {
     ...partial,
-    '@xrpl-connect/vue': { rc: CANDIDATE_VERSION },
+    '@xrpl-commons/xrpl-connect-vue': { rc: CANDIDATE_VERSION },
   };
   const interrupted = {
     'xrpl-connect': { latest: '0.8.2' },
-    '@xrpl-connect/react': {},
-    '@xrpl-connect/vue': null,
+    '@xrpl-commons/xrpl-connect-react': {},
+    '@xrpl-commons/xrpl-connect-vue': null,
   };
 
   for (const state of [pristine, partial, complete, interrupted]) {
@@ -116,7 +116,7 @@ test('RC registry preflight accepts only fresh, partial, or complete candidate s
     () =>
       assertSafePrepublishRegistryState({
         ...pristine,
-        '@xrpl-connect/react': { latest: CANDIDATE_VERSION },
+        '@xrpl-commons/xrpl-connect-react': { latest: CANDIDATE_VERSION },
       }),
     /unexpected dist-tags/
   );
@@ -131,8 +131,8 @@ function recordPublisherCalls(publishedPackages = new Set()) {
       const name = options.cwd.endsWith('dist-publish')
         ? 'xrpl-connect'
         : options.cwd.endsWith('react')
-          ? '@xrpl-connect/react'
-          : '@xrpl-connect/vue';
+          ? '@xrpl-commons/xrpl-connect-react'
+          : '@xrpl-commons/xrpl-connect-vue';
       return JSON.stringify([{ name, version: CANDIDATE_VERSION, integrity: `integrity:${name}` }]);
     }
     if (command === 'npm' && args[0] === 'view') {
@@ -178,7 +178,7 @@ test('RC publisher preflights, verifies, and publishes only through the fixed re
 
 test('RC publisher resumes by restoring rc tags for exact candidates already on npm', () => {
   const { calls, publishRc } = recordPublisherCalls(
-    new Set(['xrpl-connect', '@xrpl-connect/react'])
+    new Set(['xrpl-connect', '@xrpl-commons/xrpl-connect-react'])
   );
 
   publishRc(['--confirm', CANDIDATE_VERSION]);
@@ -201,7 +201,7 @@ test('RC publisher resumes by restoring rc tags for exact candidates already on 
       [
         'dist-tag',
         'add',
-        `@xrpl-connect/react@${CANDIDATE_VERSION}`,
+        `@xrpl-commons/xrpl-connect-react@${CANDIDATE_VERSION}`,
         'rc',
         '--registry',
         'https://registry.npmjs.org/',

--- a/packages/xrpl-connect/scripts/test-publish.mjs
+++ b/packages/xrpl-connect/scripts/test-publish.mjs
@@ -11,7 +11,7 @@ import {
 import { run } from './run-command.mjs';
 
 const FRAMEWORK_PEER_RANGE = '^1.0.0-rc.0';
-const NPM_ORGANIZATION = 'xrpl-connect';
+const NPM_ORGANIZATION = 'xrpl-commons';
 const SUPPORTED_NODE_RANGE = '^20.19.0 || ^22.18.0 || >=24.11.0';
 const PUBLISH_CONFIG = {
   access: 'public',
@@ -21,6 +21,7 @@ const PUBLISH_CONFIG = {
 const PUBLISH_GUARD =
   "node -e \"const { npm_config_tag: tag, npm_config_access: access, npm_config_registry: registry } = process.env; let registryUrl = ''; try { registryUrl = new URL(registry).href; } catch {} if (tag !== 'rc' || access !== 'public' || registryUrl !== 'https://registry.npmjs.org/') { console.error('Publish requires --tag rc --access public --registry https://registry.npmjs.org/'); process.exit(1); }\"";
 const inheritedPnpmConfig = [
+  'npm_config_dir',
   'npm_config_peer_dependency_rules',
   'npm_config_recursive',
   'npm_config_verify_deps_before_run',
@@ -57,7 +58,7 @@ const candidatePackages = [
     ],
   },
   {
-    name: '@xrpl-connect/react',
+    name: '@xrpl-commons/xrpl-connect-react',
     folder: path.join(repositoryRoot, 'packages', 'react'),
     requiredFiles: [
       'package.json',
@@ -70,7 +71,7 @@ const candidatePackages = [
     ],
   },
   {
-    name: '@xrpl-connect/vue',
+    name: '@xrpl-commons/xrpl-connect-vue',
     folder: path.join(repositoryRoot, 'packages', 'vue'),
     requiredFiles: [
       'package.json',
@@ -83,6 +84,13 @@ const candidatePackages = [
     ],
   },
 ];
+
+for (const { name } of candidatePackages.slice(1)) {
+  assert(
+    name.startsWith(`@${NPM_ORGANIZATION}/`),
+    `${name} is outside the @${NPM_ORGANIZATION} npm organization scope`
+  );
+}
 
 function parseJson(command, args, options) {
   return JSON.parse(run(command, args, { ...options, capture: true }));
@@ -152,8 +160,8 @@ function verifyRegistryTags() {
     latest: '0.8.2',
     rc: CANDIDATE_VERSION,
   });
-  assert.deepEqual(tagsByPackage['@xrpl-connect/react'], { rc: CANDIDATE_VERSION });
-  assert.deepEqual(tagsByPackage['@xrpl-connect/vue'], { rc: CANDIDATE_VERSION });
+  assert.deepEqual(tagsByPackage['@xrpl-commons/xrpl-connect-react'], { rc: CANDIDATE_VERSION });
+  assert.deepEqual(tagsByPackage['@xrpl-commons/xrpl-connect-vue'], { rc: CANDIDATE_VERSION });
   console.log('✓ Registry tags expose only the intended release candidate and preserve latest');
 }
 
@@ -354,23 +362,23 @@ try {
     /Publish requires .*--registry https:\/\/registry\.npmjs\.org\//
   );
   assert.equal(
-    installedManifests['@xrpl-connect/react'].peerDependencies?.['xrpl-connect'],
+    installedManifests['@xrpl-commons/xrpl-connect-react'].peerDependencies?.['xrpl-connect'],
     FRAMEWORK_PEER_RANGE
   );
   assert.equal(
-    installedManifests['@xrpl-connect/vue'].peerDependencies?.['xrpl-connect'],
+    installedManifests['@xrpl-commons/xrpl-connect-vue'].peerDependencies?.['xrpl-connect'],
     FRAMEWORK_PEER_RANGE
   );
   assert.deepEqual(installedManifests['xrpl-connect'].peerDependencies, {
     xrpl: '^3.0.0 || ^4.0.0',
   });
-  assert.deepEqual(installedManifests['@xrpl-connect/react'].peerDependencies, {
+  assert.deepEqual(installedManifests['@xrpl-commons/xrpl-connect-react'].peerDependencies, {
     react: '^18.0.0 || ^19.0.0',
     'react-dom': '^18.0.0 || ^19.0.0',
     xrpl: '^3.0.0 || ^4.0.0',
     'xrpl-connect': FRAMEWORK_PEER_RANGE,
   });
-  assert.deepEqual(installedManifests['@xrpl-connect/vue'].peerDependencies, {
+  assert.deepEqual(installedManifests['@xrpl-commons/xrpl-connect-vue'].peerDependencies, {
     vue: '^3.5.0',
     xrpl: '^3.0.0 || ^4.0.0',
     'xrpl-connect': FRAMEWORK_PEER_RANGE,
@@ -394,18 +402,13 @@ try {
     );
   }
 
-  for (const framework of ['react', 'vue']) {
-    const installedFrameworkFolder = path.join(
-      consumerFolder,
-      'node_modules',
-      '@xrpl-connect',
-      framework
-    );
+  for (const { name } of candidatePackages.slice(1)) {
+    const installedFrameworkFolder = path.join(consumerFolder, 'node_modules', name);
     for (const declaration of ['dist/index.d.ts', 'dist/index.d.mts']) {
       const contents = readFileSync(path.join(installedFrameworkFolder, declaration), 'utf-8');
       assert(
         !contents.includes('@xrpl-connect/core'),
-        `${framework}/${declaration} leaks the development-only @xrpl-connect/core package`
+        `${name}/${declaration} leaks the development-only @xrpl-connect/core package`
       );
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,7 +76,7 @@ importers:
 
   examples/react:
     dependencies:
-      '@xrpl-connect/react':
+      '@xrpl-commons/xrpl-connect-react':
         specifier: workspace:*
         version: link:../../packages/react
       react:

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -3,3 +3,7 @@
 ## 2026-08-18 — Make documentation versioning discoverable
 
 - A locale selector hidden behind a globe does not satisfy a visible documentation version switcher. Use the displayed version label as the dropdown trigger and verify both rendered destinations before handoff.
+
+## 2026-08-18 — Verify registry ownership before release approval
+
+- A package manifest and dry-run cannot prove that its npm scope is owned by the publishing organization. Confirm the real organization, existing package ownership, and candidate-name availability against the registry before declaring a release path ready.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,14 @@
+# RC package-scope correction
+
+- [x] Inventory every public React/Vue package-name and release-preflight reference.
+- [x] Rename the public bindings to `@xrpl-commons/xrpl-connect-react` and `@xrpl-commons/xrpl-connect-vue`.
+- [x] Update the guarded publisher, registry checks, packed-artifact tests, documentation, examples, and lockfile.
+- [x] Verify formatting, lint, builds, tests, package dry-runs, and registry preflight behavior.
+- [x] Review the final diff, commit, push, and open a release-blocker pull request.
+
+## Review
+
+- Renamed both framework package manifests and every consumer-facing install/import reference to the real XRPL Commons npm scope.
+- Updated the RC publisher and registry assertions, including an invariant preventing framework candidates from drifting outside `@xrpl-commons`.
+- Removed inherited `npm_config_dir` from child npm commands so `pnpm --dir` does not emit npm's unknown-config warning.
+- Verified with formatting, lint, the complete monorepo suite, the versioned-docs snapshot check, three-package npm dry-runs, clean packed-consumer ESM/CJS/type/SSR checks, and the live read-only npm preflight.


### PR DESCRIPTION
## Summary

- publish the React and Vue bindings as @xrpl-commons/xrpl-connect-react and @xrpl-commons/xrpl-connect-vue
- align release tooling, registry safeguards, docs, examples, tests, and the workspace lockfile
- strip inherited npm_config_dir from child npm commands invoked through pnpm --dir

## Verification

- pnpm run format:check
- pnpm run lint
- pnpm test
- pnpm --filter xrpl-connect test:publish
- pnpm run docs:snapshot:check
- node scripts/test-publish.mjs --check-prepublish