### PR TITLE
fix: make wallet list scrollable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,11 +39,11 @@ jobs:
 
       - name: Install browser
         if: matrix.node-version == '24.11'
-        run: pnpm exec playwright install --with-deps chromium
+        run: vp exec playwright install --with-deps chromium
 
       - name: Browser tests
         if: matrix.node-version == '24.11'
-        run: pnpm test:browser
+        run: vp exec playwright test
 
   docs-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,14 @@ jobs:
       - name: Test
         run: vp run -F './packages/**' --ignore-depends-on --concurrency-limit 2 test -- --passWithNoTests
 
+      - name: Install browser
+        if: matrix.node-version == '24.11'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Browser tests
+        if: matrix.node-version == '24.11'
+        run: pnpm test:browser
+
   docs-build:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ out
 
 # Testing
 coverage
+playwright-report
+test-results
 
 # Environment
 .env

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build": "vp run -r build",
     "dev": "vp run -r --parallel dev",
     "test": "vp run -r build && vp run -F './packages/**' --ignore-depends-on --concurrency-limit 2 test -- --passWithNoTests",
+    "test:browser": "playwright test",
     "lint": "vp lint",
     "format": "vp fmt",
     "format:check": "vp fmt --check",
@@ -31,6 +32,7 @@
     "docs:snapshot:check": "node docs/scripts/prepare-versioned-docs.mjs --check"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@types/node": "^20.14.0",
     "typescript": "^5.5.0",
     "vite": "catalog:",

--- a/packages/ui/src/styles/main.ts
+++ b/packages/ui/src/styles/main.ts
@@ -149,6 +149,7 @@ export const mainStyles = `
 
   .header {
     display: flex;
+    flex-shrink: 0;
     align-items: center;
     justify-content: space-between;
     padding: ${SIZES.HEADER_PADDING}px 20px 16px;
@@ -211,7 +212,9 @@ export const mainStyles = `
 
   .content {
     flex: 1;
-    overflow-y: hidden;
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
     padding: 0 24px 24px;
     transition: opacity 0.3s ease;
     -ms-overflow-style: none;

--- a/packages/ui/src/views/WalletListView.ts
+++ b/packages/ui/src/views/WalletListView.ts
@@ -21,7 +21,7 @@ export function renderWalletListView(
         <button class="close-button" part="close-button" aria-label="Close">×</button>
       </div>
 
-      <div class="content">
+      <div class="content" role="region" aria-label="Wallet options" tabindex="0">
         ${
           primaryWallet
             ? `

--- a/packages/ui/tests/browser/fixture.ts
+++ b/packages/ui/tests/browser/fixture.ts
@@ -1,0 +1,43 @@
+import { WalletManager, type NetworkInfo, type WalletAdapter } from '@xrpl-connect/core';
+import '../../src/wallet-connector';
+
+const network: NetworkInfo = {
+  id: 'testnet',
+  name: 'Testnet',
+  wss: 'wss://example.test',
+};
+
+function createUnavailableWallet(index: number): WalletAdapter {
+  const id = `wallet-${index}`;
+  return {
+    id,
+    name: `Wallet ${index}`,
+    url: `https://example.test/${id}`,
+    isAvailable: async () => false,
+    connect: async () => ({ address: `rWallet${index}`, network }),
+    disconnect: async () => {},
+    getAccount: async () => null,
+    getNetwork: async () => network,
+    sign: async () => {
+      throw new Error('Signing is not used by browser tests.');
+    },
+    signAndSubmit: async () => {
+      throw new Error('Submission is not used by browser tests.');
+    },
+    signMessage: async () => {
+      throw new Error('Message signing is not used by browser tests.');
+    },
+  };
+}
+
+const wallets = Array.from({ length: 12 }, (_, index) => createUnavailableWallet(index + 1));
+const connector = document.querySelector('#wallet-connector') as HTMLElement & {
+  setWalletManager(manager: WalletManager): void;
+  open(): Promise<void>;
+};
+connector.setAttribute('wallets', wallets.map((wallet) => wallet.id).join(','));
+connector.setWalletManager(new WalletManager({ adapters: wallets }));
+
+document.querySelector('#open-wallet-dialog')?.addEventListener('click', () => {
+  void connector.open();
+});

--- a/packages/ui/tests/browser/index.html
+++ b/packages/ui/tests/browser/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>XRPL Connect browser tests</title>
+  </head>
+  <body>
+    <button id="open-wallet-dialog" type="button">Open wallet dialog</button>
+    <xrpl-wallet-connector id="wallet-connector" show-unavailable></xrpl-wallet-connector>
+    <script type="module" src="./fixture.ts"></script>
+  </body>
+</html>

--- a/packages/ui/tests/browser/vite.config.ts
+++ b/packages/ui/tests/browser/vite.config.ts
@@ -1,0 +1,11 @@
+import path from 'node:path';
+import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  root: path.resolve(__dirname, '../../../..'),
+  resolve: {
+    alias: {
+      '@xrpl-connect/core': path.resolve(__dirname, '../../../core/src'),
+    },
+  },
+});

