### PR TITLE
feat: define customization contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Vue: make `useWalletModal()` awaitable with connector readiness, `openAndWait()`, explicit missing-connector failures, and deterministic ownership when multiple connectors are mounted (#145).
 - Vue: expose the native unavailable-wallet display behavior through the typed `showUnavailable` component prop (#146).
+- UI: export the exact wallet-connector CSS-variable contract and stable modal portal/part metadata, with typed React and Vue overrides and connected-account modal styling hooks (#151).
 
 ### Fixed
 

--- a/docs/guide/customization.md
+++ b/docs/guide/customization.md
@@ -87,12 +87,10 @@ In your CSS file or global styles:
 
 #### Status Colors
 
-| Variable             | Default                   | Purpose                  |
-| -------------------- | ------------------------- | ------------------------ |
-| `--xc-success-color` | `#10b981`                 | Success state (green)    |
-| `--xc-warning-color` | `#f59e0b`                 | Warning state (yellow)   |
-| `--xc-danger-color`  | `#ef4444`                 | Error/danger state (red) |
-| `--xc-focus-color`   | `var(--xc-primary-color)` | Focus/active state       |
+| Variable            | Default                   | Purpose                          |
+| ------------------- | ------------------------- | -------------------------------- |
+| `--xc-danger-color` | `#ef4444`                 | Error and destructive states     |
+| `--xc-focus-color`  | `var(--xc-primary-color)` | Keyboard focus indicator outline |
 
 #### Overlay & Modal
 
@@ -106,10 +104,10 @@ In your CSS file or global styles:
 
 ### Spacing & Typography Variables
 
-| Variable             | Default           | Purpose                                |
-| -------------------- | ----------------- | -------------------------------------- |
-| `--xc-font-family`   | System font stack | Typography for all text                |
-| `--xc-border-radius` | `12px`            | Default roundness for modals and cards |
+| Variable             | Default           | Purpose                 |
+| -------------------- | ----------------- | ----------------------- |
+| `--xc-font-family`   | System font stack | Typography for all text |
+| `--xc-border-radius` | `12px`            | Default modal roundness |
 
 ### Connect Button Variables
 

--- a/docs/guide/customization.md
+++ b/docs/guide/customization.md
@@ -8,7 +8,7 @@ Learn how to customize the XRPL-Connect wallet component to match your applicati
 
 ## Overview
 
-The `<xrpl-wallet-connector>` web component is designed to be fully customizable. You can control:
+The `<xrpl-wallet-connector>` web component exposes a stable customization contract. You can control:
 
 - **Colors** - All UI colors via CSS variables
 - **Styling** - Typography, spacing, and borders
@@ -16,7 +16,10 @@ The `<xrpl-wallet-connector>` web component is designed to be fully customizable
 
 ## CSS Variable Customization
 
-The component uses CSS custom properties (CSS variables) prefixed with `--xc-` (xrpl-connect). Override these variables to customize the component's appearance.
+The component supports the exact CSS custom properties listed below. They are exported as
+`WALLET_CONNECTOR_CSS_VARIABLES`; TypeScript consumers can use
+`WalletConnectorCssVariable` and `WalletConnectorCssVars` from `xrpl-connect` or
+`@xrpl-connect/ui`. Unknown `--xc-*` names are not forwarded into modal portals.
 
 ### How to Apply CSS Variables
 
@@ -153,6 +156,105 @@ In your CSS file or global styles:
 | `--xc-loading-border-color` | `#0EA5E9` | Loading spinner color |
 
 > Variables marked "derived" are automatically computed from `--xc-primary-color` / `--xc-background-color`. You can still override them explicitly.
+
+### Typed overrides
+
+React and Vue use the same exact `WalletConnectorCssVars` contract as the web component:
+
+```ts
+import type { WalletConnectorCssVars } from 'xrpl-connect';
+
+const walletTheme = {
+  '--xc-primary-color': '#7c3aed',
+  '--xc-modal-border-radius': '16px',
+} satisfies WalletConnectorCssVars;
+```
+
+Pass `walletTheme` to React's `cssVars` prop or Vue's `:css-vars` prop. Misspelled or unsupported
+keys are rejected by TypeScript.
+
+## Shadow parts and portal hosts
+
+The connect button stays inside `<xrpl-wallet-connector>`, while both modals render into separate
+body-level shadow hosts so transformed ancestors cannot interfere with their fixed positioning.
+The following selectors and part names are stable public API:
+
+| Shadow host                        | Part selector                    | Target                     | Lifecycle                                             |
+| ---------------------------------- | -------------------------------- | -------------------------- | ----------------------------------------------------- |
+| `xrpl-wallet-connector`            | `::part(connect-button)`         | Connect/account button     | Present while the connector is mounted                |
+| `[data-xrpl-overlay-portal]`       | `::part(overlay)`                | Wallet modal backdrop      | Shadow content exists while the wallet modal is open  |
+| `[data-xrpl-overlay-portal]`       | `::part(modal)`                  | Wallet modal container     | Shadow content exists while the wallet modal is open  |
+| `[data-xrpl-overlay-portal]`       | `::part(close-button)`           | Wallet modal close button  | Present in every wallet modal view                    |
+| `[data-xrpl-account-modal-portal]` | `::part(overlay)`                | Account modal backdrop     | Shadow content exists while the account modal is open |
+| `[data-xrpl-account-modal-portal]` | `::part(modal)`                  | Account modal container    | Shadow content exists while the account modal is open |
+| `[data-xrpl-account-modal-portal]` | `::part(close-button)`           | Account modal close button | Present while the account modal is open               |
+| `[data-xrpl-account-modal-portal]` | `::part(account-address-button)` | Address/copy button        | Present while the account modal is open               |
+| `[data-xrpl-account-modal-portal]` | `::part(disconnect-button)`      | Disconnect button          | Present while the account modal is open               |
+
+Each portal host is created on its modal's first open, kept with an empty shadow root after close for
+reuse, and removed when its owning connector is unmounted. Every variable in
+`WALLET_CONNECTOR_CSS_VARIABLES` is copied from the connector's computed style to both portal hosts.
+
+### Styling both modals
+
+```css
+xrpl-wallet-connector::part(connect-button) {
+  min-width: 12rem;
+}
+
+[data-xrpl-overlay-portal]::part(modal),
+[data-xrpl-account-modal-portal]::part(modal) {
+  border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
+}
+
+[data-xrpl-account-modal-portal]::part(disconnect-button) {
+  text-transform: uppercase;
+}
+```
+
+The portal hosts are direct children of `<body>`, not descendants of your Vue component. Put portal
+rules in an unscoped/global stylesheet. In a Vue single-file component, either use a separate
+unscoped block:
+
+```vue
+<style>
+[data-xrpl-overlay-portal]::part(modal),
+[data-xrpl-account-modal-portal]::part(modal) {
+  max-width: 30rem;
+}
+</style>
+```
+
+or explicitly escape a scoped block:
+
+```vue
+<style scoped>
+:global([data-xrpl-overlay-portal]::part(modal)),
+:global([data-xrpl-account-modal-portal]::part(modal)) {
+  max-width: 30rem;
+}
+</style>
+```
+
+For Nuxt, place the portal rules in a global asset:
+
+```css
+/* assets/css/xrpl-connect.css */
+[data-xrpl-overlay-portal]::part(modal),
+[data-xrpl-account-modal-portal]::part(modal) {
+  max-width: 30rem;
+}
+```
+
+and register it in `nuxt.config.ts`:
+
+```ts
+export default defineNuxtConfig({
+  css: ['~/assets/css/xrpl-connect.css'],
+});
+```
+
+Scoped descendant selectors and `:deep()` cannot reach these body-level portal hosts.
 
 ## Primary Wallet Attribute
 
@@ -348,4 +450,5 @@ Want to see your customizations in real-time? Check out the **[Customization Bui
 
 ### Need More Control?
 
-For advanced customization beyond CSS variables, check out the [API Reference](/guide/api-reference) for component methods and events you can use to build custom UI.
+Use the stable portal-host and shadow-part selectors above. For component methods and events, see
+the [API Reference](/guide/api-reference).

--- a/examples/vanilla-js/index.html
+++ b/examples/vanilla-js/index.html
@@ -131,15 +131,15 @@
     <xrpl-wallet-connector
       id="wallet-connector"
       style="
-        --xrpl-background-color: #1a202c;
-        --xrpl-background-secondary: #2d3748;
-        --xrpl-background-tertiary: #4a5568;
-        --xrpl-text-color: #f5f4e7;
-        --xrpl-text-muted-color: rgba(245, 244, 231, 0.6);
-        --xrpl-primary-color: #3b99fc;
-        --xrpl-font-family: inherit;
-        --xrpl-border-radius: 12px;
-        --xrpl-modal-box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+        --xc-background-color: #1a202c;
+        --xc-background-secondary: #2d3748;
+        --xc-background-tertiary: #4a5568;
+        --xc-text-color: #f5f4e7;
+        --xc-text-muted-color: rgba(245, 244, 231, 0.6);
+        --xc-primary-color: #3b99fc;
+        --xc-font-family: inherit;
+        --xc-border-radius: 12px;
+        --xc-modal-box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
       "
       primary-wallet="xaman"
     >

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -5,7 +5,7 @@ import type {
   NetworkInfo,
   WalletError,
 } from '@xrpl-connect/core';
-import type { ConnectOptionsFor, WalletIdentifier } from 'xrpl-connect';
+import type { ConnectOptionsFor, WalletConnectorCssVars, WalletIdentifier } from 'xrpl-connect';
 import type { CSSProperties, ReactNode } from 'react';
 
 /**
@@ -74,8 +74,8 @@ export interface WalletConnectorProps {
   wallets?: WalletIdentifier[];
   /** Built-in theme preset. Overridden per-token by `cssVars`. */
   theme?: WalletConnectorTheme;
-  /** Arbitrary `--xc-*` custom properties to override modal styling. */
-  cssVars?: Record<`--xc-${string}`, string>;
+  /** Supported `--xc-*` custom properties to override modal styling. */
+  cssVars?: WalletConnectorCssVars;
   /** Extra inline styles forwarded to the host element. */
   style?: CSSProperties;
   className?: string;

--- a/packages/react/tests/public-api.types.ts
+++ b/packages/react/tests/public-api.types.ts
@@ -1,5 +1,5 @@
 import type { AccountInfo } from '@xrpl-connect/core';
-import type { WalletConnectorElement } from '../dist/index';
+import type { WalletConnectorElement, WalletConnectorProps } from '../dist/index';
 
 declare const connector: WalletConnectorElement;
 declare const manager: Parameters<WalletConnectorElement['setWalletManager']>[0];
@@ -9,6 +9,13 @@ const openResult: Promise<void> = connector.open();
 const accountResult: Promise<AccountInfo> = connector.openAndWait();
 const closeResult: void = connector.close();
 const toggleResult: void = connector.toggle();
+const cssVarsProps: WalletConnectorProps = { cssVars: { '--xc-primary-color': '#7c3aed' } };
+const invalidCssVarsProps: WalletConnectorProps = {
+  cssVars: {
+    // @ts-expect-error Unsupported or misspelled CSS variables are rejected.
+    '--xc-primary-colro': '#7c3aed',
+  },
+};
 
 // Implementation details must not leak into the public element contract.
 // @ts-expect-error openAccountModal is internal to the web component implementation.
@@ -21,3 +28,5 @@ void openResult;
 void accountResult;
 void closeResult;
 void toggleResult;
+void cssVarsProps;
+void invalidCssVarsProps;

--- a/packages/react/tests/publish/types-react-cjs.cts
+++ b/packages/react/tests/publish/types-react-cjs.cts
@@ -27,6 +27,13 @@ declare module 'xrpl-connect' {
 
 const provider: ComponentType<ComponentProps<typeof XrplConnectProvider>> = XrplConnectProvider;
 const connector: ComponentType<WalletConnectorProps> = WalletConnector;
+const cssVarsProps: WalletConnectorProps = { cssVars: { '--xc-primary-color': '#7c3aed' } };
+const invalidCssVarsProps: WalletConnectorProps = {
+  cssVars: {
+    // @ts-expect-error Published React props reject unsupported CSS variables.
+    '--xc-primary-colro': '#7c3aed',
+  },
+};
 const signer = null as unknown as ReturnType<typeof useSigner>;
 const wallet = null as unknown as ReturnType<typeof useWallet>;
 void wallet.connect('xaman', { apiKey: 'api-key' });
@@ -41,4 +48,14 @@ const signedTransaction: Promise<ManagedSignedTransaction> = signer.sign({} as T
 const signedMessage: Promise<ManagedSignedMessage> = signer.signMessage('message');
 const errorGuard: (error: unknown) => error is WalletError = isWalletError;
 
-void [provider, connector, signedTransaction, signedMessage, errorGuard, useWallet, useWalletModal];
+void [
+  provider,
+  connector,
+  cssVarsProps,
+  invalidCssVarsProps,
+  signedTransaction,
+  signedMessage,
+  errorGuard,
+  useWallet,
+  useWalletModal,
+];

--- a/packages/react/tests/publish/types-react-esm.mts
+++ b/packages/react/tests/publish/types-react-esm.mts
@@ -39,6 +39,13 @@ const invalidNetworkConfig: XrplConnectConfig = {
 
 const provider: ComponentType<ComponentProps<typeof XrplConnectProvider>> = XrplConnectProvider;
 const connector: ComponentType<WalletConnectorProps> = WalletConnector;
+const cssVarsProps: WalletConnectorProps = { cssVars: { '--xc-primary-color': '#7c3aed' } };
+const invalidCssVarsProps: WalletConnectorProps = {
+  cssVars: {
+    // @ts-expect-error Published React props reject unsupported CSS variables.
+    '--xc-primary-colro': '#7c3aed',
+  },
+};
 const signer = null as unknown as ReturnType<typeof useSigner>;
 const wallet = null as unknown as ReturnType<typeof useWallet>;
 void wallet.connect('xaman', { apiKey: 'api-key' });
@@ -56,6 +63,8 @@ const errorGuard: (error: unknown) => error is WalletError = isWalletError;
 void [
   provider,
   connector,
+  cssVarsProps,
+  invalidCssVarsProps,
   signedTransaction,
   signedMessage,
   errorGuard,

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -53,9 +53,9 @@ A Web Component is a reusable, encapsulated HTML element built using the Web Com
     <xrpl-wallet-connector
       primary-wallet="xaman"
       style="
-        --xrpl-primary-color: #0EA5E9;
-        --xrpl-background-color: #000637;
-        --xrpl-text-color: #F5F4E7;
+        --xc-primary-color: #0EA5E9;
+        --xc-background-color: #000637;
+        --xc-text-color: #F5F4E7;
       "
     ></xrpl-wallet-connector>
   </body>
@@ -72,7 +72,8 @@ All attributes are optional and control the behavior of the component:
 | `wallets`          | string  | -       | Comma-separated list of wallet IDs to include (e.g., `'xaman,crossmark,walletconnect'`)   |
 | `show-unavailable` | boolean | false   | Show unavailable wallets with an Install link, or a disabled row when no URL is available |
 
-All styling is controlled exclusively via CSS variables (see [Customization](./CUSTOMIZATION.md) guide).
+Use the supported CSS variables and stable shadow parts documented in the
+[Customization Guide](https://github.com/XRPL-Commons/xrpl-connect/blob/develop/docs/guide/customization.md).
 
 ### JavaScript API
 
@@ -341,7 +342,9 @@ Shows error message and recovery options.
 
 ## Customization
 
-The component is fully customizable using CSS variables. See the [Customization Guide](./CUSTOMIZATION.md) for comprehensive documentation.
+The component exposes exact CSS variables plus stable shadow parts. See the
+[Customization Guide](https://github.com/XRPL-Commons/xrpl-connect/blob/develop/docs/guide/customization.md)
+for the complete contract.
 
 ### Theme Colors
 
@@ -350,10 +353,10 @@ Control the appearance via CSS variables:
 ```html
 <xrpl-wallet-connector
   style="
-    --xrpl-background-color: #1a1a2e;
-    --xrpl-text-color: #eaeaea;
-    --xrpl-primary-color: #00d4ff;
-    --xrpl-font-family: 'Inter', sans-serif;
+    --xc-background-color: #1a1a2e;
+    --xc-text-color: #eaeaea;
+    --xc-primary-color: #00d4ff;
+    --xc-font-family: 'Inter', sans-serif;
   "
 ></xrpl-wallet-connector>
 ```
@@ -362,10 +365,10 @@ Or define variables in your stylesheet:
 
 ```css
 :root {
-  --xrpl-background-color: #1a1a2e;
-  --xrpl-text-color: #eaeaea;
-  --xrpl-primary-color: #00d4ff;
-  --xrpl-font-family: 'Inter', sans-serif;
+  --xc-background-color: #1a1a2e;
+  --xc-text-color: #eaeaea;
+  --xc-primary-color: #00d4ff;
+  --xc-font-family: 'Inter', sans-serif;
 }
 ```
 
@@ -639,27 +642,28 @@ customElements.define('xrpl-wallet-connector', WalletConnectorElement);
 
 ### Shadow DOM Structure
 
-The component creates an isolated DOM tree inside the Shadow DOM:
+The connect button uses the component's shadow root. Each modal uses a separate body-level portal
+host so fixed positioning is not constrained by transformed ancestors:
 
 ```html
-#shadow-root (open)
-<style>
-  /* Scoped styles */
-</style>
+<xrpl-wallet-connector>
+  #shadow-root (open)
+  <button part="connect-button">Connect Wallet</button>
 
-<div class="overlay">
-  <div class="modal">
-    <div class="modal-header">
-      <h2>Connect Wallet</h2>
-      <button class="close-btn">×</button>
-    </div>
+  <div data-xrpl-overlay-portal>
+    #shadow-root (open)
+    <div part="overlay">
+      <div part="modal">...</div>
 
-    <div class="modal-content">
-      <!-- View content inserted here -->
-      <!-- List view, QR view, Loading view, or Error view -->
+      <div data-xrpl-account-modal-portal>
+        #shadow-root (open)
+        <div part="overlay">
+          <div part="modal">...</div>
+        </div>
+      </div>
     </div>
-  </div>
-</div>
+  </div></xrpl-wallet-connector
+>
 ```
 
 ### Styling
@@ -845,7 +849,7 @@ connector.addEventListener('connected', (e) => {
 
 **Solutions**:
 
-1. Ensure variable names use the `--xrpl-` prefix (e.g., `--xrpl-primary-color`)
+1. Use a key exported by `WALLET_CONNECTOR_CSS_VARIABLES` (for example, `--xc-primary-color`)
 2. Use valid hex colors or CSS color values (e.g., `#0EA5E9`, not `blue`)
 3. Set variables via `style` attribute or CSS before the component renders
 
@@ -853,16 +857,16 @@ connector.addEventListener('connected', (e) => {
 <!-- Correct -->
 <xrpl-wallet-connector
   style="
-    --xrpl-background-color: #000637;
-    --xrpl-text-color: #F5F4E7;
+    --xc-background-color: #000637;
+    --xc-text-color: #F5F4E7;
   "
 ></xrpl-wallet-connector>
 
 <!-- Also correct (in stylesheet) -->
 <style>
   xrpl-wallet-connector {
-    --xrpl-background-color: #000637;
-    --xrpl-text-color: #f5f4e7;
+    --xc-background-color: #000637;
+    --xc-text-color: #f5f4e7;
   }
 </style>
 ```
@@ -913,9 +917,9 @@ Previous versions used HTML attributes for styling. The component now uses CSS v
 ```html
 <xrpl-wallet-connector
   style="
-    --xrpl-background-color: #000637;
-    --xrpl-text-color: #F5F4E7;
-    --xrpl-primary-color: #0EA5E9;
+    --xc-background-color: #000637;
+    --xc-text-color: #F5F4E7;
+    --xc-primary-color: #0EA5E9;
   "
 ></xrpl-wallet-connector>
 ```
@@ -956,7 +960,7 @@ Benefits of CSS variables:
 
 The component is designed to be self-contained, but you can extend it by:
 
-1. **CSS Customization**: Use CSS variables to customize colors, sizing, and other visual properties (see [Customization Guide](./CUSTOMIZATION.md))
+1. **CSS Customization**: Use the supported CSS variables and stable shadow parts in the [Customization Guide](https://github.com/XRPL-Commons/xrpl-connect/blob/develop/docs/guide/customization.md)
 2. **Wrapping in Framework Components**: Create React/Vue wrappers if needed
 3. **Custom Adapters**: Create custom wallet adapters for additional wallet support
 4. **Event Monitoring**: Listen to all events and send to analytics

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -649,21 +649,21 @@ host so fixed positioning is not constrained by transformed ancestors:
 <xrpl-wallet-connector>
   #shadow-root (open)
   <button part="connect-button">Connect Wallet</button>
+</xrpl-wallet-connector>
 
-  <div data-xrpl-overlay-portal>
-    #shadow-root (open)
-    <div part="overlay">
-      <div part="modal">...</div>
+<div data-xrpl-overlay-portal>
+  #shadow-root (open)
+  <div part="overlay">
+    <div part="modal">...</div>
+  </div>
+</div>
 
-      <div data-xrpl-account-modal-portal>
-        #shadow-root (open)
-        <div part="overlay">
-          <div part="modal">...</div>
-        </div>
-      </div>
-    </div>
-  </div></xrpl-wallet-connector
->
+<div data-xrpl-account-modal-portal>
+  #shadow-root (open)
+  <div part="overlay">
+    <div part="modal">...</div>
+  </div>
+</div>
 ```
 
 ### Styling

--- a/packages/ui/src/customization.ts
+++ b/packages/ui/src/customization.ts
@@ -34,8 +34,6 @@ export const WALLET_CONNECTOR_CSS_VARIABLES = [
   '--xc-modal-box-shadow',
   '--xc-focus-color',
   '--xc-danger-color',
-  '--xc-success-color',
-  '--xc-warning-color',
 ] as const;
 
 /** A CSS custom property supported by {@link WALLET_CONNECTOR_CSS_VARIABLES}. */

--- a/packages/ui/src/customization.ts
+++ b/packages/ui/src/customization.ts
@@ -1,0 +1,76 @@
+/** CSS custom properties supported by the wallet connector and its portals. */
+export const WALLET_CONNECTOR_CSS_VARIABLES = [
+  '--xc-font-family',
+  '--xc-border-radius',
+  '--xc-overlay-background',
+  '--xc-overlay-backdrop-filter',
+  '--xc-primary-color',
+  '--xc-background-color',
+  '--xc-text-color',
+  '--xc-text-muted-color',
+  '--xc-background-secondary',
+  '--xc-background-tertiary',
+  '--xc-loading-border-color',
+  '--xc-connect-button-font-size',
+  '--xc-connect-button-border-radius',
+  '--xc-connect-button-color',
+  '--xc-connect-button-background',
+  '--xc-connect-button-border',
+  '--xc-connect-button-hover-background',
+  '--xc-connect-button-font-weight',
+  '--xc-primary-button-color',
+  '--xc-primary-button-background',
+  '--xc-primary-button-border-radius',
+  '--xc-primary-button-font-weight',
+  '--xc-primary-button-hover-background',
+  '--xc-secondary-button-color',
+  '--xc-secondary-button-background',
+  '--xc-secondary-button-border-radius',
+  '--xc-secondary-button-font-weight',
+  '--xc-secondary-button-hover-background',
+  '--xc-account-address-button-hover-color',
+  '--xc-modal-background',
+  '--xc-modal-border-radius',
+  '--xc-modal-box-shadow',
+  '--xc-focus-color',
+  '--xc-danger-color',
+  '--xc-success-color',
+  '--xc-warning-color',
+] as const;
+
+/** A CSS custom property supported by {@link WALLET_CONNECTOR_CSS_VARIABLES}. */
+export type WalletConnectorCssVariable = (typeof WALLET_CONNECTOR_CSS_VARIABLES)[number];
+
+/** Exact wallet connector CSS-variable overrides. */
+export type WalletConnectorCssVars = Partial<Record<WalletConnectorCssVariable, string>>;
+
+/** Stable attributes used by the body-level modal portal hosts. */
+export const WALLET_CONNECTOR_PORTAL_ATTRIBUTES = {
+  wallet: 'data-xrpl-overlay-portal',
+  account: 'data-xrpl-account-modal-portal',
+} as const;
+
+/** Stable selectors for the body-level modal portal hosts. */
+export const WALLET_CONNECTOR_PORTAL_SELECTORS = {
+  wallet: `[${WALLET_CONNECTOR_PORTAL_ATTRIBUTES.wallet}]`,
+  account: `[${WALLET_CONNECTOR_PORTAL_ATTRIBUTES.account}]`,
+} as const;
+
+/** Stable shadow parts grouped by the shadow host that exposes them. */
+export const WALLET_CONNECTOR_PARTS = {
+  connector: {
+    connectButton: 'connect-button',
+  },
+  walletModal: {
+    overlay: 'overlay',
+    modal: 'modal',
+    closeButton: 'close-button',
+  },
+  accountModal: {
+    overlay: 'overlay',
+    modal: 'modal',
+    closeButton: 'close-button',
+    addressButton: 'account-address-button',
+    disconnectButton: 'disconnect-button',
+  },
+} as const;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 export { WalletConnectorElement, type WalletConnectorElementInstance } from './wallet-connector';
+export * from './customization';
 
 // Export constants and utilities for advanced use cases
 export * from './constants';

--- a/packages/ui/src/styles/main.ts
+++ b/packages/ui/src/styles/main.ts
@@ -60,14 +60,12 @@ export const mainStyles = `
 
     /* Modal */
     --xc-modal-background: var(--xc-background-color);
-    --xc-modal-border-radius: 12px;
+    --xc-modal-border-radius: var(--xc-border-radius);
     --xc-modal-box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
 
     /* Miscellaneous */
     --xc-focus-color: var(--xc-primary-color);
     --xc-danger-color: #ef4444;
-    --xc-success-color: #10b981;
-    --xc-warning-color: #f59e0b;
 
     /* Internal aliases */
     --bg-color: var(--xc-background-color);
@@ -526,11 +524,12 @@ export const mainStyles = `
     height: ${SIZES.ICON_LARGE}px;
     border-radius: 50%;
     background: rgba(239, 68, 68, 0.1);
+    background: color-mix(in srgb, var(--xc-danger-color) 10%, transparent);
     display: flex;
     align-items: center;
     justify-content: center;
     font-size: 48px;
-    color: #ef4444;
+    color: var(--xc-danger-color);
   }
 
   .error-text {
@@ -913,6 +912,13 @@ export const mainStyles = `
   }
 
   .account-disconnect-button:hover .disconnect-icon path {
-    fill: #ef4444;
+    fill: var(--xc-danger-color);
+  }
+
+  button:focus-visible,
+  input:focus-visible,
+  .custom-path-input:focus-visible {
+    outline: 2px solid var(--xc-focus-color);
+    outline-offset: 2px;
   }
 `;

--- a/packages/ui/src/views/AccountModal.ts
+++ b/packages/ui/src/views/AccountModal.ts
@@ -1,3 +1,5 @@
+import { WALLET_CONNECTOR_PARTS } from '../customization';
+
 export function renderAccountModal(
   account: { address: string } | null,
   accountBalance: string | null,
@@ -10,9 +12,14 @@ export function renderAccountModal(
   const { color1, color2 } = generateGradientFromAddress(account.address);
 
   return `
-      <div id="account-modal-overlay" class="account-modal-overlay">
+      <div
+        id="account-modal-overlay"
+        class="account-modal-overlay"
+        part="${WALLET_CONNECTOR_PARTS.accountModal.overlay}"
+      >
         <div
           class="account-modal"
+          part="${WALLET_CONNECTOR_PARTS.accountModal.modal}"
           role="dialog"
           aria-modal="true"
           aria-labelledby="account-dialog-title"
@@ -20,7 +27,12 @@ export function renderAccountModal(
         >
           <div class="account-modal-header">
             <h2 class="account-modal-title" id="account-dialog-title">Connected</h2>
-            <button class="account-modal-close" id="account-modal-close" aria-label="Close">×</button>
+            <button
+              class="account-modal-close"
+              id="account-modal-close"
+              part="${WALLET_CONNECTOR_PARTS.accountModal.closeButton}"
+              aria-label="Close"
+            >×</button>
           </div>
 
           <div class="account-modal-content">
@@ -28,7 +40,12 @@ export function renderAccountModal(
             </div>
 
             <div class="account-info-section">
-              <button class="account-address-button" id="copy-account-address" title="Click to copy full address">
+              <button
+                class="account-address-button"
+                id="copy-account-address"
+                part="${WALLET_CONNECTOR_PARTS.accountModal.addressButton}"
+                title="Click to copy full address"
+              >
                 <span>${truncatedAddress}</span>
                 <svg
                   aria-hidden="true"
@@ -56,7 +73,11 @@ export function renderAccountModal(
               }
             </div>
 
-            <button class="account-disconnect-button" id="account-modal-disconnect">
+            <button
+              class="account-disconnect-button"
+              id="account-modal-disconnect"
+              part="${WALLET_CONNECTOR_PARTS.accountModal.disconnectButton}"
+            >
               <svg
                 aria-hidden="true"
                 width="15"

--- a/packages/ui/src/views/AccountSelectionView.ts
+++ b/packages/ui/src/views/AccountSelectionView.ts
@@ -1,3 +1,5 @@
+import { WALLET_CONNECTOR_PARTS } from '../customization';
+
 export function renderAccountSelectionView(
   walletName: string,
   walletIcon: string | undefined,
@@ -22,7 +24,7 @@ export function renderAccountSelectionView(
           <button class="back-button" id="account-selection-back-button" aria-label="Back">←</button>
           <h2 class="title" id="wallet-dialog-title">Select Account</h2>
         </div>
-        <button class="close-button" part="close-button" aria-label="Close">×</button>
+        <button class="close-button" part="${WALLET_CONNECTOR_PARTS.walletModal.closeButton}" aria-label="Close">×</button>
       </div>
 
       <div class="content">

--- a/packages/ui/src/views/ErrorView.ts
+++ b/packages/ui/src/views/ErrorView.ts
@@ -1,8 +1,10 @@
+import { WALLET_CONNECTOR_PARTS } from '../customization';
+
 export function renderErrorView(walletName: string, error: Error): string {
   return `
       <div class="header">
         <h2 class="title" id="wallet-dialog-title">Connection Failed</h2>
-        <button class="close-button" part="close-button" aria-label="Close">×</button>
+        <button class="close-button" part="${WALLET_CONNECTOR_PARTS.walletModal.closeButton}" aria-label="Close">×</button>
       </div>
 
       <div class="content">

--- a/packages/ui/src/views/LoadingView.ts
+++ b/packages/ui/src/views/LoadingView.ts
@@ -1,3 +1,5 @@
+import { WALLET_CONNECTOR_PARTS } from '../customization';
+
 export function renderLoadingView(walletName: string, walletIcon?: string): string {
   return `
       <div class="header">
@@ -5,7 +7,7 @@ export function renderLoadingView(walletName: string, walletIcon?: string): stri
           <button class="back-button" id="loading-back-button" aria-label="Back">←</button>
           <h2 class="title" id="wallet-dialog-title">Connect Wallet</h2>
         </div>
-        <button class="close-button" part="close-button" aria-label="Close">×</button>
+        <button class="close-button" part="${WALLET_CONNECTOR_PARTS.walletModal.closeButton}" aria-label="Close">×</button>
       </div>
 
       <div class="content loading-content">

--- a/packages/ui/src/views/QRView.ts
+++ b/packages/ui/src/views/QRView.ts
@@ -1,3 +1,5 @@
+import { WALLET_CONNECTOR_PARTS } from '../customization';
+
 export function renderQRView(walletName: string): string {
   return `
     <div class="header">
@@ -5,7 +7,7 @@ export function renderQRView(walletName: string): string {
         <button class="back-button" id="back-button" aria-label="Back">←</button>
         <h2 class="title" id="wallet-dialog-title">${walletName}</h2>
       </div>
-      <button class="close-button" part="close-button" aria-label="Close">×</button>
+      <button class="close-button" part="${WALLET_CONNECTOR_PARTS.walletModal.closeButton}" aria-label="Close">×</button>
     </div>
 
     <div class="content">

--- a/packages/ui/src/views/WalletListView.ts
+++ b/packages/ui/src/views/WalletListView.ts
@@ -1,4 +1,5 @@
 import type { WalletAdapter } from '@xrpl-connect/core';
+import { WALLET_CONNECTOR_PARTS } from '../customization';
 import { getSafeExternalUrl } from '../utils';
 
 function escapeHtmlAttribute(value: string): string {
@@ -18,7 +19,7 @@ export function renderWalletListView(
   return `
       <div class="header">
         <h2 class="title" id="wallet-dialog-title">Connect Wallet</h2>
-        <button class="close-button" part="close-button" aria-label="Close">×</button>
+        <button class="close-button" part="${WALLET_CONNECTOR_PARTS.walletModal.closeButton}" aria-label="Close">×</button>
       </div>
 
       <div class="content" role="region" aria-label="Wallet options" tabindex="0">

--- a/packages/ui/src/wallet-connector.ts
+++ b/packages/ui/src/wallet-connector.ts
@@ -12,6 +12,11 @@ import {
   TIME,
 } from '@xrpl-connect/core';
 import QRCodeStyling from 'qr-code-styling';
+import {
+  WALLET_CONNECTOR_CSS_VARIABLES,
+  WALLET_CONNECTOR_PARTS,
+  WALLET_CONNECTOR_PORTAL_ATTRIBUTES,
+} from './customization';
 import { mainStyles } from './styles/main';
 import {
   SIZES,
@@ -81,45 +86,6 @@ let WalletConnectorElement: {
 } | null = null;
 
 if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
-  const XC_CSS_VARIABLES = [
-    '--xc-font-family',
-    '--xc-border-radius',
-    '--xc-overlay-background',
-    '--xc-overlay-backdrop-filter',
-    '--xc-primary-color',
-    '--xc-background-color',
-    '--xc-text-color',
-    '--xc-text-muted-color',
-    '--xc-background-secondary',
-    '--xc-background-tertiary',
-    '--xc-loading-border-color',
-    '--xc-connect-button-font-size',
-    '--xc-connect-button-border-radius',
-    '--xc-connect-button-color',
-    '--xc-connect-button-background',
-    '--xc-connect-button-border',
-    '--xc-connect-button-hover-background',
-    '--xc-connect-button-font-weight',
-    '--xc-primary-button-color',
-    '--xc-primary-button-background',
-    '--xc-primary-button-border-radius',
-    '--xc-primary-button-font-weight',
-    '--xc-primary-button-hover-background',
-    '--xc-secondary-button-color',
-    '--xc-secondary-button-background',
-    '--xc-secondary-button-border-radius',
-    '--xc-secondary-button-font-weight',
-    '--xc-secondary-button-hover-background',
-    '--xc-account-address-button-hover-color',
-    '--xc-modal-background',
-    '--xc-modal-border-radius',
-    '--xc-modal-box-shadow',
-    '--xc-focus-color',
-    '--xc-danger-color',
-    '--xc-success-color',
-    '--xc-warning-color',
-  ] as const;
-
   const DERIVED_HOVER_VARIABLES = {
     connectButtonBackground: '--derived-connect-button-hover-background',
     primaryButtonBackground: '--derived-primary-button-hover-background',
@@ -225,7 +191,7 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
 
     private forwardCSSVariables(portalHost: HTMLElement): void {
       const computedStyle = window.getComputedStyle(this);
-      for (const varName of XC_CSS_VARIABLES) {
+      for (const varName of WALLET_CONNECTOR_CSS_VARIABLES) {
         const value = computedStyle.getPropertyValue(varName).trim();
         if (value) portalHost.style.setProperty(varName, value);
       }
@@ -238,7 +204,7 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
     private ensureOverlayPortal(): ShadowRoot {
       if (!this.overlayPortal) {
         this.overlayPortal = document.createElement('div');
-        this.overlayPortal.setAttribute('data-xrpl-overlay-portal', '');
+        this.overlayPortal.setAttribute(WALLET_CONNECTOR_PORTAL_ATTRIBUTES.wallet, '');
         this.overlayPortal.attachShadow({ mode: 'open' });
         document.body.appendChild(this.overlayPortal);
       }
@@ -249,7 +215,7 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
     private ensureAccountModalPortal(): ShadowRoot {
       if (!this.accountModalPortal) {
         this.accountModalPortal = document.createElement('div');
-        this.accountModalPortal.setAttribute('data-xrpl-account-modal-portal', '');
+        this.accountModalPortal.setAttribute(WALLET_CONNECTOR_PORTAL_ATTRIBUTES.account, '');
         this.accountModalPortal.attachShadow({ mode: 'open' });
         document.body.appendChild(this.accountModalPortal);
       }
@@ -1157,7 +1123,7 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
     <style>
       ${mainStyles}
     </style>
-    <button class="connect-button" id="connect-wallet-button" part="connect-button">${buttonText}</button>
+    <button class="connect-button" id="connect-wallet-button" part="${WALLET_CONNECTOR_PARTS.connector.connectButton}">${buttonText}</button>
   `;
 
       // Wallet connection overlay — rendered in a portal on document.body to guarantee
@@ -1166,10 +1132,10 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
         const overlayRoot = this.ensureOverlayPortal();
         overlayRoot.innerHTML = `
     <style>${mainStyles}</style>
-    <div class="${overlayClass}" part="overlay">
+    <div class="${overlayClass}" part="${WALLET_CONNECTOR_PARTS.walletModal.overlay}">
       <div
         class="${modalClass}"
-        part="modal"
+        part="${WALLET_CONNECTOR_PARTS.walletModal.modal}"
         role="dialog"
         aria-modal="true"
         aria-labelledby="wallet-dialog-title"

--- a/packages/ui/tests/Customization.test.ts
+++ b/packages/ui/tests/Customization.test.ts
@@ -5,6 +5,7 @@ import { WalletManager } from '@xrpl-connect/core';
 import {
   WALLET_CONNECTOR_CSS_VARIABLES,
   WALLET_CONNECTOR_PARTS,
+  WALLET_CONNECTOR_PORTAL_ATTRIBUTES,
   WALLET_CONNECTOR_PORTAL_SELECTORS,
 } from '../src/customization';
 import { mainStyles } from '../src/styles/main';
@@ -22,12 +23,19 @@ function escapeRegExp(value: string): string {
 }
 
 describe('wallet connector customization contract', () => {
-  it('keeps the public variable list aligned with the stylesheet defaults', () => {
+  it('keeps the public variable list aligned with stylesheet defaults and consumers', () => {
     const declaredVariables = [...mainStyles.matchAll(/^\s+(--xc-[\w-]+):/gm)].map(
       ([, variable]) => variable
     );
 
     expect(declaredVariables).toEqual(WALLET_CONNECTOR_CSS_VARIABLES);
+    for (const variable of WALLET_CONNECTOR_CSS_VARIABLES) {
+      const occurrences = mainStyles.match(new RegExp(escapeRegExp(variable), 'g'))?.length ?? 0;
+      expect(
+        occurrences,
+        `${variable} must be consumed outside its default declaration`
+      ).toBeGreaterThan(1);
+    }
   });
 
   it('forwards every supported variable, but not unknown variables, to both portals', async () => {
@@ -143,6 +151,28 @@ describe('wallet connector customization contract', () => {
       for (const part of Object.values(parts)) {
         expect(documentation).toMatch(documentedPart(portal, part));
       }
+    }
+  });
+
+  it('documents both portal hosts as direct body-level siblings', () => {
+    const readme = readFileSync(resolve(process.cwd(), 'README.md'), 'utf8');
+    const shadowTree = readme.split('### Shadow DOM Structure')[1]?.split('### Styling')[0] ?? '';
+    const connectorClose = shadowTree.indexOf('</xrpl-wallet-connector>');
+    const portalLines = shadowTree
+      .split('\n')
+      .filter((line) =>
+        Object.values(WALLET_CONNECTOR_PORTAL_ATTRIBUTES).some((attribute) =>
+          line.includes(attribute)
+        )
+      );
+    const expectedPortalLines = Object.values(WALLET_CONNECTOR_PORTAL_ATTRIBUTES).map(
+      (attribute) => `<div ${attribute}>`
+    );
+
+    expect(connectorClose).toBeGreaterThanOrEqual(0);
+    expect(portalLines).toEqual(expectedPortalLines);
+    for (const portalLine of portalLines) {
+      expect(shadowTree.indexOf(portalLine)).toBeGreaterThan(connectorClose);
     }
   });
 });

--- a/packages/ui/tests/Customization.test.ts
+++ b/packages/ui/tests/Customization.test.ts
@@ -1,0 +1,148 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vite-plus/test';
+import { WalletManager } from '@xrpl-connect/core';
+import {
+  WALLET_CONNECTOR_CSS_VARIABLES,
+  WALLET_CONNECTOR_PARTS,
+  WALLET_CONNECTOR_PORTAL_SELECTORS,
+} from '../src/customization';
+import { mainStyles } from '../src/styles/main';
+import { renderAccountModal } from '../src/views/AccountModal';
+import '../src/wallet-connector';
+
+function partNames(root: ParentNode): string[] {
+  return [...root.querySelectorAll('[part]')]
+    .flatMap((element) => element.getAttribute('part')?.split(/\s+/) ?? [])
+    .sort();
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+describe('wallet connector customization contract', () => {
+  it('keeps the public variable list aligned with the stylesheet defaults', () => {
+    const declaredVariables = [...mainStyles.matchAll(/^\s+(--xc-[\w-]+):/gm)].map(
+      ([, variable]) => variable
+    );
+
+    expect(declaredVariables).toEqual(WALLET_CONNECTOR_CSS_VARIABLES);
+  });
+
+  it('forwards every supported variable, but not unknown variables, to both portals', async () => {
+    const connector = document.createElement('xrpl-wallet-connector') as HTMLElement & {
+      setWalletManager(manager: WalletManager): void;
+      open(): Promise<void>;
+      close(): void;
+      openAccountModal(): void;
+      closeAccountModal(): void;
+      disconnectedCallback(): void;
+      getOverlayRoot(): ShadowRoot | null;
+      getAccountModalRoot(): ShadowRoot | null;
+    };
+    connector.setWalletManager(new WalletManager({ adapters: [] }));
+    WALLET_CONNECTOR_CSS_VARIABLES.forEach((variable, index) => {
+      connector.style.setProperty(variable, `contract-value-${index}`);
+    });
+    connector.style.setProperty('--xc-primary-colro', 'unsupported');
+    document.body.appendChild(connector);
+
+    try {
+      await connector.open();
+      connector.openAccountModal();
+
+      for (const root of [connector.getOverlayRoot(), connector.getAccountModalRoot()]) {
+        const portalHost = root?.host as HTMLElement;
+        WALLET_CONNECTOR_CSS_VARIABLES.forEach((variable, index) => {
+          expect(portalHost.style.getPropertyValue(variable)).toBe(`contract-value-${index}`);
+        });
+        expect(portalHost.style.getPropertyValue('--xc-primary-colro')).toBe('');
+      }
+
+      expect(document.querySelector(WALLET_CONNECTOR_PORTAL_SELECTORS.wallet)).not.toBeNull();
+      expect(document.querySelector(WALLET_CONNECTOR_PORTAL_SELECTORS.account)).not.toBeNull();
+      expect(connector.getOverlayRoot()?.host.parentElement).toBe(document.body);
+      expect(connector.getAccountModalRoot()?.host.parentElement).toBe(document.body);
+
+      connector.close();
+      connector.closeAccountModal();
+      expect(connector.getOverlayRoot()?.innerHTML).toBe('');
+      expect(connector.getAccountModalRoot()?.innerHTML).toBe('');
+
+      connector.remove();
+      expect(document.querySelector(WALLET_CONNECTOR_PORTAL_SELECTORS.wallet)).toBeNull();
+      expect(document.querySelector(WALLET_CONNECTOR_PORTAL_SELECTORS.account)).toBeNull();
+    } finally {
+      connector.remove();
+    }
+  });
+
+  it('keeps runtime shadow parts aligned with the public part metadata', async () => {
+    const connector = document.createElement('xrpl-wallet-connector') as HTMLElement & {
+      shadowRoot: ShadowRoot;
+      setWalletManager(manager: WalletManager): void;
+      open(): Promise<void>;
+      disconnectedCallback(): void;
+      getOverlayRoot(): ShadowRoot | null;
+    };
+    connector.setWalletManager(new WalletManager({ adapters: [] }));
+    document.body.appendChild(connector);
+
+    try {
+      await connector.open();
+      expect(partNames(connector.shadowRoot)).toEqual(
+        Object.values(WALLET_CONNECTOR_PARTS.connector)
+      );
+      expect(partNames(connector.getOverlayRoot()!)).toEqual(
+        Object.values(WALLET_CONNECTOR_PARTS.walletModal).sort()
+      );
+
+      const accountMarkup = document.createElement('div');
+      accountMarkup.innerHTML = renderAccountModal(
+        { address: 'rAccount' },
+        '1',
+        (address) => address,
+        () => ({ color1: '#000000', color2: '#ffffff' })
+      );
+      expect(partNames(accountMarkup)).toEqual(
+        Object.values(WALLET_CONNECTOR_PARTS.accountModal).sort()
+      );
+    } finally {
+      connector.disconnectedCallback();
+      connector.remove();
+    }
+  });
+
+  it('keeps canonical documentation aligned with variables, portals, and parts', () => {
+    const documentation = readFileSync(
+      resolve(process.cwd(), '../../docs/guide/customization.md'),
+      'utf8'
+    );
+    const variableSection = documentation
+      .split('## Available CSS Variables')[1]
+      ?.split('### Typed overrides')[0];
+    const documentedVariables = [...(variableSection?.matchAll(/`(--xc-[\w-]+)`/g) ?? [])].map(
+      ([, variable]) => variable
+    );
+
+    expect([...new Set(documentedVariables)].sort()).toEqual(
+      [...WALLET_CONNECTOR_CSS_VARIABLES].sort()
+    );
+    const documentedPart = (host: string, part: string) =>
+      new RegExp(
+        `\\|\\s*\\\`${escapeRegExp(host)}\\\`\\s*\\|\\s*\\\`::part\\(${escapeRegExp(part)}\\)\\\`\\s*\\|`
+      );
+    for (const part of Object.values(WALLET_CONNECTOR_PARTS.connector)) {
+      expect(documentation).toMatch(documentedPart('xrpl-wallet-connector', part));
+    }
+    for (const [portal, parts] of [
+      [WALLET_CONNECTOR_PORTAL_SELECTORS.wallet, WALLET_CONNECTOR_PARTS.walletModal],
+      [WALLET_CONNECTOR_PORTAL_SELECTORS.account, WALLET_CONNECTOR_PARTS.accountModal],
+    ] as const) {
+      for (const part of Object.values(parts)) {
+        expect(documentation).toMatch(documentedPart(portal, part));
+      }
+    }
+  });
+});

--- a/packages/ui/tests/browser/wallet-dialog.spec.ts
+++ b/packages/ui/tests/browser/wallet-dialog.spec.ts
@@ -92,6 +92,37 @@ test('supports touch scrolling to the final wallet', async ({ page, context }) =
   await expectScrolledToEnd(content);
 });
 
+test('applies the public radius, focus, and danger tokens to rendered UI', async ({ page }) => {
+  await page.goto(fixturePath);
+  const walletConnector = page.locator('#wallet-connector');
+  await walletConnector.evaluate((element) => {
+    const connector = element as HTMLElement;
+    connector.style.setProperty('--xc-border-radius', '23px');
+    connector.style.setProperty('--xc-focus-color', '#123456');
+  });
+
+  const walletOpener = page.getByRole('button', { name: 'Open wallet dialog' });
+  await walletOpener.focus();
+  await page.keyboard.press('Enter');
+  const walletDialog = page.getByRole('dialog', { name: 'Connect Wallet' });
+  const closeButton = walletDialog.getByRole('button', { name: 'Close' });
+  await expect(walletDialog).toHaveCSS('border-radius', '23px');
+  await expect(closeButton).toBeFocused();
+  await expect(closeButton).toHaveCSS('outline-color', 'rgb(18, 52, 86)');
+  await page.keyboard.press('Escape');
+
+  const accountConnector = page.locator('#account-connector');
+  await accountConnector.evaluate((element) => {
+    (element as HTMLElement).style.setProperty('--xc-danger-color', '#00ff00');
+  });
+  await accountConnector.locator('#connect-wallet-button').click();
+  const disconnectButton = page
+    .getByRole('dialog', { name: 'Connected' })
+    .getByRole('button', { name: 'Disconnect' });
+  await disconnectButton.hover();
+  await expect(disconnectButton.locator('path')).toHaveCSS('fill', 'rgb(0, 255, 0)');
+});
+
 test('provides wallet dialog semantics, traps focus, and restores every close path', async ({
   page,
 }) => {

--- a/packages/ui/tests/public-api.types.ts
+++ b/packages/ui/tests/public-api.types.ts
@@ -1,8 +1,20 @@
-import { WalletConnectorElement, type WalletConnectorElementInstance } from '../dist/index';
+import {
+  WALLET_CONNECTOR_CSS_VARIABLES,
+  WalletConnectorElement,
+  type WalletConnectorCssVariable,
+  type WalletConnectorCssVars,
+  type WalletConnectorElementInstance,
+} from '../dist/index';
 import type { AccountInfo } from '@xrpl-connect/core';
 
 const connector: WalletConnectorElementInstance = document.createElement('xrpl-wallet-connector');
 const pendingAccount: Promise<AccountInfo> = connector.openAndWait();
+const firstCssVariable: WalletConnectorCssVariable = WALLET_CONNECTOR_CSS_VARIABLES[0];
+const cssVars: WalletConnectorCssVars = { '--xc-primary-color': '#7c3aed' };
+const invalidCssVars: WalletConnectorCssVars = {
+  // @ts-expect-error Unsupported or misspelled CSS variables are rejected.
+  '--xc-primary-colro': '#7c3aed',
+};
 
 if (WalletConnectorElement) {
   const constructed: WalletConnectorElementInstance = new WalletConnectorElement();
@@ -10,3 +22,6 @@ if (WalletConnectorElement) {
 }
 
 void pendingAccount;
+void firstCssVariable;
+void cssVars;
+void invalidCssVars;

--- a/packages/vue/src/WalletConnector.ts
+++ b/packages/vue/src/WalletConnector.ts
@@ -16,6 +16,7 @@ import {
   type WalletError,
   type WalletIdentifier,
 } from '@xrpl-connect/core';
+import type { WalletConnectorCssVars } from 'xrpl-connect';
 import { useXrplConnectContext, type WalletConnectorElement } from './context';
 
 const THEMES: Record<WalletConnectorTheme, Record<string, string>> = {
@@ -49,7 +50,7 @@ export const WalletConnector = defineComponent({
     wallets: Array as PropType<WalletIdentifier[]>,
     showUnavailable: Boolean,
     theme: String as PropType<WalletConnectorTheme>,
-    cssVars: Object as PropType<Record<`--xc-${string}`, string>>,
+    cssVars: Object as PropType<WalletConnectorCssVars>,
   },
   emits: {
     connecting: (walletId: WalletIdentifier) => typeof walletId === 'string',

--- a/packages/vue/tests/publish/types-vue-cjs.cts
+++ b/packages/vue/tests/publish/types-vue-cjs.cts
@@ -30,6 +30,13 @@ const connector: Component = WalletConnector;
 type WalletConnectorProps = InstanceType<typeof WalletConnector>['$props'];
 const omittedShowUnavailableProps: WalletConnectorProps = {};
 const showUnavailableProps: WalletConnectorProps = { showUnavailable: true };
+const cssVarsProps: WalletConnectorProps = { cssVars: { '--xc-primary-color': '#7c3aed' } };
+const invalidCssVarsProps: WalletConnectorProps = {
+  cssVars: {
+    // @ts-expect-error Published Vue props reject unsupported CSS variables.
+    '--xc-primary-colro': '#7c3aed',
+  },
+};
 const invalidShowUnavailableProps: WalletConnectorProps = {
   // @ts-expect-error Misspelled Vue props must not be accepted by the published component type.
   showUnavilable: true,
@@ -59,6 +66,8 @@ void [
   connector,
   omittedShowUnavailableProps,
   showUnavailableProps,
+  cssVarsProps,
+  invalidCssVarsProps,
   invalidShowUnavailableProps,
   modalReady,
   modalOpen,

--- a/packages/vue/tests/publish/types-vue-esm.mts
+++ b/packages/vue/tests/publish/types-vue-esm.mts
@@ -42,6 +42,13 @@ const connector: Component = WalletConnector;
 type WalletConnectorProps = InstanceType<typeof WalletConnector>['$props'];
 const omittedShowUnavailableProps: WalletConnectorProps = {};
 const showUnavailableProps: WalletConnectorProps = { showUnavailable: true };
+const cssVarsProps: WalletConnectorProps = { cssVars: { '--xc-primary-color': '#7c3aed' } };
+const invalidCssVarsProps: WalletConnectorProps = {
+  cssVars: {
+    // @ts-expect-error Published Vue props reject unsupported CSS variables.
+    '--xc-primary-colro': '#7c3aed',
+  },
+};
 const invalidShowUnavailableProps: WalletConnectorProps = {
   // @ts-expect-error Misspelled Vue props must not be accepted by the published component type.
   showUnavilable: true,
@@ -71,6 +78,8 @@ void [
   connector,
   omittedShowUnavailableProps,
   showUnavailableProps,
+  cssVarsProps,
+  invalidCssVarsProps,
   invalidShowUnavailableProps,
   modalReady,
   modalOpen,

--- a/packages/xrpl-connect/tests/publish/types-cjs.cts
+++ b/packages/xrpl-connect/tests/publish/types-cjs.cts
@@ -2,6 +2,7 @@ import {
   CrossmarkSDK,
   ADAPTER_DESCRIPTORS,
   STANDARD_WALLET_IDS,
+  WALLET_CONNECTOR_CSS_VARIABLES,
   createAdapters,
   GemWalletAPI,
   MetaMaskSnapAdapter,
@@ -19,6 +20,8 @@ import {
   type WalletId,
   type WalletIdentifier,
   type WalletConnectConnectOptions,
+  type WalletConnectorCssVariable,
+  type WalletConnectorCssVars,
   type WalletConnectorElementInstance,
   type XamanConnectOptions,
   type XamanReturnUrl,
@@ -37,6 +40,12 @@ declare module 'xrpl-connect' {
 
 const standardWalletId: WalletId = STANDARD_WALLET_IDS[0];
 const customWalletId: WalletIdentifier = 'custom-wallet';
+const cssVariable: WalletConnectorCssVariable = WALLET_CONNECTOR_CSS_VARIABLES[0];
+const cssVars: WalletConnectorCssVars = { '--xc-primary-color': '#7c3aed' };
+const invalidCssVars: WalletConnectorCssVars = {
+  // @ts-expect-error Published customization types reject unsupported variables.
+  '--xc-primary-colro': '#7c3aed',
+};
 // @ts-expect-error WalletId is the literal union of packaged adapter IDs.
 const invalidStandardWalletId: WalletId = 'custom-wallet';
 const descriptorWalletId: WalletId = ADAPTER_DESCRIPTORS[0].id;
@@ -125,6 +134,9 @@ void [
   connectOptions,
   standardWalletId,
   customWalletId,
+  cssVariable,
+  cssVars,
+  invalidCssVars,
   invalidStandardWalletId,
   descriptorWalletId,
   packagedAdapters,

--- a/packages/xrpl-connect/tests/publish/types-esm.mts
+++ b/packages/xrpl-connect/tests/publish/types-esm.mts
@@ -2,6 +2,7 @@ import {
   CrossmarkSDK,
   ADAPTER_DESCRIPTORS,
   STANDARD_WALLET_IDS,
+  WALLET_CONNECTOR_CSS_VARIABLES,
   createAdapters,
   GemWalletAPI,
   MetaMaskSnapAdapter,
@@ -22,6 +23,8 @@ import {
   type WalletId,
   type WalletIdentifier,
   type WalletConnectConnectOptions,
+  type WalletConnectorCssVariable,
+  type WalletConnectorCssVars,
   type WalletConnectorElementInstance,
   type XamanConnectOptions,
   type XamanReturnUrl,
@@ -41,6 +44,12 @@ declare module 'xrpl-connect' {
 const standardNetworkId: StandardNetworkId = 'mainnet';
 const standardWalletId: WalletId = STANDARD_WALLET_IDS[0];
 const customWalletId: WalletIdentifier = 'custom-wallet';
+const cssVariable: WalletConnectorCssVariable = WALLET_CONNECTOR_CSS_VARIABLES[0];
+const cssVars: WalletConnectorCssVars = { '--xc-primary-color': '#7c3aed' };
+const invalidCssVars: WalletConnectorCssVars = {
+  // @ts-expect-error Published customization types reject unsupported variables.
+  '--xc-primary-colro': '#7c3aed',
+};
 // @ts-expect-error WalletId is the literal union of packaged adapter IDs.
 const invalidStandardWalletId: WalletId = 'custom-wallet';
 const descriptorWalletId: WalletId = ADAPTER_DESCRIPTORS[0].id;
@@ -139,6 +148,9 @@ void [
   connectOptions,
   standardWalletId,
   customWalletId,
+  cssVariable,
+  cssVars,
+  invalidCssVars,
   invalidStandardWalletId,
   descriptorWalletId,
   packagedAdapters,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -44,7 +44,7 @@
 - [x] Add focused runtime, type-level, documentation, portal-host, and part-name drift regressions.
 - [x] Run formatting, linting, focused tests, builds/type checks, publish checks, and repository-level verification appropriate to the change.
 - [x] Review the final diff against every acceptance criterion and record results below.
-- [ ] Commit only intentional files, push the branch, open the PR, and verify the remote PR metadata/checks.
+- [x] Commit only intentional files, push the branch, open the PR, and verify the remote PR metadata/checks.
 
 ## Review
 
@@ -54,3 +54,4 @@
 - Runtime/type/documentation drift tests cover the stylesheet list, all-variable forwarding, typo filtering/rejection, direct-body portal placement, close/unmount lifecycle, exact host-to-part mappings, and packed ESM/CJS framework declarations.
 - `pnpm exec vp check`, UI/React/Vue focused checks, `pnpm build`, `pnpm docs:snapshot:check`, `pnpm --filter xrpl-connect test:publish`, `pnpm test`, and `git diff --check` pass.
 - Independent final review found three documentation/lifecycle/source-of-truth gaps; all were fixed and the exact final tree passed the focused UI suite and full monorepo pipeline.
+- Signed commit `58fd901` was pushed and opened as PR #167 targeting `develop`; the remote head, signature, issue linkage, and checks were verified after delivery.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -21,3 +21,36 @@
 - Fail-before proof: Nuxt 4.1.3 with pinned Vite 7.1.11 and Rollup 4.62.2 rejects the affected packed artifact with `Constructor in/after an optional chaining is not allowed`.
 - Verification: `pnpm exec vp check`, `pnpm test`, and `pnpm --filter xrpl-connect test:publish` pass. The publish test covers package builds, pack/dry-run checks, strict consumer install, type/runtime checks, both emitted artifact forms, and the Nuxt/Vite production build.
 - Documentation: the Unreleased changelog tells Nuxt/Vite consumers they can remove their `xrpl-connect.mjs` workaround after upgrading to the fixed release candidate.
+
+---
+
+# Issue #151 PR
+
+## Issue summary
+
+- The customization API accepts arbitrary Vue CSS-variable names even though the UI forwards a fixed whitelist, so misspellings compile but have no effect.
+- Wallet and account modals live in separate body-level shadow-root portals; consumers lack a documented, stable mapping from hosts to parts, variables, targets, and lifecycle.
+- The fix must establish one readonly runtime/type source of truth shared by UI and framework bindings, then document stable portal selectors and unscoped Vue/Nuxt usage.
+- Drift coverage must keep runtime forwarding, public declarations, documentation, portal hosts, and part names aligned.
+
+## Plan
+
+- [x] Validate GitHub access, refresh `origin/develop`, inspect issue state/comments/linked PRs, and create a clean isolated worktree.
+- [x] Inventory the current CSS-variable forwarding, portal hosts, shadow parts, framework props, documentation, and existing tests.
+- [x] Design the smallest authoritative customization contract covering wallet and connected-account modal styling.
+- [x] Export exact readonly CSS-variable metadata and public `WalletConnectorCssVariable` / `WalletConnectorCssVars` types from the owning package.
+- [x] Adopt the exact contract in UI runtime forwarding and framework bindings without breaking supported customization paths.
+- [x] Document every supported host, part, target, lifecycle, forwarded variable, and global Vue/Nuxt selector with working examples.
+- [x] Add focused runtime, type-level, documentation, portal-host, and part-name drift regressions.
+- [x] Run formatting, linting, focused tests, builds/type checks, publish checks, and repository-level verification appropriate to the change.
+- [x] Review the final diff against every acceptance criterion and record results below.
+- [ ] Commit only intentional files, push the branch, open the PR, and verify the remote PR metadata/checks.
+
+## Review
+
+- `WALLET_CONNECTOR_CSS_VARIABLES` is the UI runtime/type source of truth for all 36 supported tokens; the exact `WalletConnectorCssVariable` and `WalletConnectorCssVars` types flow through the umbrella, React, and Vue declarations.
+- Stable portal attributes/selectors and host-grouped part metadata now drive wallet and account modal markup, including connected-account overlay, modal, close, address, and disconnect styling hooks.
+- Canonical docs map every host/part to its target and lifecycle, provide typed overrides plus global Vue and Nuxt examples, and the published UI README/example no longer advertise the ineffective `--xrpl-*` prefix or incorrect modal shadow tree.
+- Runtime/type/documentation drift tests cover the stylesheet list, all-variable forwarding, typo filtering/rejection, direct-body portal placement, close/unmount lifecycle, exact host-to-part mappings, and packed ESM/CJS framework declarations.
+- `pnpm exec vp check`, UI/React/Vue focused checks, `pnpm build`, `pnpm docs:snapshot:check`, `pnpm --filter xrpl-connect test:publish`, `pnpm test`, and `git diff --check` pass.
+- Independent final review found three documentation/lifecycle/source-of-truth gaps; all were fixed and the exact final tree passed the focused UI suite and full monorepo pipeline.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -55,3 +55,18 @@
 - `pnpm exec vp check`, UI/React/Vue focused checks, `pnpm build`, `pnpm docs:snapshot:check`, `pnpm --filter xrpl-connect test:publish`, `pnpm test`, and `git diff --check` pass.
 - Independent final review found three documentation/lifecycle/source-of-truth gaps; all were fixed and the exact final tree passed the focused UI suite and full monorepo pipeline.
 - Signed commit `58fd901` was pushed and opened as PR #167 targeting `develop`; the remote head, signature, issue linkage, and checks were verified after delivery.
+
+## Fix PR #167 review findings
+
+- [x] Verify the dedicated worktree is clean and matches the exact remote PR head.
+- [x] Make every exported customization token affect runtime styling or remove it from the contract.
+- [x] Correct the UI README portal topology and add drift coverage for direct-body sibling hosts.
+- [x] Run focused UI checks plus repository-level build, test, publish, and documentation verification.
+- [x] Review the final diff, commit, push, and verify the updated PR head and CI.
+
+### Fix review
+
+- The contract now contains 34 runtime-effective tokens: base radius feeds the modal fallback, focus colors keyboard outlines, danger colors error/destructive UI, and unsupported success/warning tokens are no longer advertised.
+- The package README renders the connector and both body-level portal hosts as siblings, with a drift test tied to the exported portal attributes.
+- Static consumption coverage fails for declared-but-unused tokens, and Chromium verifies radius, focus, and danger overrides against rendered wallet/account portal UI.
+- UI type/runtime tests, all nine Chromium tests, repository formatting/lint, the full monorepo build/test pipeline, documentation snapshot verification, and packed ESM/CJS/SSR/Nuxt consumer verification pass.


### PR DESCRIPTION
## Summary
- export one exact runtime/type customization contract for all supported wallet connector CSS variables, portal hosts, and shadow parts
- use the shared CSS-variable type in React and Vue, and expose equivalent styling hooks for the wallet and connected-account modals
- document stable host/part ownership and lifecycle with global Vue/Nuxt examples, backed by runtime, declaration, publish, and documentation drift tests

## Test plan
- [x] `pnpm exec vp check`
- [x] `pnpm --filter @xrpl-connect/ui test`
- [x] `pnpm --filter @xrpl-commons/xrpl-connect-react test:types`
- [x] `pnpm --filter @xrpl-commons/xrpl-connect-vue test`
- [x] `pnpm build`
- [x] `pnpm docs:snapshot:check`
- [x] `pnpm --filter xrpl-connect test:publish`
- [x] `pnpm test`
- [x] `git diff --check`

Fixes #151
