### PR TITLE
feat: make wallet credentials type-safe

### DIFF
--- a/docs/guide/wallets.md
+++ b/docs/guide/wallets.md
@@ -60,7 +60,7 @@ Xaman API keys and WalletConnect project IDs are browser identifiers, not server
 - `MetaMaskSnapAdapter`: optional `snapId`; use the default published Snap unless developing a local Snap.
 - Xyra, Otsu, Crossmark, and GemWallet work without application credentials.
 
-Connect-time options can override supported adapter settings. Configure Xaman return URLs on the adapter constructor when connecting through `WalletManager`; direct `XamanAdapter.connect()` calls can override them for one session. Return navigation may open another browser tab, so restore application state and use the signing result—not navigation—as confirmation. Keep the Xaman API key stable for the lifetime of the page because its browser SDK owns page-global OAuth state.
+Xaman and WalletConnect need constructor credentials to appear in wallet discovery and to support automatic reconnection. Direct calls can defer a credential for one session with `manager.connect('xaman', { apiKey })` or `manager.connect('walletconnect', { projectId })`; these options are selected from the wallet ID at compile time and are not persisted. Missing credentials fail early with `CONFIGURATION_REQUIRED`. Other connect-time options can override supported adapter settings. Configure Xaman return URLs on the adapter constructor when connecting through `WalletManager`; direct `XamanAdapter.connect()` calls can override them for one session. Return navigation may open another browser tab, so restore application state and use the signing result—not navigation—as confirmation. Keep the Xaman API key stable for the lifetime of the page because its browser SDK owns page-global OAuth state.
 
 ## Networks
 

--- a/packages/adapters/walletconnect/src/walletconnect-adapter.ts
+++ b/packages/adapters/walletconnect/src/walletconnect-adapter.ts
@@ -20,6 +20,7 @@ import type {
   SupportsDeepLink,
   SupportsPreInitialize,
   WalletCapabilities,
+  WalletConnectionOptionsById,
 } from '@xrpl-connect/core';
 import {
   createWalletError,
@@ -175,10 +176,7 @@ export interface WalletConnectAdapterOptions {
   themeMode?: 'dark' | 'light'; // Modal theme (default: 'dark')
 }
 
-export type WalletConnectConnectOptions = {
-  projectId?: string;
-  onQRCode?: (uri: string) => void;
-};
+export type WalletConnectConnectOptions = WalletConnectionOptionsById['walletconnect'];
 
 /**
  * WalletConnect adapter implementation using Sign Client v2
@@ -212,6 +210,12 @@ export class WalletConnectAdapter
 
   constructor(options: WalletConnectAdapterOptions = {}) {
     this.options = options;
+  }
+
+  getMissingConfiguration(
+    options?: ConnectOptions<WalletConnectConnectOptions>
+  ): readonly string[] {
+    return options?.projectId || this.options.projectId ? [] : ['projectId'];
   }
 
   private async getOrInitializeClient(projectId: string): Promise<SignClient> {
@@ -482,12 +486,7 @@ export class WalletConnectAdapter
     const projectId = options?.projectId || this.options.projectId;
 
     if (!projectId) {
-      throw createWalletError.connectionFailed(
-        this.name,
-        new Error(
-          'WalletConnect project ID is required. Get one from https://cloud.walletconnect.com or https://dashboard.reown.com'
-        )
-      );
+      throw createWalletError.configurationRequired(this.name, ['projectId']);
     }
 
     if (this.client && this.clientProjectId !== projectId) {

--- a/packages/adapters/walletconnect/tests/walletconnect-adapter.test.ts
+++ b/packages/adapters/walletconnect/tests/walletconnect-adapter.test.ts
@@ -62,6 +62,28 @@ describe('WalletConnectAdapter.isAvailable', () => {
   });
 });
 
+describe('WalletConnectAdapter configuration', () => {
+  it('accepts constructor or deferred project IDs', () => {
+    expect(
+      new WalletConnectAdapter({ projectId: 'constructor-project' }).getMissingConfiguration()
+    ).toEqual([]);
+    expect(
+      new WalletConnectAdapter().getMissingConfiguration({ projectId: 'deferred-project' })
+    ).toEqual([]);
+  });
+
+  it('identifies a missing project ID before connection work begins', async () => {
+    const adapter = new WalletConnectAdapter();
+
+    expect(adapter.getMissingConfiguration()).toEqual(['projectId']);
+    await expect(adapter.connect()).rejects.toMatchObject({
+      code: WalletErrorCode.CONFIGURATION_REQUIRED,
+      message: 'WalletConnect requires configuration before connecting: projectId.',
+    });
+    expect(SignClientMock.init).not.toHaveBeenCalled();
+  });
+});
+
 describe('WalletConnectAdapter.connect', () => {
   it('returns account info after a successful session approval', async () => {
     mockClient.connect.mockResolvedValue({
@@ -714,10 +736,10 @@ describe('WalletConnectAdapter.connect', () => {
     expect(mockClient.disconnect).toHaveBeenCalledOnce();
   });
 
-  it('throws a wrapped error when no project ID is provided', async () => {
+  it('throws a configuration error when no project ID is provided', async () => {
     const adapter = new WalletConnectAdapter();
     await expect(adapter.connect()).rejects.toMatchObject({
-      code: WalletErrorCode.CONNECTION_FAILED,
+      code: WalletErrorCode.CONFIGURATION_REQUIRED,
     });
   });
 

--- a/packages/adapters/xaman/src/xaman-adapter.ts
+++ b/packages/adapters/xaman/src/xaman-adapter.ts
@@ -22,6 +22,7 @@ import {
   SupportsDeepLink,
   SupportsFetchAccount,
   WalletCapabilities,
+  WalletConnectionOptionsById,
 } from '@xrpl-connect/core';
 import { createWalletError, createLogger, isWalletError, resolveNetwork } from '@xrpl-connect/core';
 import iconSvg from './assets/icon.svg';
@@ -133,12 +134,7 @@ export interface XamanAdapterOptions {
   returnUrl?: XamanReturnUrl;
 }
 
-export type XamanConnectOptions = {
-  apiKey?: string;
-  onQRCode?: (uri: string) => void;
-  onDeepLink?: (uri: string) => string;
-  returnUrl?: XamanReturnUrl;
-};
+export type XamanConnectOptions = WalletConnectionOptionsById['xaman'];
 
 /**
  * Xaman wallet adapter implementation
@@ -178,6 +174,10 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
     this.options = options;
   }
 
+  getMissingConfiguration(options?: ConnectOptions<XamanConnectOptions>): readonly string[] {
+    return options?.apiKey || this.options.apiKey ? [] : ['apiKey'];
+  }
+
   /**
    * Xaman is always available (uses OAuth flow, no extension needed)
    */
@@ -191,12 +191,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
     const apiKey = options?.apiKey || this.options.apiKey;
 
     if (!apiKey) {
-      throw createWalletError.connectionFailed(
-        this.name,
-        new Error(
-          'API key is required for Xaman. Please provide it in connect options or adapter constructor.'
-        )
-      );
+      throw createWalletError.configurationRequired(this.name, ['apiKey']);
     }
 
     if (this.sdkApiKey && this.sdkApiKey !== apiKey) {
@@ -315,12 +310,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
     });
 
     if (!apiKey) {
-      throw createWalletError.connectionFailed(
-        this.name,
-        new Error(
-          'API key is required for Xaman. Please provide it in connect options or adapter constructor.'
-        )
-      );
+      throw createWalletError.configurationRequired(this.name, ['apiKey']);
     }
 
     if (this.sdkApiKey && this.sdkApiKey !== apiKey) {

--- a/packages/adapters/xaman/tests/xaman-adapter.test.ts
+++ b/packages/adapters/xaman/tests/xaman-adapter.test.ts
@@ -208,6 +208,23 @@ describe('XamanAdapter.isAvailable', () => {
   });
 });
 
