### PR TITLE
fix: reject unknown network ids

### DIFF
--- a/packages/adapters/metamask-snap/src/metamask-snap-adapter.ts
+++ b/packages/adapters/metamask-snap/src/metamask-snap-adapter.ts
@@ -11,6 +11,7 @@ import type {
   ConnectOptions,
   NetworkInfo,
   NetworkConfig,
+  StandardNetworkId,
   Transaction,
   SignedTransaction,
   SignedMessage,
@@ -45,7 +46,7 @@ const DEFAULT_SNAP_ID = 'npm:xrpl-snap';
 /**
  * Mapping between xrpl-connect network IDs and snap chainIds
  */
-const NETWORK_TO_CHAIN_ID: Record<string, number> = {
+const NETWORK_TO_CHAIN_ID: Record<StandardNetworkId, number> = {
   mainnet: 0,
   testnet: 1,
   devnet: 2,
@@ -373,10 +374,10 @@ export class MetaMaskSnapAdapter implements WalletAdapter {
   }
 
   private async selectNetwork(network: NetworkInfo): Promise<NetworkInfo> {
-    const chainId = NETWORK_TO_CHAIN_ID[network.id];
-    if (chainId === undefined) {
+    if (!isStandardNetworkId(network.id)) {
       throw createWalletError.networkNotSupported(network.id, this.name);
     }
+    const chainId = NETWORK_TO_CHAIN_ID[network.id];
 
     const current = await this.readActiveNetwork();
     if (current.id !== network.id) {

--- a/packages/adapters/metamask-snap/src/metamask-snap-adapter.ts
+++ b/packages/adapters/metamask-snap/src/metamask-snap-adapter.ts
@@ -18,6 +18,7 @@ import type {
 } from '@xrpl-connect/core';
 import {
   createWalletError,
+  isStandardNetworkId,
   isWalletError,
   STANDARD_NETWORKS,
   resolveNetwork,
@@ -360,7 +361,7 @@ export class MetaMaskSnapAdapter implements WalletAdapter {
       nodeUrl: string;
     };
     const networkId = CHAIN_ID_TO_NETWORK[snapNetwork.chainId];
-    if (networkId && STANDARD_NETWORKS[networkId]) {
+    if (networkId && isStandardNetworkId(networkId)) {
       return STANDARD_NETWORKS[networkId];
     }
     return {

--- a/packages/adapters/metamask-snap/tests/metamask-snap-adapter.test.ts
+++ b/packages/adapters/metamask-snap/tests/metamask-snap-adapter.test.ts
@@ -275,6 +275,25 @@ describe('MetaMaskSnapAdapter signing', () => {
 });
 
 describe('MetaMaskSnapAdapter network switching', () => {
+  it('rejects custom ids that collide with object prototype keys', async () => {
+    const changeNetwork = vi.fn();
+    setProvider(
+      mockProvider({
+        snapHandlers: {
+          xrpl_getActiveNetwork: () => ({ chainId: 0, name: 'Mainnet', nodeUrl: '' }),
+          xrpl_changeNetwork: changeNetwork,
+        },
+      })
+    );
+
+    await expect(
+      new MetaMaskSnapAdapter().connect({
+        network: { id: 'toString', name: 'Custom', wss: 'wss://custom.example.com' },
+      })
+    ).rejects.toMatchObject({ code: WalletErrorCode.NETWORK_NOT_SUPPORTED });
+    expect(changeNetwork).not.toHaveBeenCalled();
+  });
+
   it('switches and verifies the active Snap network', async () => {
     let chainId = 0;
     setProvider(

--- a/packages/adapters/otsu/src/otsu-adapter.ts
+++ b/packages/adapters/otsu/src/otsu-adapter.ts
@@ -22,7 +22,12 @@ import type {
   SubmittedTransaction,
   WalletAdapterEvent,
 } from '@xrpl-connect/core';
-import { createWalletError, STANDARD_NETWORKS, createLogger } from '@xrpl-connect/core';
+import {
+  createWalletError,
+  isStandardNetworkId,
+  STANDARD_NETWORKS,
+  createLogger,
+} from '@xrpl-connect/core';
 import type { OtsuProvider } from './types';
 import iconDataUrl from './assets/icon.png';
 
@@ -409,7 +414,7 @@ export class OtsuAdapter implements WalletAdapter, SupportsFetchAccount {
 
     // Use the requested network or default to mainnet
     if (networkConfig) {
-      if (typeof networkConfig === 'string' && STANDARD_NETWORKS[networkConfig]) {
+      if (typeof networkConfig === 'string' && isStandardNetworkId(networkConfig)) {
         return STANDARD_NETWORKS[networkConfig];
       }
       if (typeof networkConfig === 'object') {
@@ -421,7 +426,7 @@ export class OtsuAdapter implements WalletAdapter, SupportsFetchAccount {
   }
 
   private toNetworkInfo(network: string): NetworkInfo {
-    if (STANDARD_NETWORKS[network]) {
+    if (isStandardNetworkId(network)) {
       return STANDARD_NETWORKS[network];
     }
 
@@ -451,7 +456,9 @@ export class OtsuAdapter implements WalletAdapter, SupportsFetchAccount {
     const networkHandler = (data: unknown) => {
       if (this.currentAccount && data && typeof data === 'object' && 'network' in data) {
         const networkId = (data as { network: string }).network;
-        const networkInfo = STANDARD_NETWORKS[networkId] || this.currentAccount.network;
+        const networkInfo = isStandardNetworkId(networkId)
+          ? STANDARD_NETWORKS[networkId]
+          : this.currentAccount.network;
         this.currentAccount = {
           ...this.currentAccount,
           network: networkInfo,

--- a/packages/adapters/xyra/src/types.ts
+++ b/packages/adapters/xyra/src/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Network } from '@xyrawallet/sdk';
+import type { StandardNetworkId } from '@xrpl-connect/core';
 
 /**
  * Xyra adapter constructor options
@@ -57,7 +58,7 @@ export type XyraConnectOptions = {
  * Xyra SDK uses: 'xrpl-mainnet', 'xrpl-testnet'
  *
  */
-export const XRPL_CONNECT_TO_XYRA_NETWORK: Record<string, Network> = {
+export const XRPL_CONNECT_TO_XYRA_NETWORK: Record<StandardNetworkId, Network> = {
   mainnet: 'xrpl-mainnet',
   testnet: 'xrpl-testnet',
   devnet: 'xrpl-testnet', // Xyra doesn't have devnet, fall back to testnet
@@ -66,7 +67,7 @@ export const XRPL_CONNECT_TO_XYRA_NETWORK: Record<string, Network> = {
 /**
  * Reverse mapping: Xyra SDK network → xrpl-connect network ID
  */
-export const XYRA_TO_XRPL_CONNECT_NETWORK: Partial<Record<Network, string>> = {
+export const XYRA_TO_XRPL_CONNECT_NETWORK: Partial<Record<Network, StandardNetworkId>> = {
   'xrpl-mainnet': 'mainnet',
   'xrpl-testnet': 'testnet',
 };

--- a/packages/adapters/xyra/src/xyra-adapter.ts
+++ b/packages/adapters/xyra/src/xyra-adapter.ts
@@ -458,9 +458,8 @@ export class XyraAdapter implements WalletAdapter {
     }
 
     // Map from xrpl-connect network ID to Xyra network
-    const mapped = XRPL_CONNECT_TO_XYRA_NETWORK[networkId];
-    if (mapped) {
-      return mapped;
+    if (isStandardNetworkId(networkId)) {
+      return XRPL_CONNECT_TO_XYRA_NETWORK[networkId];
     }
 
     // Try to infer from the network ID string
@@ -492,7 +491,7 @@ export class XyraAdapter implements WalletAdapter {
     const connectNetworkId = XYRA_TO_XRPL_CONNECT_NETWORK[xyraNetwork];
 
     // Check standard networks first
-    if (connectNetworkId && isStandardNetworkId(connectNetworkId)) {
+    if (connectNetworkId) {
       return STANDARD_NETWORKS[connectNetworkId];
     }
 

--- a/packages/adapters/xyra/src/xyra-adapter.ts
+++ b/packages/adapters/xyra/src/xyra-adapter.ts
@@ -28,7 +28,12 @@ import type {
   SubmittedTransaction,
   WalletAdapterEvent,
 } from '@xrpl-connect/core';
-import { createWalletError, STANDARD_NETWORKS, createLogger } from '@xrpl-connect/core';
+import {
+  createWalletError,
+  isStandardNetworkId,
+  STANDARD_NETWORKS,
+  createLogger,
+} from '@xrpl-connect/core';
 import type { XyraAdapterOptions, XyraConnectOptions } from './types';
 import { XRPL_CONNECT_TO_XYRA_NETWORK, XYRA_TO_XRPL_CONNECT_NETWORK } from './types';
 import iconSvg from './assets/icon.svg';
@@ -487,7 +492,7 @@ export class XyraAdapter implements WalletAdapter {
     const connectNetworkId = XYRA_TO_XRPL_CONNECT_NETWORK[xyraNetwork];
 
     // Check standard networks first
-    if (connectNetworkId && STANDARD_NETWORKS[connectNetworkId]) {
+    if (connectNetworkId && isStandardNetworkId(connectNetworkId)) {
       return STANDARD_NETWORKS[connectNetworkId];
     }
 

--- a/packages/adapters/xyra/tests/xyra-adapter.test.ts
+++ b/packages/adapters/xyra/tests/xyra-adapter.test.ts
@@ -70,6 +70,20 @@ describe('XyraAdapter.connect', () => {
     expect(account.network.id).toBe('mainnet');
   });
 
+  it('does not treat prototype keys as standard network ids', async () => {
+    mockSdk.connect.mockResolvedValue({
+      address: 'rXyraUser',
+      publicKey: 'PK',
+      network: 'xrpl-testnet',
+    });
+
+    await new XyraAdapter().connect({
+      network: { id: 'toString', name: 'Custom', wss: 'wss://custom.example.com' },
+    });
+
+    expect(mockSdk.connect).toHaveBeenCalledWith({ network: 'xrpl-testnet' });
+  });
+
   it('maps a closed-popup error to connection-rejected', async () => {
     mockSdk.connect.mockRejectedValue(new Error('User closed popup'));
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -42,7 +42,7 @@ const walletManager = new WalletManager({
 ```typescript
 interface WalletManagerOptions {
   adapters: WalletAdapter[]; // Array of wallet adapters to register
-  network?: NetworkConfig | string; // Default network ('mainnet', 'testnet', 'devnet')
+  network?: NetworkConfig; // Default network ('mainnet', 'testnet', 'devnet', or custom NetworkInfo)
   autoConnect?: boolean; // Attempt to reconnect from stored state
   storage?: StorageAdapter; // Custom storage implementation (defaults to LocalStorageAdapter)
   logger?: LoggerOptions | LoggerInstance; // Logging configuration — pass options or a custom logger

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export type {
   WalletManagerOptions,
   AccountInfo,
   NetworkInfo,
+  StandardNetworkId,
   NetworkConfig,
   Transaction,
   SignedTransaction,
@@ -37,6 +38,7 @@ export type {
 
 export {
   STANDARD_NETWORKS,
+  isStandardNetworkId,
   WalletErrorCode,
   WalletErrorCategory,
   supportsPreInitialize,

--- a/packages/core/src/network.test.ts
+++ b/packages/core/src/network.test.ts
@@ -26,13 +26,17 @@ describe('resolveNetwork', () => {
   });
 
   it('throws a WalletError when given an unknown network id', () => {
-    expect(() => resolveNetwork('not-a-network')).toThrow(WalletError);
-    try {
-      resolveNetwork('not-a-network');
-    } catch (err) {
-      expect(err).toBeInstanceOf(WalletError);
-      expect((err as WalletError).code).toBe(WalletErrorCode.UNKNOWN_ERROR);
-      expect((err as WalletError).message).toContain('not-a-network');
+    for (const invalidNetworkId of ['not-a-network', 'toString']) {
+      const invalidNetwork = invalidNetworkId as unknown as Parameters<typeof resolveNetwork>[0];
+
+      expect(() => resolveNetwork(invalidNetwork)).toThrow(WalletError);
+      try {
+        resolveNetwork(invalidNetwork);
+      } catch (err) {
+        expect(err).toBeInstanceOf(WalletError);
+        expect((err as WalletError).code).toBe(WalletErrorCode.UNKNOWN_ERROR);
+        expect((err as WalletError).message).toContain(invalidNetworkId);
+      }
     }
   });
 });

--- a/packages/core/src/network.ts
+++ b/packages/core/src/network.ts
@@ -4,7 +4,7 @@
 
 import { createWalletError } from './errors';
 import type { ConnectOptions, NetworkInfo } from './types';
-import { STANDARD_NETWORKS } from './types';
+import { isStandardNetworkId, STANDARD_NETWORKS } from './types';
 
 /**
  * Resolve a `ConnectOptions['network']` value to a concrete `NetworkInfo`.
@@ -19,11 +19,10 @@ export function resolveNetwork(config?: ConnectOptions['network']): NetworkInfo 
   }
 
   if (typeof config === 'string') {
-    const network = STANDARD_NETWORKS[config];
-    if (!network) {
+    if (!isStandardNetworkId(config)) {
       throw createWalletError.unknown(`Unknown network: ${config}`);
     }
-    return network;
+    return STANDARD_NETWORKS[config];
   }
 
   return config;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -49,7 +49,6 @@ export const STANDARD_NETWORKS: Record<StandardNetworkId, NetworkInfo> = {
  */
 export type NetworkConfig = StandardNetworkId | NetworkInfo;
 
-/** Check whether an external string identifies a built-in XRPL network. */
 export function isStandardNetworkId(networkId: string): networkId is StandardNetworkId {
   return Object.prototype.hasOwnProperty.call(STANDARD_NETWORKS, networkId);
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -18,7 +18,9 @@ export interface NetworkInfo {
 /**
  * Standard XRPL networks
  */
-export const STANDARD_NETWORKS: Record<string, NetworkInfo> = {
+export type StandardNetworkId = 'mainnet' | 'testnet' | 'devnet';
+
+export const STANDARD_NETWORKS: Record<StandardNetworkId, NetworkInfo> = {
   mainnet: {
     id: 'mainnet',
     name: 'Mainnet',
@@ -45,7 +47,12 @@ export const STANDARD_NETWORKS: Record<string, NetworkInfo> = {
 /**
  * Network configuration type - can be a standard network key or custom NetworkInfo
  */
-export type NetworkConfig = keyof typeof STANDARD_NETWORKS | NetworkInfo;
+export type NetworkConfig = StandardNetworkId | NetworkInfo;
+
+/** Check whether an external string identifies a built-in XRPL network. */
+export function isStandardNetworkId(networkId: string): networkId is StandardNetworkId {
+  return Object.prototype.hasOwnProperty.call(STANDARD_NETWORKS, networkId);
+}
 
 /**
  * Account information returned after connection

--- a/packages/react/tests/publish/types-react-esm.mts
+++ b/packages/react/tests/publish/types-react-esm.mts
@@ -7,6 +7,7 @@ import {
   useWallet,
   useWalletModal,
   type WalletConnectorProps,
+  type XrplConnectConfig,
 } from '@xrpl-commons/xrpl-connect-react';
 import type {
   ManagedSignedMessage,
@@ -15,6 +16,17 @@ import type {
   WalletError,
 } from 'xrpl-connect';
 
+const mainnetConfig: XrplConnectConfig = { adapters: [], network: 'mainnet' };
+const customNetworkConfig: XrplConnectConfig = {
+  adapters: [],
+  network: { id: 'sidechain', name: 'Sidechain', wss: 'wss://sidechain.example.com' },
+};
+const invalidNetworkConfig: XrplConnectConfig = {
+  adapters: [],
+  // @ts-expect-error React's published config must reject arbitrary string network IDs.
+  network: 'sidechain',
+};
+
 const provider: ComponentType<ComponentProps<typeof XrplConnectProvider>> = XrplConnectProvider;
 const connector: ComponentType<WalletConnectorProps> = WalletConnector;
 const signer = null as unknown as ReturnType<typeof useSigner>;
@@ -22,4 +34,15 @@ const signedTransaction: Promise<ManagedSignedTransaction> = signer.sign({} as T
 const signedMessage: Promise<ManagedSignedMessage> = signer.signMessage('message');
 const errorGuard: (error: unknown) => error is WalletError = isWalletError;
 
-void [provider, connector, signedTransaction, signedMessage, errorGuard, useWallet, useWalletModal];
+void [
+  provider,
+  connector,
+  signedTransaction,
+  signedMessage,
+  errorGuard,
+  useWallet,
+  useWalletModal,
+  mainnetConfig,
+  customNetworkConfig,
+  invalidNetworkConfig,
+];

--- a/packages/vue/tests/publish/types-vue-esm.mts
+++ b/packages/vue/tests/publish/types-vue-esm.mts
@@ -6,6 +6,7 @@ import {
   useSigner,
   useWallet,
   useWalletModal,
+  type XrplConnectConfig,
 } from '@xrpl-commons/xrpl-connect-vue';
 import type {
   ManagedSignedMessage,
@@ -14,6 +15,17 @@ import type {
   WalletError,
 } from 'xrpl-connect';
 
+const mainnetConfig: XrplConnectConfig = { adapters: [], network: 'mainnet' };
+const customNetworkConfig: XrplConnectConfig = {
+  adapters: [],
+  network: { id: 'sidechain', name: 'Sidechain', wss: 'wss://sidechain.example.com' },
+};
+const invalidNetworkConfig: XrplConnectConfig = {
+  adapters: [],
+  // @ts-expect-error Vue's published config must reject arbitrary string network IDs.
+  network: 'sidechain',
+};
+
 const plugin: Plugin = createXrplConnect({ adapters: [] });
 const connector: Component = WalletConnector;
 const signer = null as unknown as ReturnType<typeof useSigner>;
@@ -21,4 +33,15 @@ const signedTransaction: Promise<ManagedSignedTransaction> = signer.sign({} as T
 const signedMessage: Promise<ManagedSignedMessage> = signer.signMessage('message');
 const errorGuard: (error: unknown) => error is WalletError = isWalletError;
 
-void [plugin, connector, signedTransaction, signedMessage, errorGuard, useWallet, useWalletModal];
+void [
+  plugin,
+  connector,
+  signedTransaction,
+  signedMessage,
+  errorGuard,
+  useWallet,
+  useWalletModal,
+  mainnetConfig,
+  customNetworkConfig,
+  invalidNetworkConfig,
+];

--- a/packages/xrpl-connect/tests/publish/types-esm.mts
+++ b/packages/xrpl-connect/tests/publish/types-esm.mts
@@ -10,12 +10,26 @@ import {
   type CrossmarkClient,
   type LedgerConnectOptions,
   type MetaMaskSnapAdapterOptions,
+  type NetworkConfig,
+  type NetworkInfo,
+  type StandardNetworkId,
   type WalletConnectConnectOptions,
   type WalletConnectorElementInstance,
   type XamanConnectOptions,
   type XamanReturnUrl,
   type XyraConnectOptions,
 } from 'xrpl-connect';
+
+const standardNetworkId: StandardNetworkId = 'mainnet';
+const standardNetworkConfig: NetworkConfig = standardNetworkId;
+const customNetwork: NetworkInfo = {
+  id: 'sidechain',
+  name: 'Sidechain',
+  wss: 'wss://sidechain.example.com',
+};
+const customNetworkConfig: NetworkConfig = customNetwork;
+// @ts-expect-error Arbitrary string IDs must not survive the published declaration rollup.
+const invalidNetworkConfig: NetworkConfig = 'sidechain';
 
 const connectOptions: [
   ConnectOptions<LedgerConnectOptions>,
@@ -74,6 +88,9 @@ const metamaskAdapter = new MetaMaskSnapAdapter(metamaskOptions);
 
 void [
   connectOptions,
+  standardNetworkConfig,
+  customNetworkConfig,
+  invalidNetworkConfig,
   xamanConstructor,
   xamanReturnUrl,
   oauthConstructor,


### PR DESCRIPTION
## Summary
- narrow public network IDs to `mainnet`, `testnet`, and `devnet` while preserving custom `NetworkInfo` configurations
- guard external wallet-provided strings before standard-network lookup
- verify the narrowed type in packed umbrella, React, and Vue declarations

## Test plan
- [x] `pnpm format:check`
- [x] `pnpm exec vp check`
- [x] `pnpm --filter @xrpl-connect/core test`
- [x] `pnpm build`
- [x] `pnpm --filter xrpl-connect test:publish`
- [x] `pnpm test`
- [x] `git diff --check`

Fixes #148
