### PR TITLE
feat: make Vue wallet modal awaitable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Vue: make `useWalletModal()` awaitable with connector readiness, `openAndWait()`, explicit missing-connector failures, and deterministic ownership when multiple connectors are mounted (#145).
+
 ### Fixed
 
 - xrpl-connect (meta-bundle): emit the Xaman mock-WebSocket constructor without an optional chain so Nuxt 4 and Vite/Rollup production builds can consume the published ESM artifact. Consumers can remove `patch-package` or transpilation workarounds for `xrpl-connect.mjs` (#141).

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -504,11 +504,14 @@ composables and `<WalletConnector>` must run beneath that installation.
 
 - `useWallet()` returns the manager, readonly `connected`, `account`, `network`, `connecting`, and `error` refs, plus `connect` and `disconnect`.
 - `useSigner()` returns `sign`, `signAndSubmit`, and `signMessage`.
-- `useWalletModal()` returns `open` and `close` for the most recently mounted connector.
+- `useWalletModal()` returns readonly `ready`, `open(): Promise<void>`,
+  `openAndWait(): Promise<AccountInfo>`, and `close(): void` for the most recently registered
+  connector. Awaitable calls reject with a namespaced setup error until a connector registers.
 
 Call `connect(walletId, options?)` for a headless connection flow, or mount at least one
-connector before using the modal composable. Gate optional signing operations with
-`manager.supports(...)`.
+connector before using the modal composable. When several connectors are mounted, modal
+ownership follows registration order and falls back when the active connector unmounts. Gate
+optional signing operations with `manager.supports(...)`.
 
 ### WalletConnector
 

--- a/docs/guide/frameworks/vue.md
+++ b/docs/guide/frameworks/vue.md
@@ -46,10 +46,17 @@ from other Vue applications on the same page and are released when the app unmou
 ## Wallet state and modal
 
 `useWallet()` returns readonly Vue refs, so use them directly in templates and through `.value`
-in scripts. `useWalletModal()` controls the most recently mounted connector.
+in scripts. `useWalletModal()` returns a readonly `ready` ref, `open(): Promise<void>`,
+`openAndWait(): Promise<AccountInfo>`, and `close(): void` for the active connector. Await
+`open()` to observe availability-check failures, or await `openAndWait()` when the caller needs
+the connected account; `openAndWait()` rejects if opening fails or the modal closes first.
 
-All composables must run below an application that installed `createXrplConnect()`. Keep one
-mounted `<WalletConnector>` for predictable modal ownership.
+All composables must run below an application that installed `createXrplConnect()`. `ready`
+becomes `true` after a connector registers and returns to `false` after the last connector
+unmounts. Calling `open()` or `openAndWait()` while it is `false` rejects with a namespaced setup
+error. If several connectors are mounted, the most recently registered connector owns modal
+calls; unmounting it falls back to the previous connector. Keep one mounted `<WalletConnector>`
+when that ownership rule is unnecessary.
 
 For a headless flow, connect directly by adapter ID:
 
@@ -66,11 +73,11 @@ reactive listeners are ready.
 import { WalletConnector, useWallet, useWalletModal } from '@xrpl-commons/xrpl-connect-vue';
 
 const { connected, account, connecting, error, disconnect } = useWallet();
-const { open } = useWalletModal();
+const { ready, open } = useWalletModal();
 </script>
 
 <template>
-  <button v-if="!connected" :disabled="connecting" @click="open">
+  <button v-if="!connected" :disabled="!ready || connecting" @click="open">
     {{ connecting ? 'Connecting…' : 'Connect wallet' }}
   </button>
   <button v-else @click="disconnect">Disconnect {{ account?.address }}</button>
@@ -141,7 +148,7 @@ async function sendPayment() {
 - `useWallet()` returns `manager`, `connected`, `account`, `network`, `connecting`, `error`,
   `connect`, and `disconnect`.
 - `useSigner()` returns `sign`, `signAndSubmit`, and `signMessage`.
-- `useWalletModal()` returns `open` and `close`.
+- `useWalletModal()` returns readonly `ready`, awaitable `open` and `openAndWait`, and `close`.
 - `<WalletConnector>` wraps the browser custom element with typed Vue props and events.
 
 `WalletConnector` accepts `primaryWallet`, `wallets`, `theme`, and `cssVars`, and emits

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -40,11 +40,11 @@ import {
 
 const { connected, account, error, disconnect } = useWallet();
 const { signAndSubmit } = useSigner();
-const { open } = useWalletModal();
+const { ready, open } = useWalletModal();
 </script>
 
 <template>
-  <button v-if="!connected" @click="open">Connect wallet</button>
+  <button v-if="!connected" :disabled="!ready" @click="open">Connect wallet</button>
   <button v-else @click="disconnect">Disconnect {{ account?.address }}</button>
   <p v-if="error">Error [{{ error.code }}]: {{ error.message }}</p>
   <WalletConnector theme="dark" />
@@ -57,7 +57,9 @@ const { open } = useWalletModal();
 - `useWallet()` exposes `manager`, readonly `connected`, `account`, `network`, `connecting`,
   and `error` refs, plus `connect` and `disconnect`.
 - `useSigner()` exposes `sign`, `signAndSubmit`, and `signMessage`.
-- `useWalletModal()` exposes `open` and `close` for the active connector.
+- `useWalletModal()` exposes a readonly `ready` ref, awaitable `open()` and `openAndWait()`
+  methods, and `close()` for the active connector. `openAndWait()` resolves with the connected
+  account and rejects if opening fails or the modal closes first.
 - `<WalletConnector>` accepts `primaryWallet`, `wallets`, `theme`, and `cssVars`, and emits
   `connecting`, `connect`, and typed `error` events.
 
@@ -66,3 +68,8 @@ side-effect import is not needed. Importing `@xrpl-commons/xrpl-connect-vue` is 
 installation, injected composable calls, and wallet UI rendering must stay on the client. In
 Nuxt, put composable consumers in `.client.vue` components or wholly below a client-only child
 boundary; wrapping only the template does not stop universal setup from running during SSR.
+
+Modal ownership follows registration order: the most recently registered connector is active,
+and unmounting it falls back to the previous connector. `ready` stays `true` while any connector
+is registered. Calling `open()` or `openAndWait()` before registration rejects with a namespaced
+setup error instead of silently doing nothing.

--- a/packages/vue/src/WalletConnector.ts
+++ b/packages/vue/src/WalletConnector.ts
@@ -1,4 +1,13 @@
-import { defineComponent, h, onBeforeUnmount, onMounted, ref, type PropType } from 'vue';
+import {
+  defineComponent,
+  h,
+  onActivated,
+  onBeforeUnmount,
+  onDeactivated,
+  onMounted,
+  ref,
+  type PropType,
+} from 'vue';
 import {
   createWalletError,
   getErrorMessage,
@@ -80,32 +89,43 @@ export const WalletConnector = defineComponent({
       emit('error', error);
     };
 
-    onMounted(() => {
+    const activateConnector = () => {
+      if (active) return;
       active = true;
-      context.manager.on('connect', onManagerConnect);
-      context.manager.on('disconnect', onManagerDisconnect);
-      if (context.manager.connected && context.manager.account)
-        onManagerConnect(context.manager.account);
-
       void customElements.whenDefined('xrpl-wallet-connector').then(() => {
-        if (!active || !element.value) return;
+        if (!active || registered || !element.value) return;
         element.value.setWalletManager(context.manager);
         element.value.addEventListener('connecting', onConnecting);
         element.value.addEventListener('error', onError);
         context.registerConnector(element.value);
         registered = element.value;
       });
-    });
+    };
 
-    onBeforeUnmount(() => {
+    const deactivateConnector = () => {
       active = false;
-      context.manager.off('connect', onManagerConnect);
-      context.manager.off('disconnect', onManagerDisconnect);
       if (!registered) return;
       registered.removeEventListener('connecting', onConnecting);
       registered.removeEventListener('error', onError);
       context.unregisterConnector(registered);
       registered = null;
+    };
+
+    onMounted(() => {
+      context.manager.on('connect', onManagerConnect);
+      context.manager.on('disconnect', onManagerDisconnect);
+      if (context.manager.connected && context.manager.account)
+        onManagerConnect(context.manager.account);
+      activateConnector();
+    });
+
+    onActivated(activateConnector);
+    onDeactivated(deactivateConnector);
+
+    onBeforeUnmount(() => {
+      context.manager.off('connect', onManagerConnect);
+      context.manager.off('disconnect', onManagerDisconnect);
+      deactivateConnector();
     });
 
     return () =>

--- a/packages/vue/src/WalletConnector.ts
+++ b/packages/vue/src/WalletConnector.ts
@@ -105,6 +105,7 @@ export const WalletConnector = defineComponent({
       registered.removeEventListener('connecting', onConnecting);
       registered.removeEventListener('error', onError);
       context.unregisterConnector(registered);
+      registered = null;
     });
 
     return () =>

--- a/packages/vue/src/context.ts
+++ b/packages/vue/src/context.ts
@@ -39,11 +39,13 @@ export interface XrplConnectContextValue {
 export type XrplConnectConfig = WalletManagerOptions;
 
 interface InternalContext extends XrplConnectContextValue {
+  ready: Readonly<Ref<boolean>>;
   registerConnector(element: WalletConnectorElement): void;
   unregisterConnector(element: WalletConnectorElement): void;
   reportModalConnecting(): void;
   reportModalError(error: WalletError): void;
-  openModal(): void;
+  openModal(): Promise<void>;
+  openAndWaitModal(): Promise<AccountInfo>;
   closeModal(): void;
 }
 
@@ -58,6 +60,7 @@ export function createXrplConnect(config: XrplConnectConfig): Plugin {
       const network = shallowRef(manager.account?.network ?? null);
       const connecting = shallowRef(false);
       const error = shallowRef<WalletError | null>(null);
+      const ready = shallowRef(false);
       const connectors = new Set<WalletConnectorElement>();
       const connectionAttempts = new Set<symbol>();
       let modalConnecting = false;
@@ -90,6 +93,23 @@ export function createXrplConnect(config: XrplConnectConfig): Plugin {
         account.value = manager.account;
         network.value = manager.account?.network ?? null;
       };
+      const getActiveConnector = (): WalletConnectorElement => {
+        const mountedConnectors = [...connectors];
+        const connector = mountedConnectors[mountedConnectors.length - 1];
+        if (connector) return connector;
+        throw new Error(
+          'xrpl-connect/vue: no <WalletConnector> is registered. Mount <WalletConnector> before calling useWalletModal().'
+        );
+      };
+      const runWithActiveConnector = <T>(
+        operation: (connector: WalletConnectorElement) => Promise<T>
+      ): Promise<T> => {
+        try {
+          return Promise.resolve(operation(getActiveConnector()));
+        } catch (value) {
+          return Promise.reject(value);
+        }
+      };
       const onConnect = () => {
         error.value = null;
         modalConnecting = false;
@@ -119,6 +139,7 @@ export function createXrplConnect(config: XrplConnectConfig): Plugin {
         network: readonly(network),
         connecting: readonly(connecting),
         error: readonly(error),
+        ready: readonly(ready),
         async connect(walletId, options) {
           const attempt = beginConnectionAttempt();
           let failure: unknown;
@@ -137,8 +158,14 @@ export function createXrplConnect(config: XrplConnectConfig): Plugin {
           cancelConnectionState();
           await manager.disconnect();
         },
-        registerConnector: (element) => connectors.add(element),
-        unregisterConnector: (element) => connectors.delete(element),
+        registerConnector(element) {
+          connectors.add(element);
+          ready.value = true;
+        },
+        unregisterConnector(element) {
+          connectors.delete(element);
+          ready.value = connectors.size > 0;
+        },
         reportModalConnecting() {
           modalConnecting = true;
           error.value = null;
@@ -150,8 +177,10 @@ export function createXrplConnect(config: XrplConnectConfig): Plugin {
           syncConnecting();
         },
         openModal() {
-          const mountedConnectors = [...connectors];
-          mountedConnectors[mountedConnectors.length - 1]?.open();
+          return runWithActiveConnector((connector) => connector.open());
+        },
+        openAndWaitModal() {
+          return runWithActiveConnector((connector) => connector.openAndWait());
         },
         closeModal() {
           const mountedConnectors = [...connectors];
@@ -193,6 +222,7 @@ export function createXrplConnect(config: XrplConnectConfig): Plugin {
         manager.off('networkChanged', onNetworkChanged);
         manager.off('error', onError);
         connectors.clear();
+        ready.value = false;
         void manager.disconnect().catch(() => undefined);
       });
     },

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -37,6 +37,6 @@ export function useSigner() {
 }
 
 export function useWalletModal() {
-  const { openModal, closeModal } = useXrplConnectContext();
-  return { open: openModal, close: closeModal };
+  const { ready, openModal, openAndWaitModal, closeModal } = useXrplConnectContext();
+  return { ready, open: openModal, openAndWait: openAndWaitModal, close: closeModal };
 }

--- a/packages/vue/tests/publish/types-vue-cjs.cts
+++ b/packages/vue/tests/publish/types-vue-cjs.cts
@@ -1,4 +1,4 @@
-import type { Component, Plugin } from 'vue';
+import type { Component, Plugin, Ref } from 'vue';
 import {
   WalletConnector,
   createXrplConnect,
@@ -11,14 +11,32 @@ import type {
   ManagedSignedMessage,
   ManagedSignedTransaction,
   Transaction,
+  AccountInfo,
   WalletError,
 } from 'xrpl-connect';
 
 const plugin: Plugin = createXrplConnect({ adapters: [] });
 const connector: Component = WalletConnector;
+const modal = null as unknown as ReturnType<typeof useWalletModal>;
+const modalReady: Readonly<Ref<boolean>> = modal.ready;
+// @ts-expect-error Connector readiness is exposed as a readonly ref.
+modal.ready.value = true;
+const modalOpen: Promise<void> = modal.open();
+const modalAccount: Promise<AccountInfo> = modal.openAndWait();
 const signer = null as unknown as ReturnType<typeof useSigner>;
 const signedTransaction: Promise<ManagedSignedTransaction> = signer.sign({} as Transaction);
 const signedMessage: Promise<ManagedSignedMessage> = signer.signMessage('message');
 const errorGuard: (error: unknown) => error is WalletError = isWalletError;
 
-void [plugin, connector, signedTransaction, signedMessage, errorGuard, useWallet, useWalletModal];
+void [
+  plugin,
+  connector,
+  modalReady,
+  modalOpen,
+  modalAccount,
+  signedTransaction,
+  signedMessage,
+  errorGuard,
+  useWallet,
+  useWalletModal,
+];

--- a/packages/vue/tests/publish/types-vue-esm.mts
+++ b/packages/vue/tests/publish/types-vue-esm.mts
@@ -1,4 +1,4 @@
-import type { Component, Plugin } from 'vue';
+import type { Component, Plugin, Ref } from 'vue';
 import {
   WalletConnector,
   createXrplConnect,
@@ -9,6 +9,7 @@ import {
   type XrplConnectConfig,
 } from '@xrpl-commons/xrpl-connect-vue';
 import type {
+  AccountInfo,
   ManagedSignedMessage,
   ManagedSignedTransaction,
   Transaction,
@@ -28,6 +29,12 @@ const invalidNetworkConfig: XrplConnectConfig = {
 
 const plugin: Plugin = createXrplConnect({ adapters: [] });
 const connector: Component = WalletConnector;
+const modal = null as unknown as ReturnType<typeof useWalletModal>;
+const modalReady: Readonly<Ref<boolean>> = modal.ready;
+// @ts-expect-error Connector readiness is exposed as a readonly ref.
+modal.ready.value = true;
+const modalOpen: Promise<void> = modal.open();
+const modalAccount: Promise<AccountInfo> = modal.openAndWait();
 const signer = null as unknown as ReturnType<typeof useSigner>;
 const signedTransaction: Promise<ManagedSignedTransaction> = signer.sign({} as Transaction);
 const signedMessage: Promise<ManagedSignedMessage> = signer.signMessage('message');
@@ -36,6 +43,9 @@ const errorGuard: (error: unknown) => error is WalletError = isWalletError;
 void [
   plugin,
   connector,
+  modalReady,
+  modalOpen,
+  modalAccount,
   signedTransaction,
   signedMessage,
   errorGuard,

--- a/packages/vue/tests/vue.test.ts
+++ b/packages/vue/tests/vue.test.ts
@@ -1,4 +1,4 @@
-import { Comment, createApp, createSSRApp, defineComponent, h, nextTick } from 'vue';
+import { Comment, createApp, createSSRApp, defineComponent, h, nextTick, ref } from 'vue';
 import { renderToString } from 'vue/server-renderer';
 import type { AccountInfo, WalletAdapter } from '@xrpl-connect/core';
 import { createWalletError, MemoryStorageAdapter, WalletErrorCode } from '@xrpl-connect/core';
@@ -23,6 +23,13 @@ function deferred<T>() {
     resolve = resolvePromise;
   });
   return { promise, resolve };
+}
+
+interface TestWalletConnectorElement extends HTMLElement {
+  manager: unknown;
+  opened: boolean;
+  openError: Error | null;
+  resolveConnection(account: AccountInfo): void;
 }
 
 function makeAdapter(overrides: Partial<WalletAdapter> = {}): WalletAdapter {
@@ -60,6 +67,29 @@ function mountWithPlugin<T>(setup: () => T, adapters = [makeAdapter()]) {
     root,
     get exposed() {
       return exposed as T;
+    },
+  };
+}
+
+function mountModal(renderConnector: () => ReturnType<typeof h>) {
+  let modal: ReturnType<typeof useWalletModal> | undefined;
+  const root = document.createElement('div');
+  document.body.append(root);
+  const app = createApp(
+    defineComponent({
+      setup() {
+        modal = useWalletModal();
+        return renderConnector;
+      },
+    })
+  );
+  app.use(createXrplConnect({ adapters: [makeAdapter()], storage: new MemoryStorageAdapter() }));
+  app.mount(root);
+  return {
+    app,
+    root,
+    get modal() {
+      return modal!;
     },
   };
 }
@@ -303,6 +333,11 @@ describe('<WalletConnector>', () => {
       () => Promise<AccountInfo>
     >();
     expectTypeOf<WalletConnectorElement['toggle']>().toEqualTypeOf<() => void>();
+    type WalletModal = ReturnType<typeof useWalletModal>;
+    expectTypeOf<WalletModal['ready']['value']>().toEqualTypeOf<boolean>();
+    expectTypeOf<WalletModal['open']>().toEqualTypeOf<() => Promise<void>>();
+    expectTypeOf<WalletModal['openAndWait']>().toEqualTypeOf<() => Promise<AccountInfo>>();
+    expectTypeOf<WalletModal['close']>().toEqualTypeOf<() => void>();
   });
 
   beforeAll(() => {
@@ -312,17 +347,144 @@ describe('<WalletConnector>', () => {
       class extends HTMLElement {
         manager: unknown = null;
         opened = false;
+        openError: Error | null = null;
+        private waiters = new Set<{
+          resolve: (account: AccountInfo) => void;
+          reject: (error: Error) => void;
+        }>();
         setWalletManager(manager: unknown) {
           this.manager = manager;
         }
-        open() {
+        open(): Promise<void> {
+          if (this.openError) return Promise.reject(this.openError);
           this.opened = true;
+          return Promise.resolve();
+        }
+        openAndWait(): Promise<AccountInfo> {
+          const opening = this.open();
+          return new Promise<AccountInfo>((resolve, reject) => {
+            const waiter = { resolve, reject };
+            this.waiters.add(waiter);
+            void opening.catch((error: unknown) => {
+              if (!this.waiters.delete(waiter)) return;
+              reject(error instanceof Error ? error : new Error(String(error)));
+            });
+          });
         }
         close() {
           this.opened = false;
+          this.rejectWaiters(new Error('Modal closed before a wallet was connected.'));
+        }
+        resolveConnection(account: AccountInfo) {
+          for (const waiter of this.waiters) waiter.resolve(account);
+          this.waiters.clear();
+        }
+        disconnectedCallback() {
+          this.rejectWaiters(new Error('Wallet connector disconnected.'));
+        }
+        private rejectWaiters(error: Error) {
+          for (const waiter of this.waiters) waiter.reject(error);
+          this.waiters.clear();
         }
       }
     );
+  });
+
+  it('rejects modal calls until a connector is registered', async () => {
+    const mounted = mountWithPlugin(() => useWalletModal());
+
+    expect(mounted.exposed.ready.value).toBe(false);
+    await expect(mounted.exposed.open()).rejects.toThrow(/no <WalletConnector> is registered/);
+    await expect(mounted.exposed.openAndWait()).rejects.toThrow(
+      /no <WalletConnector> is registered/
+    );
+    expect(() => mounted.exposed.close()).not.toThrow();
+    mounted.app.unmount();
+  });
+
+  it('tracks asynchronous connector registration and unmount', async () => {
+    const registration = deferred<CustomElementConstructor>();
+    const whenDefined = vi
+      .spyOn(customElements, 'whenDefined')
+      .mockReturnValueOnce(registration.promise);
+    const mounted = mountModal(() => h(WalletConnector));
+
+    expect(mounted.modal.ready.value).toBe(false);
+    await expect(mounted.modal.open()).rejects.toThrow(/no <WalletConnector> is registered/);
+
+    registration.resolve(customElements.get('xrpl-wallet-connector')!);
+    await vi.waitFor(() => expect(mounted.modal.ready.value).toBe(true));
+
+    mounted.app.unmount();
+    expect(mounted.modal.ready.value).toBe(false);
+    whenDefined.mockRestore();
+  });
+
+  it('forwards open failures from the active connector', async () => {
+    const mounted = mountModal(() => h(WalletConnector));
+    await vi.waitFor(() => expect(mounted.modal.ready.value).toBe(true));
+    const element = mounted.root.querySelector(
+      'xrpl-wallet-connector'
+    ) as TestWalletConnectorElement;
+    const failure = new Error('availability check failed');
+    element.openError = failure;
+
+    await expect(mounted.modal.open()).rejects.toBe(failure);
+    mounted.app.unmount();
+  });
+
+  it('forwards openAndWait success and close-before-connect rejection', async () => {
+    const mounted = mountModal(() => h(WalletConnector));
+    await vi.waitFor(() => expect(mounted.modal.ready.value).toBe(true));
+    const element = mounted.root.querySelector(
+      'xrpl-wallet-connector'
+    ) as TestWalletConnectorElement;
+
+    const failure = new Error('availability check failed');
+    element.openError = failure;
+    await expect(mounted.modal.openAndWait()).rejects.toBe(failure);
+    element.openError = null;
+
+    const closed = mounted.modal.openAndWait();
+    mounted.modal.close();
+    await expect(closed).rejects.toThrow(/closed/i);
+
+    const connected = mounted.modal.openAndWait();
+    await vi.waitFor(() => expect(element.opened).toBe(true));
+    element.resolveConnection(ACCOUNT);
+    await expect(connected).resolves.toEqual(ACCOUNT);
+    mounted.app.unmount();
+  });
+
+  it('uses the newest connector and falls back when it unmounts', async () => {
+    const showSecond = ref(true);
+    const mounted = mountModal(() =>
+      h('div', [
+        h(WalletConnector, { key: 'first' }),
+        showSecond.value ? h(WalletConnector, { key: 'second' }) : null,
+      ])
+    );
+    await vi.waitFor(() =>
+      expect(mounted.root.querySelectorAll('xrpl-wallet-connector')).toHaveLength(2)
+    );
+    await vi.waitFor(() => expect(mounted.modal.ready.value).toBe(true));
+    const [first, second] = [
+      ...mounted.root.querySelectorAll<TestWalletConnectorElement>('xrpl-wallet-connector'),
+    ];
+
+    await mounted.modal.open();
+    expect(first.opened).toBe(false);
+    expect(second.opened).toBe(true);
+
+    showSecond.value = false;
+    await nextTick();
+    expect(mounted.modal.ready.value).toBe(true);
+    first.opened = false;
+    await mounted.modal.open();
+    expect(first.opened).toBe(true);
+
+    mounted.app.unmount();
+    expect(mounted.modal.ready.value).toBe(false);
   });
 
   it('binds the manager, forwards attributes/events, and supports modal control', async () => {
@@ -383,7 +545,7 @@ describe('<WalletConnector>', () => {
 
     await wallet!.connect('fake');
     expect(onConnect).toHaveBeenCalledWith(ACCOUNT);
-    modal!.open();
+    await modal!.open();
     expect(element.opened).toBe(true);
     modal!.close();
     expect(element.opened).toBe(false);

--- a/packages/vue/tests/vue.test.ts
+++ b/packages/vue/tests/vue.test.ts
@@ -1,4 +1,13 @@
-import { Comment, createApp, createSSRApp, defineComponent, h, nextTick, ref } from 'vue';
+import {
+  Comment,
+  createApp,
+  createSSRApp,
+  defineComponent,
+  h,
+  KeepAlive,
+  nextTick,
+  ref,
+} from 'vue';
 import { renderToString } from 'vue/server-renderer';
 import type { AccountInfo, WalletAdapter } from '@xrpl-connect/core';
 import { createWalletError, MemoryStorageAdapter, WalletErrorCode } from '@xrpl-connect/core';
@@ -420,6 +429,36 @@ describe('<WalletConnector>', () => {
     whenDefined.mockRestore();
   });
 
+  it('tracks connector deactivation and reactivation through KeepAlive', async () => {
+    const showConnector = ref(true);
+    const Placeholder = defineComponent(() => () => null);
+    const mounted = mountModal(() =>
+      h(KeepAlive, null, {
+        default: () => (showConnector.value ? h(WalletConnector) : h(Placeholder)),
+      })
+    );
+    await vi.waitFor(() => expect(mounted.modal.ready.value).toBe(true));
+    const element = mounted.root.querySelector(
+      'xrpl-wallet-connector'
+    ) as TestWalletConnectorElement;
+
+    showConnector.value = false;
+    await nextTick();
+    expect(element.isConnected).toBe(false);
+    expect(mounted.modal.ready.value).toBe(false);
+    await expect(mounted.modal.openAndWait()).rejects.toThrow(/no <WalletConnector> is registered/);
+
+    showConnector.value = true;
+    await nextTick();
+    await vi.waitFor(() => expect(mounted.modal.ready.value).toBe(true));
+    expect(mounted.root.querySelector('xrpl-wallet-connector')).toBe(element);
+    await mounted.modal.open();
+    expect(element.opened).toBe(true);
+
+    mounted.app.unmount();
+    expect(mounted.modal.ready.value).toBe(false);
+  });
+
   it('forwards open failures from the active connector', async () => {
     const mounted = mountModal(() => h(WalletConnector));
     await vi.waitFor(() => expect(mounted.modal.ready.value).toBe(true));
@@ -456,12 +495,18 @@ describe('<WalletConnector>', () => {
     mounted.app.unmount();
   });
 
-  it('uses the newest connector and falls back when it unmounts', async () => {
+  it('uses the newest connector and falls back while it is deactivated', async () => {
     const showSecond = ref(true);
+    const Placeholder = defineComponent(() => () => null);
     const mounted = mountModal(() =>
       h('div', [
         h(WalletConnector, { key: 'first' }),
-        showSecond.value ? h(WalletConnector, { key: 'second' }) : null,
+        h(KeepAlive, null, {
+          default: () =>
+            showSecond.value
+              ? h(WalletConnector, { key: 'second' })
+              : h(Placeholder, { key: 'placeholder' }),
+        }),
       ])
     );
     await vi.waitFor(() =>
@@ -478,10 +523,20 @@ describe('<WalletConnector>', () => {
 
     showSecond.value = false;
     await nextTick();
+    expect(second.isConnected).toBe(false);
     expect(mounted.modal.ready.value).toBe(true);
     first.opened = false;
     await mounted.modal.open();
     expect(first.opened).toBe(true);
+
+    showSecond.value = true;
+    await nextTick();
+    await Promise.resolve();
+    first.opened = false;
+    second.opened = false;
+    await mounted.modal.open();
+    expect(first.opened).toBe(false);
+    expect(second.opened).toBe(true);
 
     mounted.app.unmount();
     expect(mounted.modal.ready.value).toBe(false);


### PR DESCRIPTION
## Summary
- Expose readonly connector readiness plus awaitable `open()` and `openAndWait()` methods from Vue's `useWalletModal()`.
- Reject modal calls before connector registration and define latest-registered ownership with fallback on unmount.
- Cover registration timing, failures, cancellation, successful connection, multiple connectors, published types, and documentation.

## Test plan
- [x] `pnpm build`
- [x] `pnpm --filter @xrpl-commons/xrpl-connect-vue run build`
- [x] `pnpm --filter @xrpl-commons/xrpl-connect-vue run test`
- [x] `pnpm --filter @xrpl-commons/xrpl-connect-vue run type-check`
- [x] `pnpm exec tsc -p packages/vue/tests/publish/tsconfig.vue.json`
- [x] `pnpm exec vp check`

Fixes #145

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