+describe('XamanAdapter configuration', () => {
+  it('accepts constructor or deferred API keys', () => {
+    expect(new XamanAdapter({ apiKey: 'constructor-key' }).getMissingConfiguration()).toEqual([]);
+    expect(new XamanAdapter().getMissingConfiguration({ apiKey: 'deferred-key' })).toEqual([]);
+  });
+
+  it('identifies a missing API key before connection work begins', async () => {
+    const adapter = new XamanAdapter();
+
+    expect(adapter.getMissingConfiguration()).toEqual(['apiKey']);
+    await expect(adapter.connect()).rejects.toMatchObject({
+      code: WalletErrorCode.CONFIGURATION_REQUIRED,
+      message: 'Xaman requires configuration before connecting: apiKey.',
+    });
+  });
+});
+
 describe('XamanAdapter.checkXamanState', () => {
   it.each([
     [0, 'mainnet', 'MAINNET'],
@@ -408,10 +425,10 @@ describe('XamanAdapter.connect', () => {
     expect(account.network.id).toBe('mainnet');
   });
 
-  it('throws a wrapped connection error when no API key is given', async () => {
+  it('throws a configuration error when no API key is given', async () => {
     const adapter = new XamanAdapter();
     await expect(adapter.connect()).rejects.toMatchObject({
-      code: WalletErrorCode.CONNECTION_FAILED,
+      code: WalletErrorCode.CONFIGURATION_REQUIRED,
     });
     expect(mockXummInstance.authorize).not.toHaveBeenCalled();
   });

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -77,7 +77,21 @@ Initiates connection to a specific wallet adapter. The availability preflight is
 - `options` (optional): Network and wallet-specific connection options. Set
   `skipRequestAccess: true` to ask a supporting wallet to reuse existing access
   without prompting; adapters that cannot distinguish silent access may ignore
-  this hint.
+  this hint. Packaged adapter imports augment this type by wallet ID, so Xaman
+  accepts `apiKey`, WalletConnect accepts `projectId`, and cross-wallet options
+  are rejected by TypeScript.
+
+Xaman and WalletConnect should normally receive their credential in the adapter
+constructor. This makes them eligible for `getAvailableWallets()` and wallet
+picker discovery. A direct call can defer the credential for one connection:
+
+```typescript
+await walletManager.connect('xaman', { apiKey: process.env.XUMM_API_KEY });
+await walletManager.connect('walletconnect', { projectId: process.env.WALLETCONNECT_ID });
+```
+
+Deferred credentials are not stored. Configure the constructor when using
+automatic reconnection; otherwise reconnecting reports `CONFIGURATION_REQUIRED`.
 
 **Returns**: `AccountInfo` containing the connected account details
 
@@ -87,9 +101,7 @@ Initiates connection to a specific wallet adapter. The availability preflight is
 
 ```typescript
 try {
-  const account = await walletManager.connect('xaman', {
-    apiKey: process.env.XUMM_API_KEY,
-  });
+  const account = await walletManager.connect('xaman');
   console.log('Connected to:', account.address);
 } catch (error) {
   console.error('Connection failed:', error.code);

--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -19,6 +19,14 @@ describe('isWalletError', () => {
 });
 
 describe('createWalletError failure factories', () => {
+  it('identifies missing adapter configuration as invalid input', () => {
+    expect(createWalletError.configurationRequired('Test Wallet', ['apiKey'])).toMatchObject({
+      code: WalletErrorCode.CONFIGURATION_REQUIRED,
+      category: WalletErrorCategory.INVALID_INPUT,
+      message: 'Test Wallet requires configuration before connecting: apiKey.',
+    });
+  });
+
   it('preserves existing typed errors instead of changing their code or category', () => {
     const typedError = createWalletError.notConnected();
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -21,6 +21,7 @@ const CODE_TO_CATEGORY: Record<WalletErrorCode, WalletErrorCategory> = {
 
   [WalletErrorCode.CONNECTION_FAILED]: WalletErrorCategory.NETWORK,
 
+  [WalletErrorCode.CONFIGURATION_REQUIRED]: WalletErrorCategory.INVALID_INPUT,
   [WalletErrorCode.NOT_CONNECTED]: WalletErrorCategory.INVALID_INPUT,
   [WalletErrorCode.ALREADY_CONNECTED]: WalletErrorCategory.INVALID_INPUT,
   [WalletErrorCode.UNSUPPORTED_METHOD]: WalletErrorCategory.INVALID_INPUT,
@@ -110,6 +111,12 @@ export const createWalletError = {
     new WalletError(
       WalletErrorCode.WALLET_NOT_AVAILABLE,
       `${walletName} is not currently available.`
+    ),
+
+  configurationRequired: (walletName: string, missingFields: readonly string[]): WalletError =>
+    new WalletError(
+      WalletErrorCode.CONFIGURATION_REQUIRED,
+      `${walletName} requires configuration before connecting: ${missingFields.join(', ')}.`
     ),
 
   connectionFailed: (walletName: string, originalError?: Error): WalletError =>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,8 @@ export type {
   ManagedSignedMessage,
   SubmittedTransaction,
   ConnectOptions,
+  ConnectOptionsFor,
+  WalletConnectionOptionsById,
   ReconnectOptions,
   WalletEvent,
   WalletAdapterEvent,
@@ -50,6 +52,8 @@ export {
   adapterSupports,
   CAPABILITY_DEFAULTS,
   supportsReconnectOptions,
+  getMissingAdapterConfiguration,
+  isAdapterConfigured,
 } from './types';
 
 // Errors

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -129,7 +129,7 @@ export interface SubmittedTransaction {
  * Options for connecting to a wallet
  */
 // oxlint-disable-next-line typescript/no-empty-object-type
-export type ConnectOptions<WalletSpecificOptions extends Record<string, unknown> = {}> = {
+export type ConnectOptions<WalletSpecificOptions extends object = {}> = {
   network?: NetworkConfig; // Preferred network
   autoReconnect?: boolean; // Auto-reconnect on page load
   /**
@@ -139,6 +139,41 @@ export type ConnectOptions<WalletSpecificOptions extends Record<string, unknown>
    */
   skipRequestAccess?: boolean;
 } & WalletSpecificOptions;
+
+/**
+ * Adapter-specific connection options keyed by wallet ID. Third-party adapter
+ * packages can extend this interface through module augmentation. Augment the
+ * public module specifier being consumed: `@xrpl-connect/core` for the standalone
+ * package or `xrpl-connect` for the rolled umbrella package. Custom IDs retain
+ * an open options object without requiring augmentation.
+ */
+export interface WalletConnectionOptionsById {
+  xaman: {
+    apiKey?: string;
+    onQRCode?: (uri: string) => void;
+    onDeepLink?: (uri: string) => string;
+    returnUrl?: {
+      app?: string;
+      web?: string;
+    };
+  };
+  walletconnect: {
+    projectId?: string;
+    onQRCode?: (uri: string) => void;
+  };
+}
+
+type WalletSpecificConnectOptions<Wallet extends WalletIdentifier> =
+  Wallet extends keyof WalletConnectionOptionsById
+    ? WalletConnectionOptionsById[Wallet] extends object
+      ? WalletConnectionOptionsById[Wallet]
+      : never
+    : Record<string, unknown>;
+
+/** Connection options narrowed to the selected packaged wallet. */
+export type ConnectOptionsFor<Wallet extends WalletIdentifier> = ConnectOptions<
+  WalletSpecificConnectOptions<Wallet>
+>;
 
 /**
  * Adapter-owned, JSON-safe options required to restore a wallet account.
@@ -219,6 +254,7 @@ export interface WalletAdapter {
   serializeReconnectOptions?(options: ConnectOptions): ReconnectOptions | undefined;
 
   // Availability
+  getMissingConfiguration?(options?: ConnectOptions): readonly string[];
   isAvailable(): Promise<boolean>; // Check if wallet is installed/accessible
 
   // Connection lifecycle
@@ -237,6 +273,19 @@ export interface WalletAdapter {
   // Events (optional, for wallets that support event listening)
   on?(event: WalletAdapterEvent, callback: (data: unknown) => void): void;
   off?(event: WalletAdapterEvent, callback: (data: unknown) => void): void;
+}
+
+/** Return the configuration fields an adapter still needs before connecting. */
+export function getMissingAdapterConfiguration(
+  adapter: WalletAdapter,
+  options?: ConnectOptions
+): readonly string[] {
+  return adapter.getMissingConfiguration?.(options) ?? [];
+}
+
+/** Whether an adapter has enough configuration to begin a connection. */
+export function isAdapterConfigured(adapter: WalletAdapter, options?: ConnectOptions): boolean {
+  return getMissingAdapterConfiguration(adapter, options).length === 0;
 }
 
 /**
@@ -377,6 +426,7 @@ export enum WalletErrorCode {
   WALLET_NOT_AVAILABLE = 'WALLET_NOT_AVAILABLE',
   CONNECTION_FAILED = 'CONNECTION_FAILED',
   CONNECTION_REJECTED = 'CONNECTION_REJECTED',
+  CONFIGURATION_REQUIRED = 'CONFIGURATION_REQUIRED',
 
   // Signing errors
   SIGN_FAILED = 'SIGN_FAILED',

--- a/packages/core/src/wallet-manager.ts
+++ b/packages/core/src/wallet-manager.ts
@@ -365,9 +365,14 @@ export class WalletManager extends EventEmitter<WalletEvent> {
       // disconnect() invalidates reconnect work before cancelling or replacing
       // its adapter. A stale failure must not clear a newer session's storage.
       if (reconnectGeneration !== this.reconnectGeneration) return null;
-      // A connection may have started after the ownership check above. Do not
-      // erase its persisted state by treating that overlap as a failed restore.
-      if (isWalletError(error) && error.code === WalletErrorCode.ALREADY_CONNECTED) {
+      // Recoverable caller-action errors must remain visible and must not erase
+      // the persisted session. A later retry can succeed after the caller
+      // supplies the missing adapter configuration or resolves the overlap.
+      if (
+        isWalletError(error) &&
+        (error.code === WalletErrorCode.ALREADY_CONNECTED ||
+          error.code === WalletErrorCode.CONFIGURATION_REQUIRED)
+      ) {
         throw error;
       }
       this.logger.warn('Reconnection failed:', error);

--- a/packages/core/src/wallet-manager.ts
+++ b/packages/core/src/wallet-manager.ts
@@ -14,6 +14,7 @@ import type {
   SubmittedTransaction,
   WalletEvent,
   ConnectOptions,
+  ConnectOptionsFor,
   NetworkConfig,
   NetworkInfo,
   StoredState,
@@ -25,6 +26,7 @@ import {
   adapterSupports,
   supportsFetchAccount,
   supportsReconnectOptions,
+  getMissingAdapterConfiguration,
   WalletErrorCode,
 } from './types';
 import { createWalletError, isWalletError } from './errors';
@@ -108,7 +110,10 @@ export class WalletManager extends EventEmitter<WalletEvent> {
   /**
    * Connect to a wallet
    */
-  async connect(walletId: WalletIdentifier, options?: ConnectOptions): Promise<AccountInfo> {
+  async connect<const Wallet extends WalletIdentifier>(
+    walletId: Wallet,
+    options?: ConnectOptionsFor<Wallet>
+  ): Promise<AccountInfo> {
     return this.connectInternal(walletId, options);
   }
 
@@ -132,6 +137,12 @@ export class WalletManager extends EventEmitter<WalletEvent> {
     if (activeAdapter) {
       throw createWalletError.alreadyConnected(activeAdapter.name);
     }
+
+    const missingConfiguration = getMissingAdapterConfiguration(adapter, options);
+    if (missingConfiguration.length > 0) {
+      throw createWalletError.configurationRequired(adapter.name, missingConfiguration);
+    }
+
     this.connectingAdapter = adapter;
     const connectionAttempt = ++this.connectionAttemptGeneration;
 
@@ -466,6 +477,9 @@ export class WalletManager extends EventEmitter<WalletEvent> {
     // single slow or hung `isAvailable()` can't stall the whole list.
     const results = await Promise.all(
       adapters.map(async (adapter) => {
+        if (getMissingAdapterConfiguration(adapter).length > 0) {
+          return false;
+        }
         const result = await withTimeout<boolean | typeof AVAILABILITY_TIMED_OUT>(
           async () => {
             try {

--- a/packages/core/tests/wallet-manager.test.ts
+++ b/packages/core/tests/wallet-manager.test.ts
@@ -858,6 +858,32 @@ describe('WalletManager.reconnect()', () => {
     expect(replayed?.derivationPath).toBeUndefined();
   });
 
+  it('preserves stored state and reports missing configuration during reconnect', async () => {
+    const storage = new MemoryStorageAdapter();
+    const storedState = {
+      walletId: 'deferred-wallet',
+      account: ACCOUNT,
+      network: NETWORK,
+      timestamp: Date.now(),
+    };
+    await new Storage(storage).saveState(storedState);
+    const adapter = {
+      ...createFakeAdapter(),
+      id: 'deferred-wallet',
+      getMissingConfiguration: vi.fn(() => ['credential']),
+    };
+    const manager = new WalletManager({ adapters: [adapter], storage });
+
+    await expect(manager.reconnect()).rejects.toMatchObject({
+      code: WalletErrorCode.CONFIGURATION_REQUIRED,
+      message: 'Fake Wallet requires configuration before connecting: credential.',
+    });
+
+    expect(adapter.isAvailable).not.toHaveBeenCalled();
+    expect(adapter.connect).not.toHaveBeenCalled();
+    expect(await new Storage(storage).loadState()).toEqual(storedState);
+  });
+
   it('does not persist arbitrary options for adapters that do not opt in', async () => {
     const storage = new MemoryStorageAdapter();
     const adapter = createRecordingAdapter([]);

--- a/packages/core/tests/wallet-manager.test.ts
+++ b/packages/core/tests/wallet-manager.test.ts
@@ -547,6 +547,20 @@ describe('WalletManager.fetchAccount()', () => {
 });
 
 describe('WalletManager.getAvailableWallets()', () => {
+  it('excludes unconfigured wallets without probing their runtime availability', async () => {
+    const configured = createFakeAdapter();
+    const unconfigured = {
+      ...createFakeAdapter(),
+      id: 'unconfigured',
+      getMissingConfiguration: vi.fn(() => ['credential']),
+    };
+    const manager = new WalletManager({ adapters: [configured, unconfigured] });
+
+    await expect(manager.getAvailableWallets()).resolves.toEqual([configured]);
+    expect(unconfigured.getMissingConfiguration).toHaveBeenCalledWith(undefined);
+    expect(unconfigured.isAvailable).not.toHaveBeenCalled();
+  });
+
   it('returns responsive wallets without waiting indefinitely for a hung adapter', async () => {
     vi.useFakeTimers();
     const available = {
@@ -580,6 +594,38 @@ describe('WalletManager.getAvailableWallets()', () => {
 });
 
 describe('WalletManager.connect()', () => {
+  it('reports missing adapter configuration before checking availability', async () => {
+    const adapter = {
+      ...createFakeAdapter(),
+      getMissingConfiguration: vi.fn(() => ['credential']),
+    };
+    const manager = new WalletManager({ adapters: [adapter] });
+
+    await expect(manager.connect('fake')).rejects.toMatchObject({
+      code: WalletErrorCode.CONFIGURATION_REQUIRED,
+      message: 'Fake Wallet requires configuration before connecting: credential.',
+    });
+    expect(adapter.isAvailable).not.toHaveBeenCalled();
+    expect(adapter.connect).not.toHaveBeenCalled();
+  });
+
+  it('accepts credentials supplied for a deferred connection', async () => {
+    const adapter = {
+      ...createFakeAdapter(),
+      getMissingConfiguration: vi.fn((options?: ConnectOptions<Record<string, unknown>>) =>
+        options?.credential ? [] : ['credential']
+      ),
+    };
+    const manager = new WalletManager({ adapters: [adapter] });
+
+    await expect(manager.connect('fake', { credential: 'secret' })).resolves.toEqual(ACCOUNT);
+    expect(adapter.getMissingConfiguration).toHaveBeenCalledWith({ credential: 'secret' });
+    expect(adapter.connect).toHaveBeenCalledWith({
+      credential: 'secret',
+      network: undefined,
+    });
+  });
+
   it('rejects a repeated connection without disturbing the active session', async () => {
     const storage = new MemoryStorageAdapter();
     const adapter = createFakeAdapter();

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -90,6 +90,19 @@ subtree. The manager is created once on mount; pass a React `key` to rebuild it.
   `WalletError` (`error.code`, `error.category`), e.g. `SIGN_REJECTED` on user cancel.
 - `useWalletModal()` → `{ open, close }` — drive the `<WalletConnector>` modal.
 
+`connect` narrows deferred options from the wallet ID:
+
+```tsx
+const { connect } = useWallet();
+await connect('xaman', { apiKey: 'YOUR_KEY' });
+await connect('walletconnect', { projectId: 'YOUR_PROJECT_ID' });
+```
+
+For modal discovery and `autoConnect`, configure these credentials on the
+adapter constructor as shown above. Deferred credentials apply only to that
+direct call and are not persisted for reconnection. Missing configuration is a
+typed `CONFIGURATION_REQUIRED` error.
+
 ### `<WalletConnector />`
 
 React wrapper around the web component. Props: `primaryWallet`, `wallets`, `theme`

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -8,7 +8,13 @@ import {
   useState,
 } from 'react';
 import { WalletErrorCode, WalletManager, isWalletError } from '@xrpl-connect/core';
-import type { AccountInfo, NetworkInfo, WalletError, ConnectOptions } from '@xrpl-connect/core';
+import type {
+  AccountInfo,
+  NetworkInfo,
+  WalletError,
+  ConnectOptionsFor,
+  WalletIdentifier,
+} from '@xrpl-connect/core';
 import type {
   XrplConnectContextValue,
   XrplConnectProviderProps,
@@ -154,7 +160,10 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
   ]);
 
   const connect = useCallback(
-    async (walletId: string, options?: ConnectOptions) => {
+    async <const Wallet extends WalletIdentifier>(
+      walletId: Wallet,
+      options?: ConnectOptionsFor<Wallet>
+    ) => {
       const attempt = beginConnectionAttempt();
       let failure: unknown;
       try {

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -8,13 +8,8 @@ import {
   useState,
 } from 'react';
 import { WalletErrorCode, WalletManager, isWalletError } from '@xrpl-connect/core';
-import type {
-  AccountInfo,
-  NetworkInfo,
-  WalletError,
-  ConnectOptionsFor,
-  WalletIdentifier,
-} from '@xrpl-connect/core';
+import type { AccountInfo, NetworkInfo, WalletError } from '@xrpl-connect/core';
+import type { ConnectOptionsFor, WalletIdentifier } from 'xrpl-connect';
 import type {
   XrplConnectContextValue,
   XrplConnectProviderProps,

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -4,7 +4,7 @@ import type {
   AccountInfo,
   NetworkInfo,
   WalletError,
-  ConnectOptions,
+  ConnectOptionsFor,
   WalletIdentifier,
 } from '@xrpl-connect/core';
 import type { CSSProperties, ReactNode } from 'react';
@@ -29,7 +29,10 @@ export interface XrplConnectContextValue {
   connecting: boolean;
   /** The most recent connection/adapter error, as a typed `WalletError`. */
   error: WalletError | null;
-  connect: (walletId: WalletIdentifier, options?: ConnectOptions) => Promise<AccountInfo>;
+  connect: <const Wallet extends WalletIdentifier>(
+    walletId: Wallet,
+    options?: ConnectOptionsFor<Wallet>
+  ) => Promise<AccountInfo>;
   disconnect: () => Promise<void>;
   /** @internal — used by `<WalletConnector>` to register its element. */
   registerConnector: (el: WalletConnectorElement) => void;

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -4,9 +4,8 @@ import type {
   AccountInfo,
   NetworkInfo,
   WalletError,
-  ConnectOptionsFor,
-  WalletIdentifier,
 } from '@xrpl-connect/core';
+import type { ConnectOptionsFor, WalletIdentifier } from 'xrpl-connect';
 import type { CSSProperties, ReactNode } from 'react';
 
 /**

--- a/packages/react/tests/publish/types-react-cjs.cts
+++ b/packages/react/tests/publish/types-react-cjs.cts
@@ -18,6 +18,12 @@ import type {
 const provider: ComponentType<ComponentProps<typeof XrplConnectProvider>> = XrplConnectProvider;
 const connector: ComponentType<WalletConnectorProps> = WalletConnector;
 const signer = null as unknown as ReturnType<typeof useSigner>;
+const wallet = null as unknown as ReturnType<typeof useWallet>;
+void wallet.connect('xaman', { apiKey: 'api-key' });
+void wallet.connect('walletconnect', { projectId: 'project-id' });
+// @ts-expect-error Xaman deferred options do not accept a WalletConnect project ID.
+void wallet.connect('xaman', { projectId: 'project-id' });
+void wallet.connect('custom-wallet', { customCredential: 'credential' });
 const signedTransaction: Promise<ManagedSignedTransaction> = signer.sign({} as Transaction);
 const signedMessage: Promise<ManagedSignedMessage> = signer.signMessage('message');
 const errorGuard: (error: unknown) => error is WalletError = isWalletError;

--- a/packages/react/tests/publish/types-react-cjs.cts
+++ b/packages/react/tests/publish/types-react-cjs.cts
@@ -15,6 +15,16 @@ import type {
   WalletError,
 } from 'xrpl-connect';
 
+interface TypedCustomWalletOptions {
+  credential: string;
+}
+
+declare module 'xrpl-connect' {
+  interface WalletConnectionOptionsById {
+    'typed-custom-wallet': TypedCustomWalletOptions;
+  }
+}
+
 const provider: ComponentType<ComponentProps<typeof XrplConnectProvider>> = XrplConnectProvider;
 const connector: ComponentType<WalletConnectorProps> = WalletConnector;
 const signer = null as unknown as ReturnType<typeof useSigner>;
@@ -24,6 +34,9 @@ void wallet.connect('walletconnect', { projectId: 'project-id' });
 // @ts-expect-error Xaman deferred options do not accept a WalletConnect project ID.
 void wallet.connect('xaman', { projectId: 'project-id' });
 void wallet.connect('custom-wallet', { customCredential: 'credential' });
+void wallet.connect('typed-custom-wallet', { credential: 'credential' });
+// @ts-expect-error Augmented custom wallet mappings reject unrelated options.
+void wallet.connect('typed-custom-wallet', { otherCredential: 'credential' });
 const signedTransaction: Promise<ManagedSignedTransaction> = signer.sign({} as Transaction);
 const signedMessage: Promise<ManagedSignedMessage> = signer.signMessage('message');
 const errorGuard: (error: unknown) => error is WalletError = isWalletError;

--- a/packages/react/tests/publish/types-react-esm.mts
+++ b/packages/react/tests/publish/types-react-esm.mts
@@ -30,6 +30,12 @@ const invalidNetworkConfig: XrplConnectConfig = {
 const provider: ComponentType<ComponentProps<typeof XrplConnectProvider>> = XrplConnectProvider;
 const connector: ComponentType<WalletConnectorProps> = WalletConnector;
 const signer = null as unknown as ReturnType<typeof useSigner>;
+const wallet = null as unknown as ReturnType<typeof useWallet>;
+void wallet.connect('xaman', { apiKey: 'api-key' });
+void wallet.connect('walletconnect', { projectId: 'project-id' });
+// @ts-expect-error Xaman deferred options do not accept a WalletConnect project ID.
+void wallet.connect('xaman', { projectId: 'project-id' });
+void wallet.connect('custom-wallet', { customCredential: 'credential' });
 const signedTransaction: Promise<ManagedSignedTransaction> = signer.sign({} as Transaction);
 const signedMessage: Promise<ManagedSignedMessage> = signer.signMessage('message');
 const errorGuard: (error: unknown) => error is WalletError = isWalletError;

--- a/packages/react/tests/publish/types-react-esm.mts
+++ b/packages/react/tests/publish/types-react-esm.mts
@@ -16,6 +16,16 @@ import type {
   WalletError,
 } from 'xrpl-connect';
 
+interface TypedCustomWalletOptions {
+  credential: string;
+}
+
+declare module 'xrpl-connect' {
+  interface WalletConnectionOptionsById {
+    'typed-custom-wallet': TypedCustomWalletOptions;
+  }
+}
+
 const mainnetConfig: XrplConnectConfig = { adapters: [], network: 'mainnet' };
 const customNetworkConfig: XrplConnectConfig = {
   adapters: [],
@@ -36,6 +46,9 @@ void wallet.connect('walletconnect', { projectId: 'project-id' });
 // @ts-expect-error Xaman deferred options do not accept a WalletConnect project ID.
 void wallet.connect('xaman', { projectId: 'project-id' });
 void wallet.connect('custom-wallet', { customCredential: 'credential' });
+void wallet.connect('typed-custom-wallet', { credential: 'credential' });
+// @ts-expect-error Augmented custom wallet mappings reject unrelated options.
+void wallet.connect('typed-custom-wallet', { otherCredential: 'credential' });
 const signedTransaction: Promise<ManagedSignedTransaction> = signer.sign({} as Transaction);
 const signedMessage: Promise<ManagedSignedMessage> = signer.signMessage('message');
 const errorGuard: (error: unknown) => error is WalletError = isWalletError;

--- a/packages/ui/src/services/WalletService.ts
+++ b/packages/ui/src/services/WalletService.ts
@@ -1,5 +1,11 @@
 import type { ConnectOptions, WalletAdapter, WalletManager } from '@xrpl-connect/core';
-import { createLogger, TIME, WalletErrorCode, withTimeout } from '@xrpl-connect/core';
+import {
+  createLogger,
+  isAdapterConfigured,
+  TIME,
+  WalletErrorCode,
+  withTimeout,
+} from '@xrpl-connect/core';
 import { isSafari, isMobile, delay } from '../utils';
 import { TIMINGS, ERROR_CODES } from '../constants';
 import {
@@ -14,6 +20,8 @@ const logger = createLogger('[WalletService]');
 const AVAILABILITY_TIMED_OUT = Symbol('availability-timed-out');
 
 async function checkWalletAvailability(wallet: WalletAdapter): Promise<boolean> {
+  if (!isAdapterConfigured(wallet)) return false;
+
   const result = await withTimeout<
     | { available: boolean; error?: never }
     | { available?: never; error: unknown }

--- a/packages/ui/src/wallet-connector.ts
+++ b/packages/ui/src/wallet-connector.ts
@@ -4,7 +4,13 @@
  */
 
 import type { AccountInfo, WalletAdapter, WalletManager } from '@xrpl-connect/core';
-import { createLogger, supportsPreInitialize, withTimeout, TIME } from '@xrpl-connect/core';
+import {
+  createLogger,
+  isAdapterConfigured,
+  supportsPreInitialize,
+  withTimeout,
+  TIME,
+} from '@xrpl-connect/core';
 import QRCodeStyling from 'qr-code-styling';
 import { mainStyles } from './styles/main';
 import {
@@ -473,8 +479,9 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
 
         logger.debug('Checking availability for wallets:', specifiedWalletIds);
 
-        const walletsById = new Map(manager.wallets.map((wallet) => [wallet.id, wallet]));
-        const walletsToCheck = manager.wallets.filter(
+        const configuredWallets = manager.wallets.filter((wallet) => isAdapterConfigured(wallet));
+        const walletsById = new Map(configuredWallets.map((wallet) => [wallet.id, wallet]));
+        const walletsToCheck = configuredWallets.filter(
           (wallet) =>
             specifiedWalletIds.includes(wallet.id) &&
             (!retryWalletIds || retryWalletIds.has(wallet.id))
@@ -779,7 +786,12 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
       // Find WalletConnect adapter
       const walletConnectAdapter = this.walletManager.wallets.find((w) => w.id === 'walletconnect');
 
-      if (!walletConnectAdapter || !supportsPreInitialize(walletConnectAdapter)) return;
+      if (
+        !walletConnectAdapter ||
+        !isAdapterConfigured(walletConnectAdapter) ||
+        !supportsPreInitialize(walletConnectAdapter)
+      )
+        return;
 
       try {
         logger.debug('Pre-initializing WalletConnect...');

--- a/packages/ui/src/wallet-connector.ts
+++ b/packages/ui/src/wallet-connector.ts
@@ -406,7 +406,11 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
     private async checkXamanStateOnInit() {
       try {
         const xamanAdapter = this.walletManager?.adapters?.get('xaman');
-        if (!xamanAdapter || !isXamanStateAdapter(xamanAdapter)) {
+        if (
+          !xamanAdapter ||
+          !isXamanStateAdapter(xamanAdapter) ||
+          !isAdapterConfigured(xamanAdapter)
+        ) {
           return;
         }
 

--- a/packages/ui/tests/WalletConnector.test.ts
+++ b/packages/ui/tests/WalletConnector.test.ts
@@ -83,6 +83,24 @@ describe('WalletConnector wallet availability', () => {
     vi.useRealTimers();
   });
 
+  it('does not probe Xaman session state without constructor configuration', async () => {
+    const xaman = {
+      ...createAdapter(
+        'xaman',
+        'Xaman',
+        vi.fn(async () => true)
+      ),
+      getMissingConfiguration: vi.fn(() => ['apiKey']),
+      checkXamanState: vi.fn(async () => null),
+    };
+
+    element = createElement(new WalletManager({ adapters: [xaman] }));
+    await Promise.resolve();
+
+    expect(xaman.getMissingConfiguration).toHaveBeenCalledWith(undefined);
+    expect(xaman.checkXamanState).not.toHaveBeenCalled();
+  });
+
   it('cancels a pending wallet selection before returning to the wallet list', async () => {
     const walletConnect = createAdapter(
       'walletconnect',

--- a/packages/ui/tests/wallet-connector-availability.test.ts
+++ b/packages/ui/tests/wallet-connector-availability.test.ts
@@ -66,6 +66,26 @@ describe('WalletConnectorElement availability rendering', () => {
     expect(modal).not.toContain('Unavailable Wallet');
   });
 
+  it('omits unconfigured wallets instead of presenting them as installable', async () => {
+    const unconfiguredWallet = {
+      id: 'unconfigured',
+      name: 'Unconfigured Wallet',
+      url: 'https://example.com/install',
+      getMissingConfiguration: vi.fn(() => ['credential']),
+      isAvailable: vi.fn(async () => true),
+    } as unknown as WalletAdapter;
+    const connector = mount([unconfiguredWallet]);
+    connector.setAttribute('show-unavailable', '');
+
+    await connector.open();
+
+    const modal = connector.getOverlayRoot()?.innerHTML ?? '';
+    expect(unconfiguredWallet.getMissingConfiguration).toHaveBeenCalledWith(undefined);
+    expect(unconfiguredWallet.isAvailable).not.toHaveBeenCalled();
+    expect(modal).not.toContain('data-wallet-id="unconfigured"');
+    expect(modal).not.toContain('Unconfigured Wallet');
+  });
+
   it('preserves unavailable slots while applying MRU order to available wallets', async () => {
     const connector = mount([
       createWallet('unavailable-first', false, 'https://example.com/first'),

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -65,6 +65,19 @@ const { ready, open } = useWalletModal();
   hidden by default; set the camelCase Vue prop `showUnavailable` to show an Install action when
   the adapter provides a download URL, or a disabled Unavailable row otherwise.
 
+`useWallet().connect` narrows deferred options from the wallet ID:
+
+```ts
+const { connect } = useWallet();
+await connect('xaman', { apiKey: 'YOUR_KEY' });
+await connect('walletconnect', { projectId: 'YOUR_PROJECT_ID' });
+```
+
+For modal discovery and `autoConnect`, configure these credentials on the
+adapter constructor as shown above. Deferred credentials apply only to that
+direct call and are not persisted for reconnection. Missing configuration is a
+typed `CONFIGURATION_REQUIRED` error.
+
 The named `xrpl-connect` import also registers the wallet connector custom element, so a separate
 side-effect import is not needed. Importing `@xrpl-commons/xrpl-connect-vue` is SSR-safe, but plugin
 installation, injected composable calls, and wallet UI rendering must stay on the client. In

--- a/packages/vue/src/context.ts
+++ b/packages/vue/src/context.ts
@@ -11,7 +11,7 @@ import {
 import { WalletErrorCode, WalletManager, isWalletError } from '@xrpl-connect/core';
 import type {
   AccountInfo,
-  ConnectOptions,
+  ConnectOptionsFor,
   NetworkInfo,
   WalletError,
   WalletManagerOptions,
@@ -33,7 +33,10 @@ export interface XrplConnectContextValue {
   network: Readonly<Ref<NetworkInfo | null>>;
   connecting: Readonly<Ref<boolean>>;
   error: Readonly<Ref<WalletError | null>>;
-  connect(walletId: WalletIdentifier, options?: ConnectOptions): Promise<AccountInfo>;
+  connect<const Wallet extends WalletIdentifier>(
+    walletId: Wallet,
+    options?: ConnectOptionsFor<Wallet>
+  ): Promise<AccountInfo>;
   disconnect(): Promise<void>;
 }
 
@@ -141,7 +144,10 @@ export function createXrplConnect(config: XrplConnectConfig): Plugin {
         connecting: readonly(connecting),
         error: readonly(error),
         ready: readonly(ready),
-        async connect(walletId, options) {
+        async connect<const Wallet extends WalletIdentifier>(
+          walletId: Wallet,
+          options?: ConnectOptionsFor<Wallet>
+        ) {
           const attempt = beginConnectionAttempt();
           let failure: unknown;
           try {

--- a/packages/vue/src/context.ts
+++ b/packages/vue/src/context.ts
@@ -11,12 +11,11 @@ import {
 import { WalletErrorCode, WalletManager, isWalletError } from '@xrpl-connect/core';
 import type {
   AccountInfo,
-  ConnectOptionsFor,
   NetworkInfo,
   WalletError,
   WalletManagerOptions,
-  WalletIdentifier,
 } from '@xrpl-connect/core';
+import type { ConnectOptionsFor, WalletIdentifier } from 'xrpl-connect';
 
 export interface WalletConnectorElement extends HTMLElement {
   setWalletManager(manager: WalletManager): void;

--- a/packages/vue/tests/publish/types-vue-cjs.cts
+++ b/packages/vue/tests/publish/types-vue-cjs.cts
@@ -15,6 +15,16 @@ import type {
   WalletError,
 } from 'xrpl-connect';
 
+interface TypedCustomWalletOptions {
+  credential: string;
+}
+
+declare module 'xrpl-connect' {
+  interface WalletConnectionOptionsById {
+    'typed-custom-wallet': TypedCustomWalletOptions;
+  }
+}
+
 const plugin: Plugin = createXrplConnect({ adapters: [] });
 const connector: Component = WalletConnector;
 type WalletConnectorProps = InstanceType<typeof WalletConnector>['$props'];
@@ -37,6 +47,9 @@ void wallet.connect('walletconnect', { projectId: 'project-id' });
 // @ts-expect-error Xaman deferred options do not accept a WalletConnect project ID.
 void wallet.connect('xaman', { projectId: 'project-id' });
 void wallet.connect('custom-wallet', { customCredential: 'credential' });
+void wallet.connect('typed-custom-wallet', { credential: 'credential' });
+// @ts-expect-error Augmented custom wallet mappings reject unrelated options.
+void wallet.connect('typed-custom-wallet', { otherCredential: 'credential' });
 const signedTransaction: Promise<ManagedSignedTransaction> = signer.sign({} as Transaction);
 const signedMessage: Promise<ManagedSignedMessage> = signer.signMessage('message');
 const errorGuard: (error: unknown) => error is WalletError = isWalletError;

--- a/packages/vue/tests/publish/types-vue-cjs.cts
+++ b/packages/vue/tests/publish/types-vue-cjs.cts
@@ -31,6 +31,12 @@ modal.ready.value = true;
 const modalOpen: Promise<void> = modal.open();
 const modalAccount: Promise<AccountInfo> = modal.openAndWait();
 const signer = null as unknown as ReturnType<typeof useSigner>;
+const wallet = null as unknown as ReturnType<typeof useWallet>;
+void wallet.connect('xaman', { apiKey: 'api-key' });
+void wallet.connect('walletconnect', { projectId: 'project-id' });
+// @ts-expect-error Xaman deferred options do not accept a WalletConnect project ID.
+void wallet.connect('xaman', { projectId: 'project-id' });
+void wallet.connect('custom-wallet', { customCredential: 'credential' });
 const signedTransaction: Promise<ManagedSignedTransaction> = signer.sign({} as Transaction);
 const signedMessage: Promise<ManagedSignedMessage> = signer.signMessage('message');
 const errorGuard: (error: unknown) => error is WalletError = isWalletError;

--- a/packages/vue/tests/publish/types-vue-esm.mts
+++ b/packages/vue/tests/publish/types-vue-esm.mts
@@ -43,6 +43,12 @@ modal.ready.value = true;
 const modalOpen: Promise<void> = modal.open();
 const modalAccount: Promise<AccountInfo> = modal.openAndWait();
 const signer = null as unknown as ReturnType<typeof useSigner>;
+const wallet = null as unknown as ReturnType<typeof useWallet>;
+void wallet.connect('xaman', { apiKey: 'api-key' });
+void wallet.connect('walletconnect', { projectId: 'project-id' });
+// @ts-expect-error Xaman deferred options do not accept a WalletConnect project ID.
+void wallet.connect('xaman', { projectId: 'project-id' });
+void wallet.connect('custom-wallet', { customCredential: 'credential' });
 const signedTransaction: Promise<ManagedSignedTransaction> = signer.sign({} as Transaction);
 const signedMessage: Promise<ManagedSignedMessage> = signer.signMessage('message');
 const errorGuard: (error: unknown) => error is WalletError = isWalletError;

--- a/packages/vue/tests/publish/types-vue-esm.mts
+++ b/packages/vue/tests/publish/types-vue-esm.mts
@@ -16,6 +16,16 @@ import type {
   WalletError,
 } from 'xrpl-connect';
 
+interface TypedCustomWalletOptions {
+  credential: string;
+}
+
+declare module 'xrpl-connect' {
+  interface WalletConnectionOptionsById {
+    'typed-custom-wallet': TypedCustomWalletOptions;
+  }
+}
+
 const mainnetConfig: XrplConnectConfig = { adapters: [], network: 'mainnet' };
 const customNetworkConfig: XrplConnectConfig = {
   adapters: [],
@@ -49,6 +59,9 @@ void wallet.connect('walletconnect', { projectId: 'project-id' });
 // @ts-expect-error Xaman deferred options do not accept a WalletConnect project ID.
 void wallet.connect('xaman', { projectId: 'project-id' });
 void wallet.connect('custom-wallet', { customCredential: 'credential' });
+void wallet.connect('typed-custom-wallet', { credential: 'credential' });
+// @ts-expect-error Augmented custom wallet mappings reject unrelated options.
+void wallet.connect('typed-custom-wallet', { otherCredential: 'credential' });
 const signedTransaction: Promise<ManagedSignedTransaction> = signer.sign({} as Transaction);
 const signedMessage: Promise<ManagedSignedMessage> = signer.signMessage('message');
 const errorGuard: (error: unknown) => error is WalletError = isWalletError;

--- a/packages/xrpl-connect/README.md
+++ b/packages/xrpl-connect/README.md
@@ -672,6 +672,13 @@ const walletChoices: Array<{ id: WalletId; name: string }> = ADAPTER_DESCRIPTORS
 );
 ```
 
+Xaman and WalletConnect need constructor credentials to appear in wallet
+discovery. Direct flows may defer a credential with typed wallet-specific
+options, for example `walletManager.connect('xaman', { apiKey })` or
+`walletManager.connect('walletconnect', { projectId })`. Deferred credentials
+apply only to that call and are not persisted, so configure constructors when
+using automatic reconnection.
+
 ### Conditional Adapter Loading
 
 ```typescript

--- a/packages/xrpl-connect/scripts/test-publish.mjs
+++ b/packages/xrpl-connect/scripts/test-publish.mjs
@@ -422,8 +422,9 @@ try {
     const installedFrameworkFolder = path.join(consumerFolder, 'node_modules', name);
     for (const declaration of ['dist/index.d.ts', 'dist/index.d.mts']) {
       const contents = readFileSync(path.join(installedFrameworkFolder, declaration), 'utf-8');
+      const declarationCode = contents.replace(/\/\*[\s\S]*?\*\//g, '');
       assert(
-        !contents.includes('@xrpl-connect/core'),
+        !declarationCode.includes('@xrpl-connect/core'),
         `${name}/${declaration} leaks the development-only @xrpl-connect/core package`
       );
     }

--- a/packages/xrpl-connect/tests/publish/types-cjs.cts
+++ b/packages/xrpl-connect/tests/publish/types-cjs.cts
@@ -5,6 +5,9 @@ import {
   createAdapters,
   GemWalletAPI,
   MetaMaskSnapAdapter,
+  WalletConnectAdapter,
+  WalletManager,
+  XamanAdapter,
   WalletConnectorElement,
   XamanOAuth2,
   XamanSDK,
@@ -22,6 +25,16 @@ import {
   type XyraConnectOptions,
 } from 'xrpl-connect';
 
+interface TypedCustomWalletOptions {
+  credential: string;
+}
+
+declare module 'xrpl-connect' {
+  interface WalletConnectionOptionsById {
+    'typed-custom-wallet': TypedCustomWalletOptions;
+  }
+}
+
 const standardWalletId: WalletId = STANDARD_WALLET_IDS[0];
 const customWalletId: WalletIdentifier = 'custom-wallet';
 // @ts-expect-error WalletId is the literal union of packaged adapter IDs.
@@ -31,6 +44,25 @@ const packagedAdapters = createAdapters({
   xaman: { apiKey: 'api-key' },
   walletconnect: { projectId: 'project-id' },
 });
+const manager = new WalletManager({ adapters: packagedAdapters });
+const configuredXaman = new XamanAdapter({ apiKey: 'api-key' });
+const deferredXaman = new XamanAdapter();
+const configuredWalletConnect = new WalletConnectAdapter({ projectId: 'project-id' });
+const deferredWalletConnect = new WalletConnectAdapter();
+// @ts-expect-error Xaman constructor options do not accept a WalletConnect project ID.
+new XamanAdapter({ projectId: 'project-id' });
+// @ts-expect-error WalletConnect constructor options do not accept a Xaman API key.
+new WalletConnectAdapter({ apiKey: 'api-key' });
+void manager.connect('xaman', { apiKey: 'api-key' });
+void manager.connect('walletconnect', { projectId: 'project-id' });
+// @ts-expect-error Xaman deferred options do not accept a WalletConnect project ID.
+void manager.connect('xaman', { projectId: 'project-id' });
+// @ts-expect-error WalletConnect deferred options do not accept a Xaman API key.
+void manager.connect('walletconnect', { apiKey: 'api-key' });
+void manager.connect('custom-wallet', { customCredential: 'credential' });
+void manager.connect('typed-custom-wallet', { credential: 'credential' });
+// @ts-expect-error Interface-shaped custom mappings reject unrelated options.
+void manager.connect('typed-custom-wallet', { otherCredential: 'credential' });
 // @ts-expect-error WalletConnect constructor options do not accept a Xaman API key.
 createAdapters({ walletconnect: { apiKey: 'api-key' } });
 
@@ -96,6 +128,11 @@ void [
   invalidStandardWalletId,
   descriptorWalletId,
   packagedAdapters,
+  manager,
+  configuredXaman,
+  deferredXaman,
+  configuredWalletConnect,
+  deferredWalletConnect,
   xamanConstructor,
   xamanReturnUrl,
   oauthConstructor,

--- a/packages/xrpl-connect/tests/publish/types-esm.mts
+++ b/packages/xrpl-connect/tests/publish/types-esm.mts
@@ -5,6 +5,9 @@ import {
   createAdapters,
   GemWalletAPI,
   MetaMaskSnapAdapter,
+  WalletConnectAdapter,
+  WalletManager,
+  XamanAdapter,
   WalletConnectorElement,
   XamanOAuth2,
   XamanSDK,
@@ -25,6 +28,16 @@ import {
   type XyraConnectOptions,
 } from 'xrpl-connect';
 
+interface TypedCustomWalletOptions {
+  credential: string;
+}
+
+declare module 'xrpl-connect' {
+  interface WalletConnectionOptionsById {
+    'typed-custom-wallet': TypedCustomWalletOptions;
+  }
+}
+
 const standardNetworkId: StandardNetworkId = 'mainnet';
 const standardWalletId: WalletId = STANDARD_WALLET_IDS[0];
 const customWalletId: WalletIdentifier = 'custom-wallet';
@@ -36,6 +49,25 @@ const packagedAdapters = createAdapters({
   walletconnect: { projectId: 'project-id' },
   ledger: { accountIndex: 1 },
 });
+const manager = new WalletManager({ adapters: packagedAdapters });
+const configuredXaman = new XamanAdapter({ apiKey: 'api-key' });
+const deferredXaman = new XamanAdapter();
+const configuredWalletConnect = new WalletConnectAdapter({ projectId: 'project-id' });
+const deferredWalletConnect = new WalletConnectAdapter();
+// @ts-expect-error Xaman constructor options do not accept a WalletConnect project ID.
+new XamanAdapter({ projectId: 'project-id' });
+// @ts-expect-error WalletConnect constructor options do not accept a Xaman API key.
+new WalletConnectAdapter({ apiKey: 'api-key' });
+void manager.connect('xaman', { apiKey: 'api-key' });
+void manager.connect('walletconnect', { projectId: 'project-id' });
+// @ts-expect-error Xaman deferred options do not accept a WalletConnect project ID.
+void manager.connect('xaman', { projectId: 'project-id' });
+// @ts-expect-error WalletConnect deferred options do not accept a Xaman API key.
+void manager.connect('walletconnect', { apiKey: 'api-key' });
+void manager.connect('custom-wallet', { customCredential: 'credential' });
+void manager.connect('typed-custom-wallet', { credential: 'credential' });
+// @ts-expect-error Interface-shaped custom mappings reject unrelated options.
+void manager.connect('typed-custom-wallet', { otherCredential: 'credential' });
 // @ts-expect-error Xaman constructor options do not accept a WalletConnect project ID.
 createAdapters({ xaman: { projectId: 'project-id' } });
 const standardNetworkConfig: NetworkConfig = standardNetworkId;
@@ -110,6 +142,11 @@ void [
   invalidStandardWalletId,
   descriptorWalletId,
   packagedAdapters,
+  manager,
+  configuredXaman,
+  deferredXaman,
+  configuredWalletConnect,
+  deferredWalletConnect,
   standardNetworkConfig,
   customNetworkConfig,
   invalidNetworkConfig,


### PR DESCRIPTION
## Summary

- preserve Xaman and WalletConnect deferred credential types through core, React, and Vue APIs
- validate adapter configuration before availability checks and omit unusable adapters from wallet discovery
- add clear configuration errors plus runtime, packed declaration, and documentation coverage

## Test plan

- `pnpm exec vp check`
- `pnpm test`
- `pnpm --filter xrpl-connect test:publish`

Fixes #149
