### PR TITLE
fix: secure Crossmark sign-in challenge

### DIFF
--- a/packages/adapters/crossmark/src/crossmark-adapter.ts
+++ b/packages/adapters/crossmark/src/crossmark-adapter.ts
@@ -358,10 +358,7 @@ export class CrossmarkAdapter implements WalletAdapter, SupportsFetchAccount {
     if (typeof window !== 'undefined' && window.crypto) {
       window.crypto.getRandomValues(array);
     } else {
-      // Fallback for environments without crypto
-      for (let i = 0; i < array.length; i++) {
-        array[i] = Math.floor(Math.random() * 256);
-      }
+      throw new Error('crypto.getRandomValues is required but not available in this environment');
     }
     return Array.from(array, (byte) => byte.toString(16).padStart(2, '0')).join('');
   }

--- a/packages/adapters/crossmark/src/crossmark-adapter.ts
+++ b/packages/adapters/crossmark/src/crossmark-adapter.ts
@@ -354,12 +354,16 @@ export class CrossmarkAdapter implements WalletAdapter, SupportsFetchAccount {
    * Generate a random hash for signing
    */
   private generateRandomHash(): string {
-    const array = new Uint8Array(32);
-    if (typeof window !== 'undefined' && window.crypto) {
-      window.crypto.getRandomValues(array);
-    } else {
-      throw new Error('crypto.getRandomValues is required but not available in this environment');
+    const crypto = globalThis.crypto;
+    if (typeof crypto?.getRandomValues !== 'function') {
+      throw createWalletError.connectionFailed(
+        this.name,
+        new Error('Secure randomness is unavailable; crypto.getRandomValues is required')
+      );
     }
+
+    const array = new Uint8Array(32);
+    crypto.getRandomValues(array);
     return Array.from(array, (byte) => byte.toString(16).padStart(2, '0')).join('');
   }
 }

--- a/packages/adapters/crossmark/tests/crossmark-adapter.test.ts
+++ b/packages/adapters/crossmark/tests/crossmark-adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
 import { WalletErrorCode } from '@xrpl-connect/core';
 
 vi.mock('@crossmarkio/sdk', () => {
@@ -30,12 +30,24 @@ const sdk = sdkDefault as unknown as {
   };
 };
 
+const getRandomValues = vi.fn((array: Uint8Array) => {
+  array.fill(0xab);
+  return array;
+});
+
 beforeEach(() => {
+  getRandomValues.mockClear();
+  vi.stubGlobal('crypto', { getRandomValues });
   sdk.sync.isInstalled.mockReset();
   sdk.api.awaitRequest.mockReset();
   sdk.methods.signInAndWait.mockReset();
   sdk.methods.signAndWait.mockReset();
   sdk.methods.signAndSubmitAndWait.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe('CrossmarkAdapter.fetchAccount', () => {
@@ -217,6 +229,44 @@ describe('CrossmarkAdapter.isAvailable', () => {
 });
 
 describe('CrossmarkAdapter.connect', () => {
+  it('passes a 32-byte secure random challenge as 64 hexadecimal characters', async () => {
+    sdk.sync.isInstalled.mockReturnValue(true);
+    sdk.methods.signInAndWait.mockResolvedValue({
+      response: { data: { address: 'rUserAddress', publicKey: 'PUBKEY' } },
+    });
+
+    await new CrossmarkAdapter().connect();
+
+    expect(getRandomValues).toHaveBeenCalledOnce();
+    expect(getRandomValues).toHaveBeenCalledWith(expect.any(Uint8Array));
+    expect(getRandomValues.mock.calls[0]?.[0]).toHaveLength(32);
+    expect(sdk.methods.signInAndWait).toHaveBeenCalledWith('ab'.repeat(32));
+    expect(sdk.methods.signInAndWait.mock.calls[0]?.[0]).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('never falls back to Math.random', async () => {
+    const mathRandom = vi.spyOn(Math, 'random');
+    vi.stubGlobal('crypto', undefined);
+    sdk.sync.isInstalled.mockReturnValue(true);
+
+    await expect(new CrossmarkAdapter().connect()).rejects.toBeDefined();
+
+    expect(mathRandom).not.toHaveBeenCalled();
+    expect(sdk.methods.signInAndWait).not.toHaveBeenCalled();
+  });
+
+  it('fails with a clear typed error when secure randomness is unavailable', async () => {
+    vi.stubGlobal('crypto', undefined);
+    sdk.sync.isInstalled.mockReturnValue(true);
+
+    await expect(new CrossmarkAdapter().connect()).rejects.toMatchObject({
+      name: 'WalletError',
+      code: WalletErrorCode.CONNECTION_FAILED,
+      message: expect.stringContaining('Secure randomness is unavailable'),
+    });
+    expect(sdk.methods.signInAndWait).not.toHaveBeenCalled();
+  });
+
   it('returns account info on success', async () => {
     sdk.sync.isInstalled.mockReturnValue(true);
     sdk.methods.signInAndWait.mockResolvedValue({

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -94,3 +94,33 @@
 - The rebuilt packed artifact passes the original React 19.2.8 unmount reproduction for both native and wrapped refs.
 - Focused and full React checks, dependency-inclusive build, repository formatting/lint, documentation snapshot verification, full monorepo tests, packed publish/consumer verification, and `git diff --check` pass.
 - Merged the latest `origin/develop`, resolved the overlapping React API, documentation, and publish fixtures with `showUnavailable` intact, and repeated the full monorepo and packed-consumer verification on the combined tree.
+
+---
+
+# Issue #181 / PR #138
+
+## Issue summary
+
+- Crossmark's sign-in challenge used `Math.random()` when browser crypto was unavailable, weakening authentication material without warning.
+- The challenge must be generated exclusively with a supported cryptographically secure primitive and remain exactly 32 bytes / 64 hexadecimal characters.
+- Environments without secure randomness must fail closed with a clear typed error before Crossmark receives a sign-in request.
+- Regression coverage must prove the output contract, prevent any `Math.random()` fallback, and exercise the unavailable-crypto path.
+
+## Plan
+
+- [x] Validate GitHub access, refresh refs, inspect issue #181 and PR #138, and confirm authorization to update the existing PR.
+- [x] Attach a clean dedicated worktree to PR #138 and merge current `origin/develop` without rewriting history.
+- [x] Inspect the current Crossmark flow, typed-error conventions, test harness, and stale CI failures.
+- [x] Implement the minimal fail-closed secure randomness behavior.
+- [x] Add focused regressions for 32-byte/64-hex output, no `Math.random()` calls, and unavailable crypto.
+- [x] Run focused tests, formatting, linting, type checks, builds, and relevant repository verification.
+- [x] Review the cumulative diff against `develop` and every acceptance criterion, then record results below.
+- [ ] Commit only intentional changes, push PR #138's branch, refresh its metadata, and verify CI.
+
+## Review
+
+- PR #138's original `window.crypto` check failed 14 of 19 Crossmark tests under CI's browser-free Node environment; the new regression suite also failed before the production fix, proving the defect.
+- The challenge generator now calls `globalThis.crypto.getRandomValues` with a 32-byte array, returns exactly 64 lowercase hexadecimal characters, and throws a clear typed `CONNECTION_FAILED` error before invoking Crossmark if the primitive is missing.
+- Focused tests deterministically verify the byte/hex contract, prove `Math.random()` is never called, and cover the unavailable-crypto error path; the Crossmark suite passes all 22 tests.
+- Crossmark formatting, lint, dependency-inclusive build, runtime smoke, and public-type checks pass. `pnpm exec vp check`, `pnpm test`, `pnpm --filter xrpl-connect test:publish`, `pnpm docs:snapshot:check`, and `git diff --check` also pass.
+- Independent security/test review found no remaining correctness, compatibility, isolation, or scope issues in the cumulative diff against `origin/develop`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -115,7 +115,7 @@
 - [x] Add focused regressions for 32-byte/64-hex output, no `Math.random()` calls, and unavailable crypto.
 - [x] Run focused tests, formatting, linting, type checks, builds, and relevant repository verification.
 - [x] Review the cumulative diff against `develop` and every acceptance criterion, then record results below.
-- [ ] Commit only intentional changes, push PR #138's branch, refresh its metadata, and verify CI.
+- [x] Commit only intentional changes, push PR #138's branch, refresh its metadata, and verify CI.
 
 ## Review
 
@@ -124,3 +124,4 @@
 - Focused tests deterministically verify the byte/hex contract, prove `Math.random()` is never called, and cover the unavailable-crypto error path; the Crossmark suite passes all 22 tests.
 - Crossmark formatting, lint, dependency-inclusive build, runtime smoke, and public-type checks pass. `pnpm exec vp check`, `pnpm test`, `pnpm --filter xrpl-connect test:publish`, `pnpm docs:snapshot:check`, and `git diff --check` also pass.
 - Independent security/test review found no remaining correctness, compatibility, isolation, or scope issues in the cumulative diff against `origin/develop`.
+- PR #138's refreshed CI is green for documentation and the complete test/build matrix on Node 20.19, 22.18, and 24.11.


### PR DESCRIPTION
## Summary
- generate Crossmark sign-in challenges exclusively with `globalThis.crypto.getRandomValues`
- fail closed with a clear typed connection error when secure randomness is unavailable
- add regression coverage for the 32-byte / 64-hex challenge contract and removal of the `Math.random()` fallback

## Test plan
- [x] `pnpm --filter @xrpl-connect/adapter-crossmark... build`
- [x] `pnpm --filter @xrpl-connect/adapter-crossmark lint`
- [x] `pnpm --filter @xrpl-connect/adapter-crossmark test`
- [x] `pnpm exec vp check`
- [x] `pnpm test`
- [x] `pnpm --filter xrpl-connect test:publish`
- [x] `pnpm docs:snapshot:check`
- [x] `git diff --check`

Fixes #181
