### PR TITLE
fix: preserve explicit hover colors

### DIFF
--- a/packages/react/tests/react.test.tsx
+++ b/packages/react/tests/react.test.tsx
@@ -448,6 +448,24 @@ describe('<WalletConnector>', () => {
     await waitFor(() => expect(onConnect).toHaveBeenCalledWith(ACCOUNT));
   });
 
+  it('forwards explicit hover cssVars to the custom element', () => {
+    const cssVars = {
+      '--xc-primary-button-hover-background': '#112233',
+      '--xc-connect-button-hover-background': '#223344',
+      '--xc-account-address-button-hover-color': '#334455',
+    } as const;
+    render(
+      <XrplConnectProvider config={{ adapters: [makeAdapter()], autoConnect: false }}>
+        <WalletConnector cssVars={cssVars} />
+      </XrplConnectProvider>
+    );
+
+    const element = document.querySelector('xrpl-wallet-connector') as HTMLElement;
+    for (const [variable, value] of Object.entries(cssVars)) {
+      expect(element.style.getPropertyValue(variable)).toBe(value);
+    }
+  });
+
   it('observes a connection started before custom-element binding settles', async () => {
     const onConnect = vi.fn();
     let mgr: WalletManager | null = null;

--- a/packages/ui/src/styles/main.ts
+++ b/packages/ui/src/styles/main.ts
@@ -38,7 +38,7 @@ export const mainStyles = `
     --xc-connect-button-color: var(--xc-text-color);
     --xc-connect-button-background: var(--xc-background-color);
     --xc-connect-button-border: 1px solid rgba(255, 255, 255, 0.1);
-    --xc-connect-button-hover-background: var(--xc-background-color);
+    --xc-connect-button-hover-background: var(--derived-connect-button-hover-background);
     --xc-connect-button-font-weight: 600;
 
     /* Primary Button */
@@ -46,7 +46,7 @@ export const mainStyles = `
     --xc-primary-button-background: var(--xc-primary-color);
     --xc-primary-button-border-radius: 8px;
     --xc-primary-button-font-weight: 600;
-    --xc-primary-button-hover-background: var(--xc-primary-color);
+    --xc-primary-button-hover-background: var(--derived-primary-button-hover-background);
 
     /* Secondary Button */
     --xc-secondary-button-color: var(--xc-text-color);
@@ -56,7 +56,7 @@ export const mainStyles = `
     --xc-secondary-button-hover-background: var(--xc-background-tertiary);
 
     /* Account Address Button */
-    --xc-account-address-button-hover-color: var(--xc-primary-color);
+    --xc-account-address-button-hover-color: var(--derived-account-address-button-hover-color);
 
     /* Modal */
     --xc-modal-background: var(--xc-background-color);
@@ -77,6 +77,9 @@ export const mainStyles = `
     --font-family: var(--xc-font-family);
     --wallet-btn-bg: var(--xc-background-secondary);
     --wallet-btn-hover: var(--xc-background-tertiary);
+    --derived-connect-button-hover-background: var(--xc-background-color);
+    --derived-primary-button-hover-background: var(--xc-primary-color);
+    --derived-account-address-button-hover-color: var(--xc-primary-color);
   }
 
   /* WalletConnect Modal Overrides */

--- a/packages/ui/src/wallet-connector.ts
+++ b/packages/ui/src/wallet-connector.ts
@@ -213,6 +213,10 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
         const value = computedStyle.getPropertyValue(varName).trim();
         if (value) portalHost.style.setProperty(varName, value);
       }
+      for (const varName of Object.values(DERIVED_HOVER_VARIABLES)) {
+        const value = this.style.getPropertyValue(varName).trim();
+        if (value) portalHost.style.setProperty(varName, value);
+      }
     }
 
     private ensureOverlayPortal(): ShadowRoot {

--- a/packages/ui/src/wallet-connector.ts
+++ b/packages/ui/src/wallet-connector.ts
@@ -108,6 +108,12 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
     '--xc-warning-color',
   ] as const;
 
