### PR TITLE
feat: expose Vue unavailable-wallet prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Vue: make `useWalletModal()` awaitable with connector readiness, `openAndWait()`, explicit missing-connector failures, and deterministic ownership when multiple connectors are mounted (#145).
+- Vue: expose the native unavailable-wallet display behavior through the typed `showUnavailable` component prop (#146).
 
 ### Fixed
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -515,10 +515,13 @@ optional signing operations with `manager.supports(...)`.
 
 ### WalletConnector
 
-`<WalletConnector />` accepts `primaryWallet`, `wallets`, `theme`, and `cssVars`, and emits
-`connecting`, `connect`, and typed `error` events. Public types include `XrplConnectConfig`,
-`XrplConnectContextValue`, `WalletConnectorElement`, and `WalletConnectorTheme`. The package
-also re-exports the core wallet error classes, enums, and `isWalletError` guard. See the
+`<WalletConnector />` accepts `primaryWallet`, `wallets`, `showUnavailable`, `theme`, and
+`cssVars`, and emits `connecting`, `connect`, and typed `error` events. The camelCase
+`showUnavailable` Vue prop maps to the native `show-unavailable` boolean attribute: unavailable
+wallets are hidden by default, while `true` shows an Install action when a download URL exists or
+a disabled Unavailable row otherwise. Public types include `XrplConnectConfig`,
+`XrplConnectContextValue`, `WalletConnectorElement`, and `WalletConnectorTheme`. The package also
+re-exports the core wallet error classes, enums, and `isWalletError` guard. See the
 [Vue guide](/guide/frameworks/vue) and [Nuxt guide](/guide/frameworks/nuxt).
 
 ## Direct Wallet SDK Access

--- a/docs/guide/frameworks/vue.md
+++ b/docs/guide/frameworks/vue.md
@@ -87,6 +87,7 @@ const { ready, open } = useWalletModal();
   <WalletConnector
     primary-wallet="xaman"
     :wallets="['xaman', 'crossmark']"
+    showUnavailable
     theme="dark"
     :css-vars="{ '--xc-primary-color': '#a78bfa' }"
     @connecting="(walletId) => console.log('Connecting', walletId)"
@@ -151,9 +152,12 @@ async function sendPayment() {
 - `useWalletModal()` returns readonly `ready`, awaitable `open` and `openAndWait`, and `close`.
 - `<WalletConnector>` wraps the browser custom element with typed Vue props and events.
 
-`WalletConnector` accepts `primaryWallet`, `wallets`, `theme`, and `cssVars`, and emits
-`connecting`, `connect`, and typed `error` events. Use `manager.supports('signMessage')` before
-showing optional signing actions.
+`WalletConnector` accepts `primaryWallet`, `wallets`, `showUnavailable`, `theme`, and `cssVars`,
+and emits `connecting`, `connect`, and typed `error` events. Unavailable wallets are hidden by
+default. Set the camelCase Vue prop `showUnavailable` to show an Install action when an adapter
+provides a download URL, or a disabled Unavailable row when it does not. Removing the prop or
+setting it to `false` removes the native `show-unavailable` attribute. Use
+`manager.supports('signMessage')` before showing optional signing actions.
 
 ## SSR and Nuxt
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -47,7 +47,7 @@ const { ready, open } = useWalletModal();
   <button v-if="!connected" :disabled="!ready" @click="open">Connect wallet</button>
   <button v-else @click="disconnect">Disconnect {{ account?.address }}</button>
   <p v-if="error">Error [{{ error.code }}]: {{ error.message }}</p>
-  <WalletConnector theme="dark" />
+  <WalletConnector theme="dark" showUnavailable />
 </template>
 ```
 
@@ -60,8 +60,10 @@ const { ready, open } = useWalletModal();
 - `useWalletModal()` exposes a readonly `ready` ref, awaitable `open()` and `openAndWait()`
   methods, and `close()` for the active connector. `openAndWait()` resolves with the connected
   account and rejects if opening fails or the modal closes first.
-- `<WalletConnector>` accepts `primaryWallet`, `wallets`, `theme`, and `cssVars`, and emits
-  `connecting`, `connect`, and typed `error` events.
+- `<WalletConnector>` accepts `primaryWallet`, `wallets`, `showUnavailable`, `theme`, and
+  `cssVars`, and emits `connecting`, `connect`, and typed `error` events. Unavailable wallets are
+  hidden by default; set the camelCase Vue prop `showUnavailable` to show an Install action when
+  the adapter provides a download URL, or a disabled Unavailable row otherwise.
 
 The named `xrpl-connect` import also registers the wallet connector custom element, so a separate
 side-effect import is not needed. Importing `@xrpl-commons/xrpl-connect-vue` is SSR-safe, but plugin

--- a/packages/vue/src/WalletConnector.ts
+++ b/packages/vue/src/WalletConnector.ts
@@ -46,6 +46,7 @@ export const WalletConnector = defineComponent({
   props: {
     primaryWallet: String,
     wallets: Array as PropType<string[]>,
+    showUnavailable: Boolean,
     theme: String as PropType<WalletConnectorTheme>,
     cssVars: Object as PropType<Record<`--xc-${string}`, string>>,
   },
@@ -134,6 +135,7 @@ export const WalletConnector = defineComponent({
         ref: element,
         'primary-wallet': props.primaryWallet,
         wallets: props.wallets?.join(','),
+        'show-unavailable': props.showUnavailable ? '' : undefined,
         style: [props.theme ? THEMES[props.theme] : undefined, props.cssVars, attrs.style],
       });
   },

--- a/packages/vue/tests/publish/types-vue-cjs.cts
+++ b/packages/vue/tests/publish/types-vue-cjs.cts
@@ -17,6 +17,13 @@ import type {
 
 const plugin: Plugin = createXrplConnect({ adapters: [] });
 const connector: Component = WalletConnector;
+type WalletConnectorProps = InstanceType<typeof WalletConnector>['$props'];
+const omittedShowUnavailableProps: WalletConnectorProps = {};
+const showUnavailableProps: WalletConnectorProps = { showUnavailable: true };
+const invalidShowUnavailableProps: WalletConnectorProps = {
+  // @ts-expect-error Misspelled Vue props must not be accepted by the published component type.
+  showUnavilable: true,
+};
 const modal = null as unknown as ReturnType<typeof useWalletModal>;
 const modalReady: Readonly<Ref<boolean>> = modal.ready;
 // @ts-expect-error Connector readiness is exposed as a readonly ref.
@@ -31,6 +38,9 @@ const errorGuard: (error: unknown) => error is WalletError = isWalletError;
 void [
   plugin,
   connector,
+  omittedShowUnavailableProps,
+  showUnavailableProps,
+  invalidShowUnavailableProps,
   modalReady,
   modalOpen,
   modalAccount,

--- a/packages/vue/tests/publish/types-vue-esm.mts
+++ b/packages/vue/tests/publish/types-vue-esm.mts
@@ -29,6 +29,13 @@ const invalidNetworkConfig: XrplConnectConfig = {
 
 const plugin: Plugin = createXrplConnect({ adapters: [] });
 const connector: Component = WalletConnector;
+type WalletConnectorProps = InstanceType<typeof WalletConnector>['$props'];
+const omittedShowUnavailableProps: WalletConnectorProps = {};
+const showUnavailableProps: WalletConnectorProps = { showUnavailable: true };
+const invalidShowUnavailableProps: WalletConnectorProps = {
+  // @ts-expect-error Misspelled Vue props must not be accepted by the published component type.
+  showUnavilable: true,
+};
 const modal = null as unknown as ReturnType<typeof useWalletModal>;
 const modalReady: Readonly<Ref<boolean>> = modal.ready;
 // @ts-expect-error Connector readiness is exposed as a readonly ref.
@@ -43,6 +50,9 @@ const errorGuard: (error: unknown) => error is WalletError = isWalletError;
 void [
   plugin,
   connector,
+  omittedShowUnavailableProps,
+  showUnavailableProps,
+  invalidShowUnavailableProps,
   modalReady,
   modalOpen,
   modalAccount,

--- a/packages/vue/tests/vue.test.ts
+++ b/packages/vue/tests/vue.test.ts
@@ -542,6 +542,34 @@ describe('<WalletConnector>', () => {
     expect(mounted.modal.ready.value).toBe(false);
   });
 
+  it('maps showUnavailable to native boolean-attribute presence', async () => {
+    const passShowUnavailable = ref(false);
+    const showUnavailable = ref<boolean>();
+    const mounted = mountModal(() =>
+      h(
+        WalletConnector,
+        passShowUnavailable.value ? { showUnavailable: showUnavailable.value } : {}
+      )
+    );
+    await vi.waitFor(() => expect(mounted.modal.ready.value).toBe(true));
+    const element = mounted.root.querySelector('xrpl-wallet-connector')!;
+
+    expect(element.hasAttribute('show-unavailable')).toBe(false);
+    passShowUnavailable.value = true;
+    showUnavailable.value = true;
+    await nextTick();
+    expect(element.getAttribute('show-unavailable')).toBe('');
+
+    showUnavailable.value = false;
+    await nextTick();
+    expect(element.hasAttribute('show-unavailable')).toBe(false);
+
+    showUnavailable.value = undefined;
+    await nextTick();
+    expect(element.hasAttribute('show-unavailable')).toBe(false);
+    mounted.app.unmount();
+  });
+
   it('binds the manager, forwards attributes/events, and supports modal control', async () => {
     const onConnecting = vi.fn();
     const onConnect = vi.fn();


### PR DESCRIPTION
## Summary
- Add the typed optional Vue `showUnavailable` boolean prop.
- Map `true` to native `show-unavailable` presence and remove the attribute for false, undefined, or omitted values.
- Cover runtime and published prop types, including misspellings, and document Install versus disabled Unavailable behavior.

## Test plan
- [x] `pnpm --filter @xrpl-commons/xrpl-connect-vue run build`
- [x] `pnpm --filter @xrpl-commons/xrpl-connect-vue run test`
- [x] `pnpm --filter @xrpl-commons/xrpl-connect-vue run type-check`
- [x] `pnpm exec tsc -p packages/vue/tests/publish/tsconfig.vue.json`
- [x] `pnpm test`
- [x] `pnpm --filter xrpl-connect run test:publish`
- [x] `pnpm exec vp check`
- [x] `pnpm docs:snapshot:check`

Fixes #146

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
