### PR TITLE
feat: export canonical wallet registry

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,8 @@ export { WalletManager } from './wallet-manager';
 // Types
 export type {
   WalletAdapter,
+  WalletId,
+  WalletIdentifier,
   WalletManagerOptions,
   AccountInfo,
   NetworkInfo,
@@ -37,6 +39,7 @@ export type {
 } from './types';
 
 export {
+  STANDARD_WALLET_IDS,
   STANDARD_NETWORKS,
   isStandardNetworkId,
   WalletErrorCode,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -4,6 +4,24 @@
 
 import type { SubmittableTransaction as XRPLTransaction } from 'xrpl';
 
+/** Canonical runtime IDs for the adapters packaged by `xrpl-connect`. */
+export const STANDARD_WALLET_IDS = [
+  'xaman',
+  'crossmark',
+  'gemwallet',
+  'walletconnect',
+  'ledger',
+  'xyra',
+  'otsu',
+  'metamask-snap',
+] as const;
+
+/** Runtime ID of an adapter packaged by `xrpl-connect`. */
+export type WalletId = (typeof STANDARD_WALLET_IDS)[number];
+
+/** A packaged wallet ID or an application-defined custom adapter ID. */
+export type WalletIdentifier = WalletId | (string & Record<never, never>);
+
 /**
  * Network information
  */
@@ -184,7 +202,7 @@ export function adapterSupports(
  */
 export interface WalletAdapter {
   // Metadata
-  readonly id: string; // 'xaman', 'crossmark', 'walletconnect', 'gemwallet'
+  readonly id: WalletIdentifier; // packaged or application-defined adapter ID
   readonly name: string; // 'Xaman Wallet', 'Crossmark', etc.
   readonly icon?: string; // URL or base64 icon
   readonly url?: string; // Wallet website/download URL
@@ -310,7 +328,7 @@ export interface StorageAdapter {
  * Stored connection state
  */
 export interface StoredState {
-  walletId: string;
+  walletId: WalletIdentifier;
   account: AccountInfo;
   network: NetworkInfo;
   timestamp: number;

--- a/packages/core/src/wallet-manager.ts
+++ b/packages/core/src/wallet-manager.ts
@@ -19,6 +19,7 @@ import type {
   StoredState,
   WalletCapabilities,
   ReconnectOptions,
+  WalletIdentifier,
 } from './types';
 import {
   adapterSupports,
@@ -107,12 +108,12 @@ export class WalletManager extends EventEmitter<WalletEvent> {
   /**
    * Connect to a wallet
    */
-  async connect(walletId: string, options?: ConnectOptions): Promise<AccountInfo> {
+  async connect(walletId: WalletIdentifier, options?: ConnectOptions): Promise<AccountInfo> {
     return this.connectInternal(walletId, options);
   }
 
   private async connectInternal(
-    walletId: string,
+    walletId: WalletIdentifier,
     options?: ConnectOptions,
     expectedState?: StoredState
   ): Promise<AccountInfo> {

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -5,6 +5,7 @@ import type {
   NetworkInfo,
   WalletError,
   ConnectOptions,
+  WalletIdentifier,
 } from '@xrpl-connect/core';
 import type { CSSProperties, ReactNode } from 'react';
 
@@ -28,7 +29,7 @@ export interface XrplConnectContextValue {
   connecting: boolean;
   /** The most recent connection/adapter error, as a typed `WalletError`. */
   error: WalletError | null;
-  connect: (walletId: string, options?: ConnectOptions) => Promise<AccountInfo>;
+  connect: (walletId: WalletIdentifier, options?: ConnectOptions) => Promise<AccountInfo>;
   disconnect: () => Promise<void>;
   /** @internal — used by `<WalletConnector>` to register its element. */
   registerConnector: (el: WalletConnectorElement) => void;
@@ -66,9 +67,9 @@ export type WalletConnectorTheme = 'dark' | 'light' | 'purple';
 
 export interface WalletConnectorProps {
   /** Pre-select a wallet in the modal (maps to the `primary-wallet` attribute). */
-  primaryWallet?: string;
+  primaryWallet?: WalletIdentifier;
   /** Restrict/order the wallet list (maps to the `wallets` attribute). */
-  wallets?: string[];
+  wallets?: WalletIdentifier[];
   /** Built-in theme preset. Overridden per-token by `cssVars`. */
   theme?: WalletConnectorTheme;
   /** Arbitrary `--xc-*` custom properties to override modal styling. */
@@ -77,7 +78,7 @@ export interface WalletConnectorProps {
   style?: CSSProperties;
   className?: string;
   /** Fired (with the wallet id) when a connection attempt starts. */
-  onConnecting?: (walletId: string) => void;
+  onConnecting?: (walletId: WalletIdentifier) => void;
   /** Fired with the connected account once the wallet approves. */
   onConnect?: (account: AccountInfo) => void;
   /** Fired with a typed `WalletError` (`error.code`, `error.category`) on failure. */

--- a/packages/vue/src/WalletConnector.ts
+++ b/packages/vue/src/WalletConnector.ts
@@ -14,6 +14,7 @@ import {
   isWalletError,
   type AccountInfo,
   type WalletError,
+  type WalletIdentifier,
 } from '@xrpl-connect/core';
 import { useXrplConnectContext, type WalletConnectorElement } from './context';
 
@@ -44,14 +45,14 @@ export const WalletConnector = defineComponent({
   name: 'WalletConnector',
   inheritAttrs: false,
   props: {
-    primaryWallet: String,
-    wallets: Array as PropType<string[]>,
+    primaryWallet: String as PropType<WalletIdentifier>,
+    wallets: Array as PropType<WalletIdentifier[]>,
     showUnavailable: Boolean,
     theme: String as PropType<WalletConnectorTheme>,
     cssVars: Object as PropType<Record<`--xc-${string}`, string>>,
   },
   emits: {
-    connecting: (walletId: string) => typeof walletId === 'string',
+    connecting: (walletId: WalletIdentifier) => typeof walletId === 'string',
     connect: (account: AccountInfo) => Boolean(account),
     error: (error: WalletError) => isWalletError(error),
   },

--- a/packages/vue/src/context.ts
+++ b/packages/vue/src/context.ts
@@ -15,6 +15,7 @@ import type {
   NetworkInfo,
   WalletError,
   WalletManagerOptions,
+  WalletIdentifier,
 } from '@xrpl-connect/core';
 
 export interface WalletConnectorElement extends HTMLElement {
@@ -32,7 +33,7 @@ export interface XrplConnectContextValue {
   network: Readonly<Ref<NetworkInfo | null>>;
   connecting: Readonly<Ref<boolean>>;
   error: Readonly<Ref<WalletError | null>>;
-  connect(walletId: string, options?: ConnectOptions): Promise<AccountInfo>;
+  connect(walletId: WalletIdentifier, options?: ConnectOptions): Promise<AccountInfo>;
   disconnect(): Promise<void>;
 }
 

--- a/packages/xrpl-connect/README.md
+++ b/packages/xrpl-connect/README.md
@@ -647,22 +647,29 @@ function createAdapter(type: 'xaman' | 'crossmark', opts: any) {
 ### Initialize with All Adapters
 
 ```typescript
-import { WalletManager, Adapters, STANDARD_NETWORKS } from 'xrpl-connect';
+import {
+  ADAPTER_DESCRIPTORS,
+  STANDARD_NETWORKS,
+  WalletManager,
+  createAdapters,
+  type WalletId,
+} from 'xrpl-connect';
 
-const allAdapters = Object.values(Adapters).map((AdapterClass) => {
-  if (AdapterClass === Adapters.Xaman) {
-    return new AdapterClass({ apiKey: process.env.XUMM_API_KEY });
-  }
-  if (AdapterClass === Adapters.WalletConnect) {
-    return new AdapterClass({ projectId: process.env.WALLETCONNECT_ID });
-  }
-  return new AdapterClass();
+const allAdapters = createAdapters({
+  xaman: { apiKey: process.env.XUMM_API_KEY },
+  walletconnect: { projectId: process.env.WALLETCONNECT_ID },
 });
 
 const walletManager = new WalletManager({
   adapters: allAdapters,
   network: STANDARD_NETWORKS.mainnet,
 });
+
+// Canonical display order, IDs, constructors, and setup requirements are
+// available without maintaining a parallel application registry.
+const walletChoices: Array<{ id: WalletId; name: string }> = ADAPTER_DESCRIPTORS.map(
+  ({ id, name }) => ({ id, name })
+);
 ```
 
 ### Conditional Adapter Loading

--- a/packages/xrpl-connect/src/adapters.ts
+++ b/packages/xrpl-connect/src/adapters.ts
@@ -1,0 +1,137 @@
+import type { WalletAdapter } from '@xrpl-connect/core';
+import { XamanAdapter } from '@xrpl-connect/adapter-xaman';
+import { CrossmarkAdapter } from '@xrpl-connect/adapter-crossmark';
+import { GemWalletAdapter } from '@xrpl-connect/adapter-gemwallet';
+import { WalletConnectAdapter } from '@xrpl-connect/adapter-walletconnect';
+import { LedgerAdapter } from '@xrpl-connect/adapter-ledger';
+import { XyraAdapter } from '@xrpl-connect/adapter-xyra';
+import { OtsuAdapter } from '@xrpl-connect/adapter-otsu';
+import { MetaMaskSnapAdapter } from '@xrpl-connect/adapter-metamask-snap';
+
+/** Constructors for every adapter included in the umbrella package. */
+export const Adapters = {
+  Xaman: XamanAdapter,
+  Crossmark: CrossmarkAdapter,
+  GemWallet: GemWalletAdapter,
+  WalletConnect: WalletConnectAdapter,
+  Ledger: LedgerAdapter,
+  Xyra: XyraAdapter,
+  Otsu: OtsuAdapter,
+  MetaMaskSnap: MetaMaskSnapAdapter,
+} as const;
+
+export type AdapterExportKey = keyof typeof Adapters;
+export type AdapterAvailability = 'remote' | 'extension' | 'browser' | 'device';
+
+type AdapterConstructor<TKey extends AdapterExportKey> = (typeof Adapters)[TKey];
+type AdapterInstance<TKey extends AdapterExportKey> = InstanceType<AdapterConstructor<TKey>>;
+type AdapterOptions<TKey extends AdapterExportKey> =
+  ConstructorParameters<AdapterConstructor<TKey>> extends []
+    ? never
+    : NonNullable<ConstructorParameters<AdapterConstructor<TKey>>[0]>;
+type AdapterOptionKey<TKey extends AdapterExportKey> = Extract<keyof AdapterOptions<TKey>, string>;
+
+type DescriptorFor<TKey extends AdapterExportKey> = {
+  readonly exportKey: TKey;
+  readonly id: AdapterInstance<TKey>['id'];
+  readonly name: string;
+  readonly Adapter: AdapterConstructor<TKey>;
+  readonly availability: AdapterAvailability;
+  readonly configuration: {
+    readonly requiredOptions: readonly AdapterOptionKey<TKey>[];
+    readonly supportsDeferredConnection: boolean;
+  };
+};
+
+/** Metadata for one packaged adapter, tied to its exact constructor and runtime ID. */
+export type AdapterDescriptor = {
+  [TKey in AdapterExportKey]: DescriptorFor<TKey>;
+}[AdapterExportKey];
+
+/**
+ * Packaged adapters in their recommended display order.
+ *
+ * `remote` wallets open a hosted/QR flow, `extension` wallets require an
+ * injected browser provider, `browser` wallets need browser primitives such as
+ * popups, and `device` wallets require browser hardware APIs.
+ */
+export const ADAPTER_DESCRIPTORS = [
+  {
+    exportKey: 'Xaman',
+    id: 'xaman',
+    name: 'Xaman',
+    Adapter: Adapters.Xaman,
+    availability: 'remote',
+    configuration: { requiredOptions: ['apiKey'], supportsDeferredConnection: true },
+  },
+  {
+    exportKey: 'Crossmark',
+    id: 'crossmark',
+    name: 'Crossmark',
+    Adapter: Adapters.Crossmark,
+    availability: 'extension',
+    configuration: { requiredOptions: [], supportsDeferredConnection: false },
+  },
+  {
+    exportKey: 'GemWallet',
+    id: 'gemwallet',
+    name: 'GemWallet',
+    Adapter: Adapters.GemWallet,
+    availability: 'extension',
+    configuration: { requiredOptions: [], supportsDeferredConnection: false },
+  },
+  {
+    exportKey: 'WalletConnect',
+    id: 'walletconnect',
+    name: 'WalletConnect',
+    Adapter: Adapters.WalletConnect,
+    availability: 'remote',
+    configuration: { requiredOptions: ['projectId'], supportsDeferredConnection: true },
+  },
+  {
+    exportKey: 'Ledger',
+    id: 'ledger',
+    name: 'Ledger',
+    Adapter: Adapters.Ledger,
+    availability: 'device',
+    configuration: { requiredOptions: [], supportsDeferredConnection: false },
+  },
+  {
+    exportKey: 'Xyra',
+    id: 'xyra',
+    name: 'Xyra',
+    Adapter: Adapters.Xyra,
+    availability: 'browser',
+    configuration: { requiredOptions: [], supportsDeferredConnection: false },
+  },
+  {
+    exportKey: 'Otsu',
+    id: 'otsu',
+    name: 'Otsu',
+    Adapter: Adapters.Otsu,
+    availability: 'extension',
+    configuration: { requiredOptions: [], supportsDeferredConnection: false },
+  },
+  {
+    exportKey: 'MetaMaskSnap',
+    id: 'metamask-snap',
+    name: 'MetaMask Snap',
+    Adapter: Adapters.MetaMaskSnap,
+    availability: 'extension',
+    configuration: { requiredOptions: [], supportsDeferredConnection: false },
+  },
+] as const satisfies readonly AdapterDescriptor[];
+
+/** Constructor options keyed by canonical runtime wallet ID. */
+export type PackagedAdapterOptions = {
+  [TKey in AdapterExportKey as AdapterInstance<TKey>['id']]?: AdapterOptions<TKey>;
+};
+
+/** Instantiate every packaged adapter in canonical display order. */
+export function createAdapters(configuration: PackagedAdapterOptions = {}): WalletAdapter[] {
+  return ADAPTER_DESCRIPTORS.map((descriptor) => {
+    const options = configuration[descriptor.id];
+    const args = options === undefined ? [] : [options];
+    return Reflect.construct(descriptor.Adapter, args) as WalletAdapter;
+  });
+}

--- a/packages/xrpl-connect/src/index.browser.ts
+++ b/packages/xrpl-connect/src/index.browser.ts
@@ -15,33 +15,5 @@
  * ```
  */
 
-export * from '../../core';
-export * from '../../ui';
-
-// Re-export all adapters
-export { XamanAdapter } from '../../adapters/xaman';
-export { CrossmarkAdapter } from '../../adapters/crossmark';
-export { GemWalletAdapter } from '../../adapters/gemwallet';
-export { WalletConnectAdapter } from '../../adapters/walletconnect';
-export { LedgerAdapter } from '../../adapters/ledger';
-export { XyraAdapter } from '../../adapters/xyra';
-export { OtsuAdapter } from '../../adapters/otsu';
-
-// Convenient grouped exports for better DX
-import { XamanAdapter } from '../../adapters/xaman';
-import { CrossmarkAdapter } from '../../adapters/crossmark';
-import { GemWalletAdapter } from '../../adapters/gemwallet';
-import { WalletConnectAdapter } from '../../adapters/walletconnect';
-import { LedgerAdapter } from '../../adapters/ledger';
-import { XyraAdapter } from '../../adapters/xyra';
-import { OtsuAdapter } from '../../adapters/otsu';
-
-export const Adapters = {
-  Xaman: XamanAdapter,
-  Crossmark: CrossmarkAdapter,
-  GemWallet: GemWalletAdapter,
-  WalletConnect: WalletConnectAdapter,
-  Ledger: LedgerAdapter,
-  Xyra: XyraAdapter,
-  Otsu: OtsuAdapter,
-};
+// Forward the complete public surface instead of maintaining a second export list.
+export * from './index';

--- a/packages/xrpl-connect/src/index.ts
+++ b/packages/xrpl-connect/src/index.ts
@@ -36,39 +36,4 @@ export * from '@xrpl-connect/adapter-ledger';
 export * from '@xrpl-connect/adapter-xyra';
 export * from '@xrpl-connect/adapter-otsu';
 export * from '@xrpl-connect/adapter-metamask-snap';
-
-// Convenient grouped exports for better DX
-import { XamanAdapter } from '@xrpl-connect/adapter-xaman';
-import { CrossmarkAdapter } from '@xrpl-connect/adapter-crossmark';
-import { GemWalletAdapter } from '@xrpl-connect/adapter-gemwallet';
-import { WalletConnectAdapter } from '@xrpl-connect/adapter-walletconnect';
-import { LedgerAdapter } from '@xrpl-connect/adapter-ledger';
-import { XyraAdapter } from '@xrpl-connect/adapter-xyra';
-import { OtsuAdapter } from '@xrpl-connect/adapter-otsu';
-import { MetaMaskSnapAdapter } from '@xrpl-connect/adapter-metamask-snap';
-
-/**
- * Convenient object containing all wallet adapters
- *
- * @example
- * ```typescript
- * import { WalletManager, Adapters } from 'xrpl-connect';
- *
- * const walletManager = new WalletManager({
- *   adapters: [
- *     new Adapters.Xaman({ apiKey: 'YOUR_XAMAN_API_KEY' }),
- *     new Adapters.Crossmark(),
- *   ],
- * });
- * ```
- */
-export const Adapters = {
-  Xaman: XamanAdapter,
-  Crossmark: CrossmarkAdapter,
-  GemWallet: GemWalletAdapter,
-  WalletConnect: WalletConnectAdapter,
-  Ledger: LedgerAdapter,
-  Xyra: XyraAdapter,
-  Otsu: OtsuAdapter,
-  MetaMaskSnap: MetaMaskSnapAdapter,
-};
+export * from './adapters';

--- a/packages/xrpl-connect/tests/publish/runtime-cjs.cjs
+++ b/packages/xrpl-connect/tests/publish/runtime-cjs.cjs
@@ -12,6 +12,35 @@ assert.equal(typeof api.GemWalletAPI.getAddress, 'function');
 assert.equal(typeof api.XRPLMethod, 'object');
 assert.equal(typeof api.LEDGER_STATE_MESSAGES, 'object');
 
+assert.deepEqual(api.STANDARD_WALLET_IDS, [
+  'xaman',
+  'crossmark',
+  'gemwallet',
+  'walletconnect',
+  'ledger',
+  'xyra',
+  'otsu',
+  'metamask-snap',
+]);
+assert.equal(api.ADAPTER_DESCRIPTORS.length, Object.keys(api.Adapters).length);
+assert.deepEqual(
+  api.ADAPTER_DESCRIPTORS.map(({ id }) => id),
+  api.STANDARD_WALLET_IDS
+);
+for (const descriptor of api.ADAPTER_DESCRIPTORS) {
+  assert.equal(descriptor.Adapter, api.Adapters[descriptor.exportKey]);
+  assert.equal(new descriptor.Adapter().id, descriptor.id);
+}
+assert.deepEqual(
+  api
+    .createAdapters({
+      xaman: { apiKey: 'publish-smoke-test' },
+      walletconnect: { projectId: 'publish-smoke-test' },
+    })
+    .map(({ id }) => id),
+  api.STANDARD_WALLET_IDS
+);
+
 for (const exportName of ['XummPkce', 'XummPkceThread']) {
   assert(exportName in api.XamanOAuth2, `XamanOAuth2 is missing ${exportName}`);
 }

--- a/packages/xrpl-connect/tests/publish/runtime-esm.mjs
+++ b/packages/xrpl-connect/tests/publish/runtime-esm.mjs
@@ -13,6 +13,43 @@ assert.equal(typeof api.GemWalletAPI.getAddress, 'function');
 assert.equal(typeof api.XRPLMethod, 'object');
 assert.equal(typeof api.LEDGER_STATE_MESSAGES, 'object');
 
+assert.deepEqual(api.STANDARD_WALLET_IDS, [
+  'xaman',
+  'crossmark',
+  'gemwallet',
+  'walletconnect',
+  'ledger',
+  'xyra',
+  'otsu',
+  'metamask-snap',
+]);
+assert.equal(api.ADAPTER_DESCRIPTORS.length, Object.keys(api.Adapters).length);
+assert.deepEqual(
+  api.ADAPTER_DESCRIPTORS.map(({ id }) => id),
+  api.STANDARD_WALLET_IDS
+);
+assert.equal(
+  new Set(api.ADAPTER_DESCRIPTORS.map(({ exportKey }) => exportKey)).size,
+  api.ADAPTER_DESCRIPTORS.length
+);
+assert.equal(
+  new Set(api.ADAPTER_DESCRIPTORS.map(({ id }) => id)).size,
+  api.ADAPTER_DESCRIPTORS.length
+);
+for (const descriptor of api.ADAPTER_DESCRIPTORS) {
+  assert.equal(descriptor.Adapter, api.Adapters[descriptor.exportKey]);
+  assert.equal(new descriptor.Adapter().id, descriptor.id);
+}
+assert.deepEqual(
+  api
+    .createAdapters({
+      xaman: { apiKey: 'publish-smoke-test' },
+      walletconnect: { projectId: 'publish-smoke-test' },
+    })
+    .map(({ id }) => id),
+  api.STANDARD_WALLET_IDS
+);
+
 for (const exportName of ['XummPkce', 'XummPkceThread']) {
   assert(exportName in api.XamanOAuth2, `XamanOAuth2 is missing ${exportName}`);
 }

--- a/packages/xrpl-connect/tests/publish/types-cjs.cts
+++ b/packages/xrpl-connect/tests/publish/types-cjs.cts
@@ -1,5 +1,8 @@
 import {
   CrossmarkSDK,
+  ADAPTER_DESCRIPTORS,
+  STANDARD_WALLET_IDS,
+  createAdapters,
   GemWalletAPI,
   MetaMaskSnapAdapter,
   WalletConnectorElement,
@@ -10,12 +13,26 @@ import {
   type CrossmarkClient,
   type LedgerConnectOptions,
   type MetaMaskSnapAdapterOptions,
+  type WalletId,
+  type WalletIdentifier,
   type WalletConnectConnectOptions,
   type WalletConnectorElementInstance,
   type XamanConnectOptions,
   type XamanReturnUrl,
   type XyraConnectOptions,
 } from 'xrpl-connect';
+
+const standardWalletId: WalletId = STANDARD_WALLET_IDS[0];
+const customWalletId: WalletIdentifier = 'custom-wallet';
+// @ts-expect-error WalletId is the literal union of packaged adapter IDs.
+const invalidStandardWalletId: WalletId = 'custom-wallet';
+const descriptorWalletId: WalletId = ADAPTER_DESCRIPTORS[0].id;
+const packagedAdapters = createAdapters({
+  xaman: { apiKey: 'api-key' },
+  walletconnect: { projectId: 'project-id' },
+});
+// @ts-expect-error WalletConnect constructor options do not accept a Xaman API key.
+createAdapters({ walletconnect: { apiKey: 'api-key' } });
 
 const connectOptions: [
   ConnectOptions<LedgerConnectOptions>,
@@ -74,6 +91,11 @@ const metamaskAdapter = new MetaMaskSnapAdapter(metamaskOptions);
 
 void [
   connectOptions,
+  standardWalletId,
+  customWalletId,
+  invalidStandardWalletId,
+  descriptorWalletId,
+  packagedAdapters,
   xamanConstructor,
   xamanReturnUrl,
   oauthConstructor,

--- a/packages/xrpl-connect/tests/publish/types-esm.mts
+++ b/packages/xrpl-connect/tests/publish/types-esm.mts
@@ -1,5 +1,8 @@
 import {
   CrossmarkSDK,
+  ADAPTER_DESCRIPTORS,
+  STANDARD_WALLET_IDS,
+  createAdapters,
   GemWalletAPI,
   MetaMaskSnapAdapter,
   WalletConnectorElement,
@@ -13,6 +16,8 @@ import {
   type NetworkConfig,
   type NetworkInfo,
   type StandardNetworkId,
+  type WalletId,
+  type WalletIdentifier,
   type WalletConnectConnectOptions,
   type WalletConnectorElementInstance,
   type XamanConnectOptions,
@@ -21,6 +26,18 @@ import {
 } from 'xrpl-connect';
 
 const standardNetworkId: StandardNetworkId = 'mainnet';
+const standardWalletId: WalletId = STANDARD_WALLET_IDS[0];
+const customWalletId: WalletIdentifier = 'custom-wallet';
+// @ts-expect-error WalletId is the literal union of packaged adapter IDs.
+const invalidStandardWalletId: WalletId = 'custom-wallet';
+const descriptorWalletId: WalletId = ADAPTER_DESCRIPTORS[0].id;
+const packagedAdapters = createAdapters({
+  xaman: { apiKey: 'api-key' },
+  walletconnect: { projectId: 'project-id' },
+  ledger: { accountIndex: 1 },
+});
+// @ts-expect-error Xaman constructor options do not accept a WalletConnect project ID.
+createAdapters({ xaman: { projectId: 'project-id' } });
 const standardNetworkConfig: NetworkConfig = standardNetworkId;
 const customNetwork: NetworkInfo = {
   id: 'sidechain',
@@ -88,6 +105,11 @@ const metamaskAdapter = new MetaMaskSnapAdapter(metamaskOptions);
 
 void [
   connectOptions,
+  standardWalletId,
+  customWalletId,
+  invalidStandardWalletId,
+  descriptorWalletId,
+  packagedAdapters,
   standardNetworkConfig,
   customNetworkConfig,
   invalidNetworkConfig,


### PR DESCRIPTION
## Summary

- export the canonical packaged wallet ID tuple and custom-compatible identifier type
- add a typed adapter descriptor registry and configuration helper shared by Node and browser entries
- cover registry completeness, runtime constructor identity, and packed ESM/CJS declarations

## Test plan

- `pnpm exec vp check`
- `pnpm build`
- `pnpm test`
- `pnpm --filter xrpl-connect test:publish`

Fixes #150