+  const DERIVED_HOVER_VARIABLES = {
+    connectButtonBackground: '--derived-connect-button-hover-background',
+    primaryButtonBackground: '--derived-primary-button-hover-background',
+    accountAddressColor: '--derived-account-address-button-hover-color',
+  } as const;
+
   class WalletConnectorElementImpl
     extends HTMLElement
     implements WalletConnectorContext, WalletConnectorElementInstance
@@ -260,10 +266,21 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
         COLOR_ADJUSTMENT.HOVER_BRIGHTNESS
       );
 
-      // Apply hover colors
-      this.style.setProperty('--xc-primary-button-hover-background', primaryHoverColor);
-      this.style.setProperty('--xc-connect-button-hover-background', backgroundHoverColor);
-      this.style.setProperty('--xc-account-address-button-hover-color', primaryHoverColor);
+      const derivedColors = [
+        [DERIVED_HOVER_VARIABLES.primaryButtonBackground, primaryHoverColor],
+        [DERIVED_HOVER_VARIABLES.connectButtonBackground, backgroundHoverColor],
+        [DERIVED_HOVER_VARIABLES.accountAddressColor, primaryHoverColor],
+      ] as const;
+      let changed = false;
+
+      for (const [variable, value] of derivedColors) {
+        if (this.style.getPropertyValue(variable).trim() === value) continue;
+        this.style.setProperty(variable, value);
+        changed = true;
+      }
+
+      // Ignore style mutations caused by these internal fallback updates.
+      if (changed) this.styleObserver?.takeRecords();
 
       // Forward updated variables to portals
       if (this.overlayPortal) this.forwardCSSVariables(this.overlayPortal);

--- a/packages/ui/tests/WalletConnector.test.ts
+++ b/packages/ui/tests/WalletConnector.test.ts
@@ -17,6 +17,16 @@ const DERIVED_HOVER_VARIABLES = {
   account: '--derived-account-address-button-hover-color',
 } as const;
 
