### PR TITLE
fix: detect Otsu provider availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Otsu/UI: report Otsu as available only when its injected provider is present,
+  and retry unavailable wallets when the connector is reopened so late provider
+  injection is discovered (#140).
 - Dependencies: refresh WalletConnect and constrain vulnerable transitive ranges used by WalletConnect, Crossmark declarations, and documentation tooling so production installs no longer report high-severity advisories; document the remaining declarations-only low-severity finding (#116).
 - Xyra/meta-bundle: lazy-load the browser-only Xyra SDK so both ESM and CommonJS umbrella imports are safe during SSR; verify no-DOM imports in fresh packed consumers.
 - Crossmark: normalize the upstream CommonJS SDK namespace so the standalone adapter loads through both Node ESM and CommonJS, with a build-time runtime smoke test.

--- a/docs/guide/wallets.md
+++ b/docs/guide/wallets.md
@@ -77,4 +77,11 @@ The web component hides unavailable wallets by default. Use its `wallets` attrib
 ></xrpl-wallet-connector>
 ```
 
+Otsu is available only when its extension has injected a provider with
+`window.xrpl?.isOtsu === true`. The adapter checks the current provider on every
+`isAvailable()` call, so applications using `WalletManager` directly can call
+`getAvailableWallets()` again after a late extension injection. The wallet
+connector retries wallets that were unavailable or timed out whenever the modal
+is opened again, so closing and reopening it refreshes late-injected providers.
+
 See the [API reference](/guide/api-reference) for constructor and connect-option types.

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -498,7 +498,9 @@ if (available) {
 
 #### Implementation Details
 
-- **isAvailable()**: Checks if `window.xrpl?.isOtsu` exists (injected by extension)
+- **isAvailable()**: Returns `true` only when the extension has injected
+  `window.xrpl?.isOtsu === true`. The adapter does not cache this check, so a
+  provider injected later is detected by the next call.
 - **connect()**: Requests connection with full permission scopes; opens extension notification popup for user approval
 - **sign()**: Uses extension's `signTransaction` method with transaction simulation
 - **signAndSubmit()**: Uses extension's `signAndSubmit` method

--- a/packages/adapters/otsu/src/otsu-adapter.ts
+++ b/packages/adapters/otsu/src/otsu-adapter.ts
@@ -72,13 +72,11 @@ export class OtsuAdapter implements WalletAdapter, SupportsFetchAccount {
    * Check if the Otsu Wallet extension is installed.
    *
    * The extension injects a provider object at window.xrpl with
-   * isOtsu=true. Returns false in non-browser environments.
+   * isOtsu=true. The provider is checked on every call so an extension
+   * injected after adapter construction can be detected.
    */
   async isAvailable(): Promise<boolean> {
-    if (typeof window === 'undefined') {
-      return false;
-    }
-    return true;
+    return typeof window !== 'undefined' && window.xrpl?.isOtsu === true;
   }
 
   // ==================== Connection Lifecycle ====================

--- a/packages/adapters/otsu/tests/otsu-adapter.test.ts
+++ b/packages/adapters/otsu/tests/otsu-adapter.test.ts
@@ -41,9 +41,19 @@ describe('OtsuAdapter.isAvailable', () => {
     await expect(new OtsuAdapter().isAvailable()).resolves.toBe(false);
   });
 
-  it('returns true when window exists', async () => {
+  it('returns false in a browser without an Otsu provider', async () => {
+    installProvider(null);
+
+    await expect(new OtsuAdapter().isAvailable()).resolves.toBe(false);
+  });
+
+  it('detects an Otsu provider injected after an earlier availability check', async () => {
+    const adapter = new OtsuAdapter();
+    installProvider(null);
+    await expect(adapter.isAvailable()).resolves.toBe(false);
+
     installProvider(makeProvider());
-    await expect(new OtsuAdapter().isAvailable()).resolves.toBe(true);
+    await expect(adapter.isAvailable()).resolves.toBe(true);
   });
 });
 

--- a/packages/ui/src/wallet-connector.ts
+++ b/packages/ui/src/wallet-connector.ts
@@ -417,10 +417,12 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
     /**
      * Check which wallets are available
      * Filters wallets based on 'wallets' attribute and checks isAvailable() on each
+     * When retryWalletIds is provided, previously available wallets remain cached.
      */
-    private async checkWalletAvailability(): Promise<boolean> {
+    private async checkWalletAvailability(retryWalletIds?: ReadonlySet<string>): Promise<boolean> {
       const manager = this.walletManager;
       const generation = ++this.walletAvailabilityGeneration;
+      const cachedAvailableWalletIds = new Set(this.availableWallets.map((wallet) => wallet.id));
 
       if (!manager || !manager.wallets.length) {
         logger.warn('No wallet manager or wallets registered');
@@ -439,8 +441,12 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
 
         logger.debug('Checking availability for wallets:', specifiedWalletIds);
 
-        // Get adapters for specified wallet IDs
-        const walletsToCheck = manager.wallets.filter((w) => specifiedWalletIds.includes(w.id));
+        const walletsById = new Map(manager.wallets.map((wallet) => [wallet.id, wallet]));
+        const walletsToCheck = manager.wallets.filter(
+          (wallet) =>
+            specifiedWalletIds.includes(wallet.id) &&
+            (!retryWalletIds || retryWalletIds.has(wallet.id))
+        );
 
         // Check availability for each wallet in parallel. Each check is capped
         // with a timeout so one slow or hung wallet (e.g. a network probe on a
@@ -479,9 +485,22 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
 
         this.walletAvailabilityTimedOut = availabilityChecks.some((check) => check.timedOut);
 
-        // Split into available / unavailable, preserving the specified order.
+        // Merge retried results with cached available wallets while preserving
+        // the configured order.
+        const availabilityByWalletId = new Map(
+          availabilityChecks.map((check) => [check.wallet.id, check])
+        );
         const ordered = specifiedWalletIds
-          .map((id) => availabilityChecks.find((check) => check.wallet.id === id))
+          .map((id) => {
+            const wallet = walletsById.get(id);
+            if (!wallet) return undefined;
+            return (
+              availabilityByWalletId.get(id) ??
+              (retryWalletIds && cachedAvailableWalletIds.has(id)
+                ? { wallet, available: true, timedOut: false }
+                : undefined)
+            );
+          })
           .filter(
             (check): check is { wallet: WalletAdapter; available: boolean; timedOut: boolean } =>
               !!check
@@ -500,6 +519,10 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
           return false;
         }
         logger.error('Error checking wallet availability:', error);
+        if (retryWalletIds) {
+          this.walletAvailabilityTimedOut = true;
+          return true;
+        }
         this.availableWallets = [];
         this.unavailableWallets = [];
         this.walletAvailabilityTimedOut = true;
@@ -573,12 +596,16 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
 
       // Retry bounded checks for wallets that may have timed out or been injected
       // by a browser extension since the previous open.
+      const retryWalletIds =
+        this.walletAvailabilityChecked && this.unavailableWallets.length > 0
+          ? new Set(this.unavailableWallets.map((wallet) => wallet.id))
+          : undefined;
       if (
         !this.walletAvailabilityChecked ||
         this.walletAvailabilityTimedOut ||
-        this.unavailableWallets.length > 0
+        retryWalletIds !== undefined
       ) {
-        const availabilityApplied = await this.checkWalletAvailability();
+        const availabilityApplied = await this.checkWalletAvailability(retryWalletIds);
         if (openGeneration !== this.openGeneration || !this.isOpen) {
           return;
         }

--- a/packages/ui/src/wallet-connector.ts
+++ b/packages/ui/src/wallet-connector.ts
@@ -571,8 +571,13 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
       // Prevent body scroll when modal is open
       document.body.style.overflow = 'hidden';
 
-      // Retry a bounded check on later opens when an adapter previously timed out.
-      if (!this.walletAvailabilityChecked || this.walletAvailabilityTimedOut) {
+      // Retry bounded checks for wallets that may have timed out or been injected
+      // by a browser extension since the previous open.
+      if (
+        !this.walletAvailabilityChecked ||
+        this.walletAvailabilityTimedOut ||
+        this.unavailableWallets.length > 0
+      ) {
         const availabilityApplied = await this.checkWalletAvailability();
         if (openGeneration !== this.openGeneration || !this.isOpen) {
           return;

--- a/packages/ui/tests/WalletConnector.test.ts
+++ b/packages/ui/tests/WalletConnector.test.ts
@@ -144,6 +144,29 @@ describe('WalletConnector wallet availability', () => {
     ).not.toBeNull();
   });
 
+  it('preserves available wallets while retrying only unavailable wallets', async () => {
+    const availableProbe = vi
+      .fn<WalletAdapter['isAvailable']>()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValue(false);
+    const recoveringProbe = vi
+      .fn<WalletAdapter['isAvailable']>()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValue(true);
+    const available = createAdapter('available', 'Available Wallet', availableProbe);
+    const recovering = createAdapter('recovering', 'Recovering Wallet', recoveringProbe);
+    element = createElement(new WalletManager({ adapters: [available, recovering] }));
+
+    await element.open();
+    element.close();
+    await element.open();
+
+    expect(availableProbe).toHaveBeenCalledTimes(1);
+    expect(recoveringProbe).toHaveBeenCalledTimes(2);
+    expect(element.getOverlayRoot()?.querySelector('[data-wallet-id="available"]')).not.toBeNull();
+    expect(element.getOverlayRoot()?.querySelector('[data-wallet-id="recovering"]')).not.toBeNull();
+  });
+
   it('retries timed-out wallets on a later open and renders them when they recover', async () => {
     let resolveFirst!: (available: boolean) => void;
     const firstProbe = new Promise<boolean>((resolve) => {

--- a/packages/ui/tests/WalletConnector.test.ts
+++ b/packages/ui/tests/WalletConnector.test.ts
@@ -119,8 +119,11 @@ describe('WalletConnector wallet availability', () => {
     expect(manager.wallet).toBeNull();
   });
 
-  it('renders an empty state instead of falling back to unavailable wallets', async () => {
-    const isAvailable = vi.fn(async () => false);
+  it('retries unavailable wallets on a later open and renders them when they appear', async () => {
+    const isAvailable = vi
+      .fn<WalletAdapter['isAvailable']>()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValue(true);
     const adapter = createAdapter('unavailable', 'Unavailable Wallet', isAvailable);
     element = createElement(new WalletManager({ adapters: [adapter] }));
 
@@ -134,7 +137,11 @@ describe('WalletConnector wallet availability', () => {
 
     element.close();
     await element.open();
-    expect(isAvailable).toHaveBeenCalledTimes(1);
+
+    expect(isAvailable).toHaveBeenCalledTimes(2);
+    expect(
+      element.getOverlayRoot()?.querySelector('[data-wallet-id="unavailable"]')
+    ).not.toBeNull();
   });
 
   it('retries timed-out wallets on a later open and renders them when they recover', async () => {


### PR DESCRIPTION
## Summary
- require Otsu's injected `window.xrpl.isOtsu` marker before reporting the wallet as available
- recheck previously unavailable wallets when the connector is reopened so late provider injection is discovered
- cover SSR, provider-less browsers, late injection, and connector refresh behavior; document the refresh contract

## Test plan
- [x] `pnpm --filter @xrpl-connect/adapter-otsu test`
- [x] `pnpm --filter @xrpl-connect/ui test`
- [x] `pnpm --filter @xrpl-connect/adapter-otsu build`
- [x] `pnpm --filter @xrpl-connect/ui build`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm docs:build`
- [x] `pnpm test`

Fixes #140