--- a/packages/ui/tests/browser/wallet-dialog.spec.ts
+++ b/packages/ui/tests/browser/wallet-dialog.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+const fixturePath = '/packages/ui/tests/browser/';
+
+async function openOverflowingWalletDialog(page: Page): Promise<Locator> {
+  await page.goto(fixturePath);
+  await page.getByRole('button', { name: 'Open wallet dialog' }).click();
+  const content = page.getByRole('region', { name: 'Wallet options' });
+  await expect(content).toBeVisible();
+  return content;
+}
+
+async function expectScrolledToEnd(content: Locator): Promise<void> {
+  await expect
+    .poll(() =>
+      content.evaluate((element) => element.scrollHeight - element.clientHeight - element.scrollTop)
+    )
+    .toBeLessThanOrEqual(1);
+  await expect(content.getByRole('button', { name: 'Install Wallet 12' })).toBeInViewport();
+}
+
+for (const viewport of [
+  { width: 320, height: 568 },
+  { width: 375, height: 667 },
+]) {
+  test(`keeps the header visible and the wallet list scrollable at ${viewport.width}x${viewport.height}`, async ({
+    page,
+  }) => {
+    await page.setViewportSize(viewport);
+    const content = await openOverflowingWalletDialog(page);
+    const modal = page.locator('[data-xrpl-overlay-portal] .modal');
+    const header = page.locator('[data-xrpl-overlay-portal] .header');
+
+    await expect
+      .poll(() => content.evaluate((element) => element.scrollHeight > element.clientHeight))
+      .toBe(true);
+    await expect(content).toHaveCSS('overflow-y', 'auto');
+    await expect(content).toHaveCSS('overscroll-behavior-y', 'contain');
+    await expect(page.locator('body')).toHaveCSS('overflow', 'hidden');
+
+    const [modalBox, headerBox] = await Promise.all([modal.boundingBox(), header.boundingBox()]);
+    expect(modalBox).not.toBeNull();
+    expect(headerBox).not.toBeNull();
+    expect(modalBox!.height).toBeLessThanOrEqual(viewport.height * 0.85 + 1);
+    expect(headerBox!.y).toBeGreaterThanOrEqual(modalBox!.y);
+    expect(headerBox!.y + headerBox!.height).toBeLessThanOrEqual(modalBox!.y + modalBox!.height);
+  });
+}
+
+test('supports wheel scrolling without moving the locked document', async ({ page }) => {
+  await page.setViewportSize({ width: 320, height: 568 });
+  const content = await openOverflowingWalletDialog(page);
+
+  await content.hover();
+  await page.mouse.wheel(0, 10_000);
+  await expectScrolledToEnd(content);
+  await page.mouse.wheel(0, 1_000);
+  expect(await page.evaluate(() => window.scrollY)).toBe(0);
+});
+
+test('supports keyboard scrolling to the final wallet', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 667 });
+  const content = await openOverflowingWalletDialog(page);
+
+  await content.focus();
+  await page.keyboard.press('End');
+  await expectScrolledToEnd(content);
+});
+
+test('supports touch scrolling to the final wallet', async ({ page, context }) => {
+  await page.setViewportSize({ width: 375, height: 667 });
+  const content = await openOverflowingWalletDialog(page);
+  const box = await content.boundingBox();
+  expect(box).not.toBeNull();
+
+  const client = await context.newCDPSession(page);
+  const x = box!.x + box!.width / 2;
+  const startY = box!.y + box!.height - 24;
+  const endY = box!.y + 24;
+  await client.send('Input.dispatchTouchEvent', {
+    type: 'touchStart',
+    touchPoints: [{ x, y: startY }],
+  });
+  for (let step = 1; step <= 8; step += 1) {
+    await client.send('Input.dispatchTouchEvent', {
+      type: 'touchMove',
+      touchPoints: [{ x, y: startY + ((endY - startY) * step) / 8 }],
+    });
+  }
+  await client.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+
+  await expectScrolledToEnd(content);
+});

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    exclude: ['tests/browser/**'],
   },
   resolve: {
     alias: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   ],
   webServer: {
     command:
-      'pnpm exec vp dev --config packages/ui/tests/browser/vite.config.ts --host 127.0.0.1 --port 4173 --strictPort',
+      'vp dev --config packages/ui/tests/browser/vite.config.ts --host 127.0.0.1 --port 4173 --strictPort',
     url: 'http://127.0.0.1:4173/packages/ui/tests/browser/',
     reuseExistingServer: !process.env.CI,
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './packages/ui/tests/browser',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], hasTouch: true },
+    },
+  ],
+  webServer: {
+    command:
+      'pnpm exec vp dev --config packages/ui/tests/browser/vite.config.ts --host 127.0.0.1 --port 4173 --strictPort',
+    url: 'http://127.0.0.1:4173/packages/ui/tests/browser/',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
 
   .:
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@types/node':
         specifier: ^20.14.0
         version: 20.19.21
@@ -1170,6 +1173,11 @@ packages:
   '@oxlint/plugins@1.73.0':
     resolution: {integrity: sha512-OhgMQeMmZA0dcFcX4/priaJZWdFECxiClgq6mRX6aatZEcV9PbKC3P3/v8U1hVjviT1i5U+vR8lAtBV6m4FXAA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -2320,6 +2328,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   cssstyle@3.0.0:
     resolution: {integrity: sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==}
@@ -2592,6 +2601,11 @@ packages:
   fs-extra@11.3.5:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -3312,6 +3326,16 @@ packages:
   pkg-dir@5.0.0:
     resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==}
     engines: {node: '>=10'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
@@ -4732,6 +4756,10 @@ snapshots:
     optional: true
 
   '@oxlint/plugins@1.73.0': {}
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -6364,6 +6392,9 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -7257,6 +7288,14 @@ snapshots:
   pkg-dir@5.0.0:
     dependencies:
       find-up: 5.0.0
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pngjs@5.0.0: {}
 


### PR DESCRIPTION
## Summary
- Keep the wallet modal header visible while wallet choices overflow within the viewport.
- Make the flex content shrinkable and vertically scrollable while containing overscroll inside the locked document.
- Add Chromium coverage for 320×568 and 375×667 viewports, including wheel, touch, and keyboard scrolling.

## Stack
- 1 of 2; followed by #157.

## Test plan
- [x] `pnpm exec vp run -r build`
- [x] `pnpm exec vp check`
- [x] `pnpm exec vp run -F './packages/**' --ignore-depends-on --concurrency-limit 2 test -- --passWithNoTests`
- [x] `pnpm exec vp run -F xrpl-connect test:publish`
- [x] `pnpm test:browser`

Fixes #143