+function derivedHoverColors(primaryColor: string, backgroundColor: string) {
+  const primaryHover = adjustColorBrightness(primaryColor, COLOR_ADJUSTMENT.HOVER_BRIGHTNESS);
+  const backgroundHover = adjustColorBrightness(backgroundColor, COLOR_ADJUSTMENT.HOVER_BRIGHTNESS);
+  return {
+    [DERIVED_HOVER_VARIABLES.primary]: primaryHover,
+    [DERIVED_HOVER_VARIABLES.connect]: backgroundHover,
+    [DERIVED_HOVER_VARIABLES.account]: primaryHover,
+  };
+}
+
 function createAdapter(
   id: string,
   name: string,
@@ -463,18 +473,23 @@ describe('WalletConnector wallet availability', () => {
     document.body.appendChild(element);
 
     await vi.advanceTimersByTimeAsync(20);
-    expect(element.style.getPropertyValue(DERIVED_HOVER_VARIABLES.primary)).toBe(
-      adjustColorBrightness(primaryColor, COLOR_ADJUSTMENT.HOVER_BRIGHTNESS)
-    );
-    expect(element.style.getPropertyValue(DERIVED_HOVER_VARIABLES.account)).toBe(
-      adjustColorBrightness(primaryColor, COLOR_ADJUSTMENT.HOVER_BRIGHTNESS)
-    );
-    expect(element.style.getPropertyValue(DERIVED_HOVER_VARIABLES.connect)).toBe(
-      adjustColorBrightness(backgroundColor, COLOR_ADJUSTMENT.HOVER_BRIGHTNESS)
-    );
-    for (const variable of Object.keys(EXPLICIT_HOVER_COLORS)) {
-      expect(element.style.getPropertyValue(variable)).toBe('');
-    }
+    await element.open();
+    element.openAccountModal();
+
+    const expectOmittedHover = (colors: ReturnType<typeof derivedHoverColors>) => {
+      const overlayHost = element!.getOverlayRoot()?.host as HTMLElement;
+      const accountModalHost = element!.getAccountModalRoot()?.host as HTMLElement;
+      for (const [variable, value] of Object.entries(colors)) {
+        expect(element!.style.getPropertyValue(variable)).toBe(value);
+        expect(overlayHost.style.getPropertyValue(variable)).toBe(value);
+        expect(accountModalHost.style.getPropertyValue(variable)).toBe(value);
+      }
+      for (const variable of Object.keys(EXPLICIT_HOVER_COLORS)) {
+        expect(element!.style.getPropertyValue(variable)).toBe('');
+      }
+    };
+
+    expectOmittedHover(derivedHoverColors(primaryColor, backgroundColor));
 
     const nextPrimaryColor = '#345678';
     const nextBackgroundColor = '#456789';
@@ -482,14 +497,6 @@ describe('WalletConnector wallet availability', () => {
     element.style.setProperty('--xc-background-color', nextBackgroundColor);
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(element.style.getPropertyValue(DERIVED_HOVER_VARIABLES.primary)).toBe(
-      adjustColorBrightness(nextPrimaryColor, COLOR_ADJUSTMENT.HOVER_BRIGHTNESS)
-    );
-    expect(element.style.getPropertyValue(DERIVED_HOVER_VARIABLES.account)).toBe(
-      adjustColorBrightness(nextPrimaryColor, COLOR_ADJUSTMENT.HOVER_BRIGHTNESS)
-    );
-    expect(element.style.getPropertyValue(DERIVED_HOVER_VARIABLES.connect)).toBe(
-      adjustColorBrightness(nextBackgroundColor, COLOR_ADJUSTMENT.HOVER_BRIGHTNESS)
-    );
+    expectOmittedHover(derivedHoverColors(nextPrimaryColor, nextBackgroundColor));
   });
 });

--- a/packages/ui/tests/WalletConnector.test.ts
+++ b/packages/ui/tests/WalletConnector.test.ts
@@ -2,8 +2,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { MemoryStorageAdapter, TIME, WalletManager } from '@xrpl-connect/core';
 import type { NetworkInfo, WalletAdapter } from '@xrpl-connect/core';
 import '../src/wallet-connector';
+import { COLOR_ADJUSTMENT } from '../src/constants';
+import { adjustColorBrightness } from '../src/utils';
 
 const NETWORK: NetworkInfo = { id: 'testnet', name: 'Testnet', wss: 'wss://example' };
+const EXPLICIT_HOVER_COLORS = {
+  '--xc-primary-button-hover-background': '#112233',
+  '--xc-connect-button-hover-background': '#223344',
+  '--xc-account-address-button-hover-color': '#334455',
+} as const;
+const DERIVED_HOVER_VARIABLES = {
+  primary: '--derived-primary-button-hover-background',
+  connect: '--derived-connect-button-hover-background',
+  account: '--derived-account-address-button-hover-color',
+} as const;
 
 function createAdapter(
   id: string,
@@ -40,6 +52,7 @@ function createElement(manager: WalletManager) {
     openAccountModal(): void;
     disconnectedCallback(): void;
     getOverlayRoot(): ShadowRoot | null;
+    getAccountModalRoot(): ShadowRoot | null;
     showWalletList(): void;
   };
   element.setWalletManager(manager);
@@ -369,5 +382,114 @@ describe('WalletConnector wallet availability', () => {
 
     expect(isAvailable).toHaveBeenCalledTimes(3);
     expect(element.getOverlayRoot()?.querySelector('[data-wallet-id="wallet"]')).not.toBeNull();
+  });
+
+  it('preserves explicit inline hover colors across base-color changes and portals', async () => {
+    element = createElement(new WalletManager({ adapters: [] }));
+    element.style.setProperty('--xc-primary-color', '#445566');
+    element.style.setProperty('--xc-background-color', '#556677');
+    for (const [variable, value] of Object.entries(EXPLICIT_HOVER_COLORS)) {
+      element.style.setProperty(variable, value);
+    }
+    document.body.appendChild(element);
+
+    await vi.advanceTimersByTimeAsync(20);
+    await element.open();
+    element.openAccountModal();
+
+    const overlayHost = element.getOverlayRoot()?.host as HTMLElement;
+    const accountModalHost = element.getAccountModalRoot()?.host as HTMLElement;
+    for (const [variable, value] of Object.entries(EXPLICIT_HOVER_COLORS)) {
+      expect(element.style.getPropertyValue(variable)).toBe(value);
+      expect(overlayHost.style.getPropertyValue(variable)).toBe(value);
+      expect(accountModalHost.style.getPropertyValue(variable)).toBe(value);
+    }
+
+    element.style.setProperty('--xc-primary-color', '#667788');
+    element.style.setProperty('--xc-background-color', '#778899');
+    await vi.advanceTimersByTimeAsync(0);
+
+    for (const [variable, value] of Object.entries(EXPLICIT_HOVER_COLORS)) {
+      expect(element.style.getPropertyValue(variable)).toBe(value);
+      expect(overlayHost.style.getPropertyValue(variable)).toBe(value);
+      expect(accountModalHost.style.getPropertyValue(variable)).toBe(value);
+    }
+  });
+
+  it('preserves stylesheet hover colors when inline base colors change', async () => {
+    const style = document.createElement('style');
+    style.textContent = `
+      xrpl-wallet-connector.stylesheet-hover-colors {
+        --xc-primary-button-hover-background: ${EXPLICIT_HOVER_COLORS['--xc-primary-button-hover-background']};
+        --xc-connect-button-hover-background: ${EXPLICIT_HOVER_COLORS['--xc-connect-button-hover-background']};
+        --xc-account-address-button-hover-color: ${EXPLICIT_HOVER_COLORS['--xc-account-address-button-hover-color']};
+      }
+    `;
+    document.head.appendChild(style);
+    element = createElement(new WalletManager({ adapters: [] }));
+    element.className = 'stylesheet-hover-colors';
+    element.style.setProperty('--xc-primary-color', '#445566');
+    element.style.setProperty('--xc-background-color', '#556677');
+    document.body.appendChild(element);
+
+    try {
+      await vi.advanceTimersByTimeAsync(20);
+      await element.open();
+      element.openAccountModal();
+      element.style.setProperty('--xc-primary-color', '#667788');
+      element.style.setProperty('--xc-background-color', '#778899');
+      await vi.advanceTimersByTimeAsync(0);
+
+      const computedStyle = getComputedStyle(element);
+      const overlayHost = element.getOverlayRoot()?.host as HTMLElement;
+      const accountModalHost = element.getAccountModalRoot()?.host as HTMLElement;
+      for (const [variable, value] of Object.entries(EXPLICIT_HOVER_COLORS)) {
+        expect(element.style.getPropertyValue(variable)).toBe('');
+        expect(computedStyle.getPropertyValue(variable).trim()).toBe(value);
+        expect(overlayHost.style.getPropertyValue(variable)).toBe(value);
+        expect(accountModalHost.style.getPropertyValue(variable)).toBe(value);
+      }
+    } finally {
+      style.remove();
+    }
+  });
+
+  it('updates private hover fallbacks when their base colors change', async () => {
+    const primaryColor = '#123456';
+    const backgroundColor = '#234567';
+    element = createElement(new WalletManager({ adapters: [] }));
+    element.style.setProperty('--xc-primary-color', primaryColor);
+    element.style.setProperty('--xc-background-color', backgroundColor);
+    document.body.appendChild(element);
+
+    await vi.advanceTimersByTimeAsync(20);
+    expect(element.style.getPropertyValue(DERIVED_HOVER_VARIABLES.primary)).toBe(
+      adjustColorBrightness(primaryColor, COLOR_ADJUSTMENT.HOVER_BRIGHTNESS)
+    );
+    expect(element.style.getPropertyValue(DERIVED_HOVER_VARIABLES.account)).toBe(
+      adjustColorBrightness(primaryColor, COLOR_ADJUSTMENT.HOVER_BRIGHTNESS)
+    );
+    expect(element.style.getPropertyValue(DERIVED_HOVER_VARIABLES.connect)).toBe(
+      adjustColorBrightness(backgroundColor, COLOR_ADJUSTMENT.HOVER_BRIGHTNESS)
+    );
+    for (const variable of Object.keys(EXPLICIT_HOVER_COLORS)) {
+      expect(element.style.getPropertyValue(variable)).toBe('');
+    }
+
+    const nextPrimaryColor = '#345678';
+    const nextBackgroundColor = '#456789';
+    element.style.setProperty('--xc-primary-color', nextPrimaryColor);
+    element.style.setProperty('--xc-background-color', nextBackgroundColor);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(element.style.getPropertyValue(DERIVED_HOVER_VARIABLES.primary)).toBe(
+      adjustColorBrightness(nextPrimaryColor, COLOR_ADJUSTMENT.HOVER_BRIGHTNESS)
+    );
+    expect(element.style.getPropertyValue(DERIVED_HOVER_VARIABLES.account)).toBe(
+      adjustColorBrightness(nextPrimaryColor, COLOR_ADJUSTMENT.HOVER_BRIGHTNESS)
+    );
+    expect(element.style.getPropertyValue(DERIVED_HOVER_VARIABLES.connect)).toBe(
+      adjustColorBrightness(nextBackgroundColor, COLOR_ADJUSTMENT.HOVER_BRIGHTNESS)
+    );
   });
 });

