### PR TITLE
fix: make wallet dialogs accessible

### DIFF
--- a/packages/ui/src/services/EventHandler.ts
+++ b/packages/ui/src/services/EventHandler.ts
@@ -42,6 +42,13 @@ export class EventHandler {
     const overlayRoot = this.component.getOverlayRoot();
     const accountRoot = this.component.getAccountModalRoot();
 
+    this.add(overlayRoot?.querySelector('[role="dialog"]'), 'keydown', (event: Event) => {
+      this.component.handleDialogKeyDown('wallet', event as KeyboardEvent);
+    });
+    this.add(accountRoot?.querySelector('[role="dialog"]'), 'keydown', (event: Event) => {
+      this.component.handleDialogKeyDown('account', event as KeyboardEvent);
+    });
+
     // Connect wallet button (in component shadow root)
     this.add(shadow.querySelector('#connect-wallet-button'), 'click', async () => {
       const isConnected = this.component.walletManager?.connected ?? false;

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -99,6 +99,7 @@ export interface WalletConnectorContext extends HTMLElement {
 
   getOverlayRoot(): ShadowRoot | null;
   getAccountModalRoot(): ShadowRoot | null;
+  handleDialogKeyDown(dialog: 'wallet' | 'account', event: KeyboardEvent): void;
 }
 
 /**

--- a/packages/ui/src/views/AccountModal.ts
+++ b/packages/ui/src/views/AccountModal.ts
@@ -11,9 +11,15 @@ export function renderAccountModal(
 
   return `
       <div id="account-modal-overlay" class="account-modal-overlay">
-        <div class="account-modal">
+        <div
+          class="account-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="account-dialog-title"
+          tabindex="-1"
+        >
           <div class="account-modal-header">
-            <h2 class="account-modal-title">Connected</h2>
+            <h2 class="account-modal-title" id="account-dialog-title">Connected</h2>
             <button class="account-modal-close" id="account-modal-close" aria-label="Close">×</button>
           </div>
 

--- a/packages/ui/src/views/AccountSelectionView.ts
+++ b/packages/ui/src/views/AccountSelectionView.ts
@@ -20,7 +20,7 @@ export function renderAccountSelectionView(
       <div class="header">
         <div class="header-with-back">
           <button class="back-button" id="account-selection-back-button" aria-label="Back">←</button>
-          <h2 class="title">Select Account</h2>
+          <h2 class="title" id="wallet-dialog-title">Select Account</h2>
         </div>
         <button class="close-button" part="close-button" aria-label="Close">×</button>
       </div>

--- a/packages/ui/src/views/ErrorView.ts
+++ b/packages/ui/src/views/ErrorView.ts
@@ -1,7 +1,7 @@
 export function renderErrorView(walletName: string, error: Error): string {
   return `
       <div class="header">
-        <h2 class="title">Connection Failed</h2>
+        <h2 class="title" id="wallet-dialog-title">Connection Failed</h2>
         <button class="close-button" part="close-button" aria-label="Close">×</button>
       </div>
 

--- a/packages/ui/src/views/LoadingView.ts
+++ b/packages/ui/src/views/LoadingView.ts
@@ -3,7 +3,7 @@ export function renderLoadingView(walletName: string, walletIcon?: string): stri
       <div class="header">
         <div class="header-with-back">
           <button class="back-button" id="loading-back-button" aria-label="Back">←</button>
-          <h2 class="title">Connect Wallet</h2>
+          <h2 class="title" id="wallet-dialog-title">Connect Wallet</h2>
         </div>
         <button class="close-button" part="close-button" aria-label="Close">×</button>
       </div>

--- a/packages/ui/src/views/QRView.ts
+++ b/packages/ui/src/views/QRView.ts
@@ -3,7 +3,7 @@ export function renderQRView(walletName: string): string {
     <div class="header">
       <div class="header-with-back">
         <button class="back-button" id="back-button" aria-label="Back">←</button>
-        <h2 class="title">${walletName}</h2>
+        <h2 class="title" id="wallet-dialog-title">${walletName}</h2>
       </div>
       <button class="close-button" part="close-button" aria-label="Close">×</button>
     </div>

--- a/packages/ui/src/views/WalletListView.ts
+++ b/packages/ui/src/views/WalletListView.ts
@@ -17,7 +17,7 @@ export function renderWalletListView(
 ): string {
   return `
       <div class="header">
-        <h2 class="title">Connect Wallet</h2>
+        <h2 class="title" id="wallet-dialog-title">Connect Wallet</h2>
         <button class="close-button" part="close-button" aria-label="Close">×</button>
       </div>
 

--- a/packages/ui/src/wallet-connector.ts
+++ b/packages/ui/src/wallet-connector.ts
@@ -360,7 +360,9 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
           this.close();
         },
         disconnect: () => {
-          if (manager === this.walletManager) this.render();
+          if (manager !== this.walletManager) return;
+          if (this.accountModalOpen) this.closeAccountModal();
+          else this.render();
         },
         accountChanged: () => {
           if (manager === this.walletManager) this.render();
@@ -746,7 +748,7 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
     public async disconnectFromAccountModal() {
       try {
         await this.walletManager?.disconnect();
-        this.closeAccountModal();
+        if (this.accountModalOpen) this.closeAccountModal();
       } catch (error) {
         logger.error('Failed to disconnect:', error);
       }

--- a/packages/ui/src/wallet-connector.ts
+++ b/packages/ui/src/wallet-connector.ts
@@ -62,6 +62,12 @@ interface ConnectionWaiter {
   reject(error: Error): void;
 }
 
+interface FocusReturnTarget {
+  element: HTMLElement;
+  root: Document | ShadowRoot;
+  id: string | null;
+}
+
 // Only define the component in browser (guard against SSR)
 let WalletConnectorElement: {
   new (): WalletConnectorElementInstance;
@@ -144,6 +150,8 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
     private overlayPortal: HTMLDivElement | null = null;
     private accountModalPortal: HTMLDivElement | null = null;
     private styleObserver: MutationObserver | null = null;
+    private walletDialogOpener: FocusReturnTarget | null = null;
+    private accountDialogOpener: FocusReturnTarget | null = null;
     private readonly connectionWaiters = new Set<ConnectionWaiter>();
     private walletManagerHandlers: {
       connect: (account: AccountInfo) => void;
@@ -199,6 +207,8 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
 
       this.styleObserver?.disconnect();
       this.styleObserver = null;
+      this.walletDialogOpener = null;
+      this.accountDialogOpener = null;
 
       this.overlayPortal?.remove();
       this.overlayPortal = null;
@@ -348,7 +358,6 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
           const connectedId = manager.wallet?.id;
           if (connectedId) this.recordMruId(connectedId);
           this.close();
-          this.render();
         },
         disconnect: () => {
           if (manager === this.walletManager) this.render();
@@ -608,6 +617,9 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
      * Open the modal
      */
     async open() {
+      if (!this.isOpen) {
+        this.walletDialogOpener = this.captureFocusReturnTarget();
+      }
       const openGeneration = ++this.openGeneration;
       this.isOpen = true;
       this.isFirstOpen = true;
@@ -670,6 +682,7 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
      * Close the modal
      */
     close() {
+      const wasOpen = this.isOpen;
       this.cancelPendingConnection();
       this.openGeneration += 1;
       this.isOpen = false;
@@ -685,6 +698,10 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
       this.errorData = null;
       this.accountSelectionData = null;
       this.render();
+      if (wasOpen) {
+        this.restoreFocus(this.walletDialogOpener);
+        this.walletDialogOpener = null;
+      }
       this.dispatchEvent(new CustomEvent('close'));
     }
 
@@ -703,6 +720,9 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
      * Open the account details modal
      */
     public openAccountModal() {
+      if (!this.accountModalOpen) {
+        this.accountDialogOpener = this.captureFocusReturnTarget();
+      }
       this.accountModalOpen = true;
       this.render();
     }
@@ -711,8 +731,13 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
      * Close the account details modal
      */
     public closeAccountModal() {
+      const wasOpen = this.accountModalOpen;
       this.accountModalOpen = false;
       this.render();
+      if (wasOpen) {
+        this.restoreFocus(this.accountDialogOpener);
+        this.accountDialogOpener = null;
+      }
     }
 
     /**
@@ -722,7 +747,6 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
       try {
         await this.walletManager?.disconnect();
         this.closeAccountModal();
-        this.render();
       } catch (error) {
         logger.error('Failed to disconnect:', error);
       }
@@ -1125,7 +1149,14 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
         overlayRoot.innerHTML = `
     <style>${mainStyles}</style>
     <div class="${overlayClass}" part="overlay">
-      <div class="${modalClass}" part="modal">
+      <div
+        class="${modalClass}"
+        part="modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="wallet-dialog-title"
+        tabindex="-1"
+      >
         ${contentHTML}
       </div>
     </div>
@@ -1151,6 +1182,8 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
       }
 
       this.eventHandler?.attachEventListeners();
+      if (this.isOpen) this.ensureDialogFocus('wallet');
+      if (this.accountModalOpen) this.ensureDialogFocus('account');
 
       // Update modal height smoothly after render
       requestAnimationFrame(() => {
@@ -1187,6 +1220,97 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
 
       // Store current height for next transition
       this.previousModalHeight = newHeight;
+    }
+
+    private captureFocusReturnTarget(): FocusReturnTarget | null {
+      let root: Document | ShadowRoot = document;
+      let activeElement = root.activeElement;
+
+      while (activeElement instanceof HTMLElement && activeElement.shadowRoot?.activeElement) {
+        root = activeElement.shadowRoot;
+        activeElement = root.activeElement;
+      }
+
+      if (
+        !(activeElement instanceof HTMLElement) ||
+        activeElement === document.body ||
+        activeElement === document.documentElement
+      ) {
+        return null;
+      }
+
+      return {
+        element: activeElement,
+        root,
+        id: activeElement.id || null,
+      };
+    }
+
+    private restoreFocus(target: FocusReturnTarget | null): void {
+      if (!target) return;
+
+      const replacement = target.id ? target.root.getElementById(target.id) : null;
+      const element = target.element.isConnected ? target.element : replacement;
+      if (element?.isConnected) element.focus();
+    }
+
+    private getDialog(dialog: 'wallet' | 'account'): HTMLElement | null {
+      const root = dialog === 'wallet' ? this.getOverlayRoot() : this.getAccountModalRoot();
+      return root?.querySelector<HTMLElement>('[role="dialog"]') ?? null;
+    }
+
+    private getDialogFocusables(dialog: HTMLElement): HTMLElement[] {
+      return Array.from(
+        dialog.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        )
+      );
+    }
+
+    private ensureDialogFocus(dialogType: 'wallet' | 'account'): void {
+      const dialog = this.getDialog(dialogType);
+      if (!dialog) return;
+
+      const root = dialog.getRootNode() as ShadowRoot;
+      if (root.activeElement && dialog.contains(root.activeElement)) return;
+
+      (this.getDialogFocusables(dialog)[0] ?? dialog).focus();
+    }
+
+    public handleDialogKeyDown(dialogType: 'wallet' | 'account', event: KeyboardEvent): void {
+      const dialog = this.getDialog(dialogType);
+      if (!dialog) return;
+
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        event.stopPropagation();
+        if (dialogType === 'wallet') this.close();
+        else this.closeAccountModal();
+        return;
+      }
+
+      if (event.key !== 'Tab') return;
+
+      const focusableElements = this.getDialogFocusables(dialog);
+      if (focusableElements.length === 0) {
+        event.preventDefault();
+        dialog.focus();
+        return;
+      }
+
+      const root = dialog.getRootNode() as ShadowRoot;
+      const activeElement = root.activeElement;
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+      const shouldWrapBackward = event.shiftKey && activeElement === firstElement;
+      const shouldWrapForward = !event.shiftKey && activeElement === lastElement;
+      const focusIsOutsideDialog = !activeElement || !dialog.contains(activeElement);
+
+      if (shouldWrapBackward || shouldWrapForward || focusIsOutsideDialog) {
+        event.preventDefault();
+        if (event.shiftKey) lastElement.focus();
+        else firstElement.focus();
+      }
     }
   }
 

--- a/packages/ui/tests/browser/fixture.ts
+++ b/packages/ui/tests/browser/fixture.ts
@@ -49,3 +49,15 @@ const accountConnector = document.querySelector('#account-connector') as HTMLEle
   setWalletManager(manager: WalletManager): void;
 };
 accountConnector.setWalletManager(accountManager);
+
+declare global {
+  interface Window {
+    disconnectAccountWallet(): Promise<void>;
+    reconnectAccountWallet(): Promise<void>;
+  }
+}
+
+window.disconnectAccountWallet = () => accountManager.disconnect();
+window.reconnectAccountWallet = async () => {
+  await accountManager.connect(accountWallet.id);
+};

--- a/packages/ui/tests/browser/fixture.ts
+++ b/packages/ui/tests/browser/fixture.ts
@@ -7,13 +7,13 @@ const network: NetworkInfo = {
   wss: 'wss://example.test',
 };
 
-function createUnavailableWallet(index: number): WalletAdapter {
+function createWallet(index: number, available: boolean): WalletAdapter {
   const id = `wallet-${index}`;
   return {
     id,
     name: `Wallet ${index}`,
     url: `https://example.test/${id}`,
-    isAvailable: async () => false,
+    isAvailable: async () => available,
     connect: async () => ({ address: `rWallet${index}`, network }),
     disconnect: async () => {},
     getAccount: async () => null,
@@ -30,7 +30,7 @@ function createUnavailableWallet(index: number): WalletAdapter {
   };
 }
 
-const wallets = Array.from({ length: 12 }, (_, index) => createUnavailableWallet(index + 1));
+const wallets = Array.from({ length: 12 }, (_, index) => createWallet(index + 1, index === 0));
 const connector = document.querySelector('#wallet-connector') as HTMLElement & {
   setWalletManager(manager: WalletManager): void;
   open(): Promise<void>;
@@ -41,3 +41,11 @@ connector.setWalletManager(new WalletManager({ adapters: wallets }));
 document.querySelector('#open-wallet-dialog')?.addEventListener('click', () => {
   void connector.open();
 });
+
+const accountWallet = createWallet(100, true);
+const accountManager = new WalletManager({ adapters: [accountWallet] });
+await accountManager.connect(accountWallet.id);
+const accountConnector = document.querySelector('#account-connector') as HTMLElement & {
+  setWalletManager(manager: WalletManager): void;
+};
+accountConnector.setWalletManager(accountManager);

--- a/packages/ui/tests/browser/index.html
+++ b/packages/ui/tests/browser/index.html
@@ -8,6 +8,7 @@
   <body>
     <button id="open-wallet-dialog" type="button">Open wallet dialog</button>
     <xrpl-wallet-connector id="wallet-connector" show-unavailable></xrpl-wallet-connector>
+    <xrpl-wallet-connector id="account-connector"></xrpl-wallet-connector>
     <script type="module" src="./fixture.ts"></script>
   </body>
 </html>

--- a/packages/ui/tests/browser/wallet-dialog.spec.ts
+++ b/packages/ui/tests/browser/wallet-dialog.spec.ts
@@ -91,3 +91,90 @@ test('supports touch scrolling to the final wallet', async ({ page, context }) =
 
   await expectScrolledToEnd(content);
 });
+
+test('provides wallet dialog semantics, traps focus, and restores every close path', async ({
+  page,
+}) => {
+  await page.goto(fixturePath);
+  const opener = page.getByRole('button', { name: 'Open wallet dialog' });
+
+  await opener.click();
+  const dialog = page.getByRole('dialog', { name: 'Connect Wallet' });
+  const closeButton = dialog.getByRole('button', { name: 'Close' });
+  const lastWallet = dialog.getByRole('button', { name: 'Install Wallet 12' });
+  await expect(dialog).toHaveAttribute('aria-modal', 'true');
+  await expect(closeButton).toBeFocused();
+
+  await lastWallet.focus();
+  await page.keyboard.press('Tab');
+  await expect(closeButton).toBeFocused();
+  await page.keyboard.press('Shift+Tab');
+  await expect(lastWallet).toBeFocused();
+
+  await page.keyboard.press('Escape');
+  await expect(dialog).toBeHidden();
+  await expect(opener).toBeFocused();
+
+  await opener.click();
+  await page
+    .getByRole('dialog', { name: 'Connect Wallet' })
+    .getByRole('button', {
+      name: 'Close',
+    })
+    .click();
+  await expect(opener).toBeFocused();
+
+  await opener.click();
+  await page.locator('[data-xrpl-overlay-portal] .overlay').dispatchEvent('click');
+  await expect(opener).toBeFocused();
+
+  await opener.click();
+  await page
+    .getByRole('dialog', { name: 'Connect Wallet' })
+    .getByRole('button', {
+      name: 'Wallet 1',
+      exact: true,
+    })
+    .click();
+  await expect(page.getByRole('dialog', { name: 'Connect Wallet' })).toBeHidden();
+  await expect(opener).toBeFocused();
+});
+
+test('provides account dialog semantics, traps focus, and restores its internal opener', async ({
+  page,
+}) => {
+  await page.goto(fixturePath);
+  const opener = page.locator('#account-connector').locator('#connect-wallet-button');
+
+  await opener.click();
+  const dialog = page.getByRole('dialog', { name: 'Connected' });
+  const closeButton = dialog.getByRole('button', { name: 'Close' });
+  const disconnectButton = dialog.getByRole('button', { name: 'Disconnect' });
+  await expect(dialog).toHaveAttribute('aria-modal', 'true');
+  await expect(closeButton).toBeFocused();
+
+  await disconnectButton.focus();
+  await page.keyboard.press('Tab');
+  await expect(closeButton).toBeFocused();
+  await page.keyboard.press('Shift+Tab');
+  await expect(disconnectButton).toBeFocused();
+
+  await page.keyboard.press('Escape');
+  await expect(dialog).toBeHidden();
+  await expect(opener).toBeFocused();
+
+  await opener.click();
+  await page
+    .locator('[data-xrpl-account-modal-portal] .account-modal-overlay')
+    .dispatchEvent('click');
+  await expect(opener).toBeFocused();
+
+  await opener.click();
+  await page
+    .getByRole('dialog', { name: 'Connected' })
+    .getByRole('button', {
+      name: 'Close',
+    })
+    .click();
+  await expect(opener).toBeFocused();
+});

--- a/packages/ui/tests/browser/wallet-dialog.spec.ts
+++ b/packages/ui/tests/browser/wallet-dialog.spec.ts
@@ -177,4 +177,29 @@ test('provides account dialog semantics, traps focus, and restores its internal 
     })
     .click();
   await expect(opener).toBeFocused();
+
+  await opener.click();
+  await page
+    .getByRole('dialog', { name: 'Connected' })
+    .getByRole('button', {
+      name: 'Disconnect',
+    })
+    .click();
+  await expect(page.getByRole('dialog', { name: 'Connected' })).toBeHidden();
+  await expect(opener).toBeFocused();
+});
+
+test('cleans up the account dialog after an external wallet disconnect', async ({ page }) => {
+  await page.goto(fixturePath);
+  const opener = page.locator('#account-connector').locator('#connect-wallet-button');
+
+  await opener.click();
+  await expect(page.getByRole('dialog', { name: 'Connected' })).toBeVisible();
+
+  await page.evaluate(() => window.disconnectAccountWallet());
+  await expect(page.getByRole('dialog', { name: 'Connected' })).toBeHidden();
+  await expect(opener).toBeFocused();
+
+  await page.evaluate(() => window.reconnectAccountWallet());
+  await expect(page.getByRole('dialog', { name: 'Connected' })).toBeHidden();
 });


### PR DESCRIPTION
## Summary
- Give wallet and account overlays proper modal-dialog semantics tied to their visible headings.
- Move focus into each dialog, trap Tab and Shift+Tab, support Escape, and restore focus across button, backdrop, and successful-connection close paths.
- Reuse tracked listeners so keyboard handling is removed on rerender and component disconnect.

## Stack
- 2 of 2; depends on #156.

## Test plan
- [x] `pnpm exec vp run -r build`
- [x] `pnpm exec vp check`
- [x] `pnpm exec vp run -F './packages/**' --ignore-depends-on --concurrency-limit 2 test -- --passWithNoTests`
- [x] `pnpm exec vp run -F xrpl-connect test:publish`
- [x] `pnpm test:browser`

Fixes #147