--- a/packages/vue/tests/vue.test.ts
+++ b/packages/vue/tests/vue.test.ts
@@ -342,6 +342,11 @@ describe('<WalletConnector>', () => {
               primaryWallet: 'fake',
               wallets: ['fake'],
               theme: 'purple',
+              cssVars: {
+                '--xc-primary-button-hover-background': '#112233',
+                '--xc-connect-button-hover-background': '#223344',
+                '--xc-account-address-button-hover-color': '#334455',
+              },
               class: 'connector',
               onConnecting,
               onConnect,
@@ -361,6 +366,11 @@ describe('<WalletConnector>', () => {
     expect(element.getAttribute('wallets')).toBe('fake');
     expect(element.className).toBe('connector');
     expect(element.style.getPropertyValue('--xc-primary-color')).toBe('#a78bfa');
+    expect(element.style.getPropertyValue('--xc-primary-button-hover-background')).toBe('#112233');
+    expect(element.style.getPropertyValue('--xc-connect-button-hover-background')).toBe('#223344');
+    expect(element.style.getPropertyValue('--xc-account-address-button-hover-color')).toBe(
+      '#334455'
+    );
 
     element.dispatchEvent(new CustomEvent('connecting', { detail: { walletId: 'fake' } }));
     expect(wallet!.connecting.value).toBe(true);


### PR DESCRIPTION
## Summary
- Preserve explicit public hover tokens by writing generated colors to private CSS fallbacks.
- Keep derived fallbacks synchronized with base colors without observer self-triggering, and forward resolved precedence to both portals.
- Cover inline values, stylesheet values, later base-color changes, and React/Vue `cssVars` forwarding.

## Test plan
- [x] `pnpm --filter @xrpl-connect/ui test`
- [x] `pnpm --filter @xrpl-commons/xrpl-connect-react test`
- [x] `pnpm --filter @xrpl-commons/xrpl-connect-vue test`
- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm test`

Depends on #152.

Fixes #144
