### PR TITLE
feat: expose awaitable React modal API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- React: make `useWalletModal()` awaitable with connector readiness, `openAndWait()`, explicit missing-connector failures, and deterministic ownership when multiple connectors are mounted (#171).
 - Vue: make `useWalletModal()` awaitable with connector readiness, `openAndWait()`, explicit missing-connector failures, and deterministic ownership when multiple connectors are mounted (#145).
 - Vue: expose the native unavailable-wallet display behavior through the typed `showUnavailable` component prop (#146).
 - UI: export the exact wallet-connector CSS-variable contract and stable modal portal/part metadata, with typed React and Vue overrides and connected-account modal styling hooks (#151).

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -479,10 +479,15 @@ mount; use a React `key` when an intentional configuration change must rebuild i
 
 - `useWallet()` returns `{ manager, connected, account, network, connecting, error, connect, disconnect }`.
 - `useSigner()` returns `{ sign, signAndSubmit, signMessage }`.
-- `useWalletModal()` returns `{ open, close }` for the mounted connector modal.
+- `useWalletModal()` returns reactive `ready`, `open(): Promise<void>`,
+  `openAndWait(): Promise<AccountInfo>`, and `close(): void` for the most recently registered
+  connector. Awaitable calls reject with a namespaced setup error until a connector registers.
 
 All hooks must be used below `XrplConnectProvider`. Signing methods reject with
 the same typed `WalletError` values as the core manager.
+
+When several connectors are mounted, modal ownership follows registration order and falls back
+when the active connector unmounts. `ready` remains `true` while any connector is registered.
 
 ### WalletConnector
 

--- a/docs/guide/frameworks/react.md
+++ b/docs/guide/frameworks/react.md
@@ -61,11 +61,11 @@ import { useWallet, useWalletModal } from '@xrpl-commons/xrpl-connect-react';
 
 function Header() {
   const { connected, connecting, account, network, error, disconnect } = useWallet();
-  const { open } = useWalletModal();
+  const { ready, open } = useWalletModal();
 
   if (!connected || !account) {
     return (
-      <button onClick={open} disabled={connecting}>
+      <button onClick={() => void open()} disabled={!ready || connecting}>
         Connect wallet
       </button>
     );
@@ -123,7 +123,17 @@ function PaymentButton({ destination }: { destination: string }) {
 
 ## Modal control
 
-`useWalletModal()` returns `open` and `close`. Render one or more `<WalletConnector>` components inside the provider; modal ownership follows the mounted connector. `WalletConnector` accepts:
+`useWalletModal()` returns reactive `ready`, `open(): Promise<void>`,
+`openAndWait(): Promise<AccountInfo>`, and `close(): void`. Await `open()` to observe availability
+failures, or await `openAndWait()` when the caller needs the connected account; `openAndWait()`
+also rejects if the modal closes before a connection completes.
+
+`ready` becomes `true` after a connector registers and returns to `false` after the last connector
+unmounts. Calling `open()` or `openAndWait()` while it is `false` rejects with a namespaced setup
+error. With multiple connectors, the newest registration owns modal calls; unmounting it falls
+back to the previous connector. `close()` is a safe no-op when none is registered.
+
+`WalletConnector` accepts:
 
 - `primaryWallet` and ordered `wallets`
 - `theme`: `dark`, `light`, or `purple`

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -43,7 +43,7 @@ import {
 
 export function App() {
   const { connected, account, disconnect, error } = useWallet();
-  const { open } = useWalletModal();
+  const { ready, open } = useWalletModal();
   const { signAndSubmit } = useSigner();
 
   return (
@@ -54,7 +54,9 @@ export function App() {
           <button onClick={disconnect}>Disconnect</button>
         </>
       ) : (
-        <button onClick={open}>Connect Wallet</button>
+        <button disabled={!ready} onClick={() => void open()}>
+          Connect Wallet
+        </button>
       )}
 
       {error && (
@@ -88,7 +90,14 @@ subtree. The manager is created once on mount; pass a React `key` to rebuild it.
 - `useWallet()` → `{ manager, connected, account, network, connecting, error, connect, disconnect }`
 - `useSigner()` → `{ sign, signAndSubmit, signMessage }` — each rejects with a typed
   `WalletError` (`error.code`, `error.category`), e.g. `SIGN_REJECTED` on user cancel.
-- `useWalletModal()` → `{ open, close }` — drive the `<WalletConnector>` modal.
+- `useWalletModal()` → `{ ready, open, openAndWait, close }` — drive the active
+  `<WalletConnector>` modal. `open()` is awaitable, and `openAndWait()` resolves with the
+  connected account or rejects if opening fails or the modal closes first.
+
+`ready` becomes `true` after a connector registers and returns to `false` after the last
+connector unmounts. Calling `open()` or `openAndWait()` while it is `false` rejects with a
+namespaced setup error. When multiple connectors are mounted, the newest registration owns modal
+calls; unmounting it falls back to the previous connector.
 
 `connect` narrows deferred options from the wallet ID:
 

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -53,10 +53,10 @@ export function useSigner() {
  * Imperatively control the `<WalletConnector>` modal.
  *
  * @example
- * const { open } = useWalletModal();
- * <button onClick={open}>Connect Wallet</button>
+ * const { ready, open } = useWalletModal();
+ * <button disabled={!ready} onClick={() => void open()}>Connect Wallet</button>
  */
 export function useWalletModal() {
-  const { openModal, closeModal } = useXrplConnectContext();
-  return { open: openModal, close: closeModal };
+  const { ready, openModal, openAndWaitModal, closeModal } = useXrplConnectContext();
+  return { ready, open: openModal, openAndWait: openAndWaitModal, close: closeModal };
 }

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -46,6 +46,7 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
   const [network, setNetwork] = useState<NetworkInfo | null>(manager.account?.network ?? null);
   const [connecting, setConnecting] = useState<boolean>(false);
   const [error, setError] = useState<WalletError | null>(null);
+  const [ready, setReady] = useState(false);
 
   const syncConnecting = useCallback(() => {
     if (mountedRef.current) {
@@ -184,9 +185,11 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
 
   const registerConnector = useCallback((el: WalletConnectorElement) => {
     connectorsRef.current.add(el);
+    if (mountedRef.current) setReady(true);
   }, []);
   const unregisterConnector = useCallback((el: WalletConnectorElement) => {
     connectorsRef.current.delete(el);
+    if (mountedRef.current) setReady(connectorsRef.current.size > 0);
   }, []);
   const reportModalConnecting = useCallback(() => {
     const attempt = Symbol('modalConnectionAttempt');
@@ -216,12 +219,36 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
     [syncConnecting]
   );
 
-  const getActiveConnector = useCallback(() => {
+  const getActiveConnector = useCallback((): WalletConnectorElement => {
     const connectors = [...connectorsRef.current];
-    return connectors.at(-1) ?? null;
+    const connector = connectors.at(-1);
+    if (connector) return connector;
+    throw new Error(
+      'xrpl-connect/react: no <WalletConnector> is registered. Mount <WalletConnector> before calling useWalletModal().'
+    );
   }, []);
-  const openModal = useCallback(() => getActiveConnector()?.open(), [getActiveConnector]);
-  const closeModal = useCallback(() => getActiveConnector()?.close(), [getActiveConnector]);
+  const runWithActiveConnector = useCallback(
+    <T,>(operation: (connector: WalletConnectorElement) => Promise<T>): Promise<T> => {
+      try {
+        return Promise.resolve(operation(getActiveConnector()));
+      } catch (value) {
+        return Promise.reject(value);
+      }
+    },
+    [getActiveConnector]
+  );
+  const openModal = useCallback(
+    () => runWithActiveConnector((connector) => connector.open()),
+    [runWithActiveConnector]
+  );
+  const openAndWaitModal = useCallback(
+    () => runWithActiveConnector((connector) => connector.openAndWait()),
+    [runWithActiveConnector]
+  );
+  const closeModal = useCallback(() => {
+    const connectors = [...connectorsRef.current];
+    connectors.at(-1)?.close();
+  }, []);
 
   const value = useMemo<XrplConnectContextValue>(
     () => ({
@@ -231,6 +258,7 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
       network,
       connecting,
       error,
+      ready,
       connect,
       disconnect,
       registerConnector,
@@ -239,6 +267,7 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
       reportModalError,
       reportModalClosed,
       openModal,
+      openAndWaitModal,
       closeModal,
     }),
     [
@@ -248,6 +277,7 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
       network,
       connecting,
       error,
+      ready,
       connect,
       disconnect,
       registerConnector,
@@ -256,6 +286,7 @@ export function XrplConnectProvider({ config, children }: XrplConnectProviderPro
       reportModalError,
       reportModalClosed,
       openModal,
+      openAndWaitModal,
       closeModal,
     ]
   );

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -26,6 +26,8 @@ export interface XrplConnectContextValue {
   network: NetworkInfo | null;
   /** True while a `connect()` call (or the modal flow) is in progress. */
   connecting: boolean;
+  /** True while at least one `<WalletConnector>` is registered. */
+  ready: boolean;
   /** The most recent connection/adapter error, as a typed `WalletError`. */
   error: WalletError | null;
   connect: <const Wallet extends WalletIdentifier>(
@@ -43,7 +45,8 @@ export interface XrplConnectContextValue {
   reportModalError: (attempt: symbol | null, error: WalletError) => boolean;
   /** @internal — cancels modal attempts owned by a closing connector. */
   reportModalClosed: (attempts: readonly symbol[]) => void;
-  openModal: () => void;
+  openModal: () => Promise<void>;
+  openAndWaitModal: () => Promise<AccountInfo>;
   closeModal: () => void;
 }
 

--- a/packages/react/tests/public-api.types.ts
+++ b/packages/react/tests/public-api.types.ts
@@ -1,5 +1,9 @@
 import type { AccountInfo } from '@xrpl-connect/core';
-import type { WalletConnectorElement, WalletConnectorProps } from '../dist/index';
+import {
+  useWalletModal,
+  type WalletConnectorElement,
+  type WalletConnectorProps,
+} from '../dist/index';
 
 declare const connector: WalletConnectorElement;
 declare const manager: Parameters<WalletConnectorElement['setWalletManager']>[0];
@@ -16,6 +20,11 @@ const invalidCssVarsProps: WalletConnectorProps = {
     '--xc-primary-colro': '#7c3aed',
   },
 };
+const modal = null as unknown as ReturnType<typeof useWalletModal>;
+const modalReady: boolean = modal.ready;
+const modalOpen: Promise<void> = modal.open();
+const modalAccount: Promise<AccountInfo> = modal.openAndWait();
+const modalClose: void = modal.close();
 
 // Implementation details must not leak into the public element contract.
 // @ts-expect-error openAccountModal is internal to the web component implementation.
@@ -30,3 +39,7 @@ void closeResult;
 void toggleResult;
 void cssVarsProps;
 void invalidCssVarsProps;
+void modalReady;
+void modalOpen;
+void modalAccount;
+void modalClose;

--- a/packages/react/tests/publish/types-react-cjs.cts
+++ b/packages/react/tests/publish/types-react-cjs.cts
@@ -9,6 +9,7 @@ import {
   type WalletConnectorProps,
 } from '@xrpl-commons/xrpl-connect-react';
 import type {
+  AccountInfo,
   ManagedSignedMessage,
   ManagedSignedTransaction,
   Transaction,
@@ -36,6 +37,11 @@ const invalidCssVarsProps: WalletConnectorProps = {
 };
 const signer = null as unknown as ReturnType<typeof useSigner>;
 const wallet = null as unknown as ReturnType<typeof useWallet>;
+const modal = null as unknown as ReturnType<typeof useWalletModal>;
+const modalReady: boolean = modal.ready;
+const modalOpen: Promise<void> = modal.open();
+const modalAccount: Promise<AccountInfo> = modal.openAndWait();
+const modalClose: void = modal.close();
 void wallet.connect('xaman', { apiKey: 'api-key' });
 void wallet.connect('walletconnect', { projectId: 'project-id' });
 // @ts-expect-error Xaman deferred options do not accept a WalletConnect project ID.
@@ -56,6 +62,10 @@ void [
   signedTransaction,
   signedMessage,
   errorGuard,
+  modalReady,
+  modalOpen,
+  modalAccount,
+  modalClose,
   useWallet,
   useWalletModal,
 ];

--- a/packages/react/tests/publish/types-react-esm.mts
+++ b/packages/react/tests/publish/types-react-esm.mts
@@ -10,6 +10,7 @@ import {
   type XrplConnectConfig,
 } from '@xrpl-commons/xrpl-connect-react';
 import type {
+  AccountInfo,
   ManagedSignedMessage,
   ManagedSignedTransaction,
   Transaction,
@@ -48,6 +49,11 @@ const invalidCssVarsProps: WalletConnectorProps = {
 };
 const signer = null as unknown as ReturnType<typeof useSigner>;
 const wallet = null as unknown as ReturnType<typeof useWallet>;
+const modal = null as unknown as ReturnType<typeof useWalletModal>;
+const modalReady: boolean = modal.ready;
+const modalOpen: Promise<void> = modal.open();
+const modalAccount: Promise<AccountInfo> = modal.openAndWait();
+const modalClose: void = modal.close();
 void wallet.connect('xaman', { apiKey: 'api-key' });
 void wallet.connect('walletconnect', { projectId: 'project-id' });
 // @ts-expect-error Xaman deferred options do not accept a WalletConnect project ID.
@@ -68,6 +74,10 @@ void [
   signedTransaction,
   signedMessage,
   errorGuard,
+  modalReady,
+  modalOpen,
+  modalAccount,
+  modalClose,
   useWallet,
   useWalletModal,
   mainnetConfig,

--- a/packages/react/tests/react.test.tsx
+++ b/packages/react/tests/react.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, vi } from 'vite-plus/test';
+import { describe, it, expect, expectTypeOf, beforeAll, vi } from 'vite-plus/test';
 import { render, act, waitFor, renderHook } from '@testing-library/react';
 import { StrictMode, useRef } from 'react';
 import { renderToString } from 'react-dom/server';
@@ -408,18 +408,106 @@ describe('<WalletConnector>', () => {
       class Stub extends HTMLElement {
         manager: unknown = null;
         opened = false;
+        openError: Error | null = null;
+        private waiters = new Set<{
+          resolve: (account: AccountInfo) => void;
+          reject: (error: Error) => void;
+        }>();
         setWalletManager(m: unknown) {
           this.manager = m;
         }
-        open() {
+        open(): Promise<void> {
+          if (this.openError) return Promise.reject(this.openError);
           this.opened = true;
+          return Promise.resolve();
+        }
+        openAndWait(): Promise<AccountInfo> {
+          const opening = this.open();
+          return new Promise<AccountInfo>((resolve, reject) => {
+            const waiter = { resolve, reject };
+            this.waiters.add(waiter);
+            void opening.catch((error: unknown) => {
+              if (!this.waiters.delete(waiter)) return;
+              reject(error instanceof Error ? error : new Error(String(error)));
+            });
+          });
         }
         close() {
           this.opened = false;
+          this.rejectWaiters(new Error('Modal closed before a wallet was connected.'));
+        }
+        resolveConnection(account: AccountInfo) {
+          for (const waiter of this.waiters) waiter.resolve(account);
+          this.waiters.clear();
+        }
+        disconnectedCallback() {
+          this.rejectWaiters(new Error('Wallet connector disconnected.'));
+        }
+        private rejectWaiters(error: Error) {
+          for (const waiter of this.waiters) waiter.reject(error);
+          this.waiters.clear();
         }
       }
       customElements.define('xrpl-wallet-connector', Stub);
     }
+  });
+
+  it('exposes the complete asynchronous modal contract', () => {
+    type WalletModal = ReturnType<typeof useWalletModal>;
+    expectTypeOf<WalletModal['ready']>().toEqualTypeOf<boolean>();
+    expectTypeOf<WalletModal['open']>().toEqualTypeOf<() => Promise<void>>();
+    expectTypeOf<WalletModal['openAndWait']>().toEqualTypeOf<() => Promise<AccountInfo>>();
+    expectTypeOf<WalletModal['close']>().toEqualTypeOf<() => void>();
+  });
+
+  it('rejects modal calls until a connector is registered', async () => {
+    const { result } = renderHook(() => useWalletModal(), {
+      wrapper: wrapper([makeAdapter()]),
+    });
+
+    expect(result.current.ready).toBe(false);
+    await expect(result.current.open()).rejects.toThrow(
+      'xrpl-connect/react: no <WalletConnector> is registered'
+    );
+    await expect(result.current.openAndWait()).rejects.toThrow(
+      'xrpl-connect/react: no <WalletConnector> is registered'
+    );
+    expect(() => result.current.close()).not.toThrow();
+  });
+
+  it('forwards open failures and openAndWait results from the active connector', async () => {
+    let modal: ReturnType<typeof useWalletModal> | null = null;
+    function Capture() {
+      modal = useWalletModal();
+      return null;
+    }
+    render(
+      <XrplConnectProvider config={{ adapters: [makeAdapter()], autoConnect: false }}>
+        <Capture />
+        <WalletConnector />
+      </XrplConnectProvider>
+    );
+
+    await waitFor(() => expect(modal!.ready).toBe(true));
+    const element = document.querySelector('xrpl-wallet-connector') as HTMLElement & {
+      opened: boolean;
+      openError: Error | null;
+      resolveConnection(account: AccountInfo): void;
+    };
+    const failure = new Error('availability check failed');
+    element.openError = failure;
+    await expect(modal!.open()).rejects.toBe(failure);
+    await expect(modal!.openAndWait()).rejects.toBe(failure);
+    element.openError = null;
+
+    const connected = modal!.openAndWait();
+    await waitFor(() => expect(element.opened).toBe(true));
+    element.resolveConnection(ACCOUNT);
+    await expect(connected).resolves.toEqual(ACCOUNT);
+
+    const closed = modal!.openAndWait();
+    modal!.close();
+    await expect(closed).rejects.toThrow(/closed/i);
   });
 
   it('binds the provider manager and fires onConnect with the account', async () => {
@@ -448,7 +536,7 @@ describe('<WalletConnector>', () => {
     await waitFor(() => expect(onConnect).toHaveBeenCalledWith(ACCOUNT));
   });
 
-  it('forwards explicit hover cssVars to the custom element', () => {
+  it('forwards explicit hover cssVars to the custom element', async () => {
     const cssVars = {
       '--xc-primary-button-hover-background': '#112233',
       '--xc-connect-button-hover-background': '#223344',
@@ -460,7 +548,10 @@ describe('<WalletConnector>', () => {
       </XrplConnectProvider>
     );
 
-    const element = document.querySelector('xrpl-wallet-connector') as HTMLElement;
+    const element = document.querySelector('xrpl-wallet-connector') as HTMLElement & {
+      manager: unknown;
+    };
+    await waitFor(() => expect(element.manager).not.toBeNull());
     for (const [variable, value] of Object.entries(cssVars)) {
       expect(element.style.getPropertyValue(variable)).toBe(value);
     }
@@ -766,37 +857,54 @@ describe('<WalletConnector>', () => {
     expect(onError).toHaveBeenCalledWith(currentError);
   });
 
-  it('keeps the remaining connector registered when a sibling unmounts', async () => {
+  it('tracks readiness and falls back to the previous connector when the newest unmounts', async () => {
     let modal: ReturnType<typeof useWalletModal> | null = null;
     function Capture() {
       modal = useWalletModal();
       return null;
     }
-    function View({ showFirst }: { showFirst: boolean }) {
+    function View({ showFirst, showSecond }: { showFirst: boolean; showSecond: boolean }) {
       return (
         <XrplConnectProvider config={{ adapters: [makeAdapter()], autoConnect: false }}>
           <Capture />
           {showFirst && <WalletConnector key="first" className="first" />}
-          <WalletConnector key="second" className="second" />
+          {showSecond && <WalletConnector key="second" className="second" />}
         </XrplConnectProvider>
       );
     }
 
-    const { rerender } = render(<View showFirst />);
+    const { rerender } = render(<View showFirst={false} showSecond={false} />);
+    expect(modal!.ready).toBe(false);
+
+    rerender(<View showFirst showSecond />);
     await waitFor(() => {
+      expect(modal!.ready).toBe(true);
+      expect(
+        (document.querySelector('.first') as HTMLElement & { manager: unknown }).manager
+      ).not.toBeNull();
       expect(
         (document.querySelector('.second') as HTMLElement & { manager: unknown }).manager
       ).not.toBeNull();
     });
-    rerender(<View showFirst={false} />);
+    const first = document.querySelector('.first') as HTMLElement & { opened: boolean };
+    const second = document.querySelector('.second') as HTMLElement & { opened: boolean };
 
-    act(() => modal!.open());
-    expect((document.querySelector('.second') as HTMLElement & { opened: boolean }).opened).toBe(
-      true
-    );
+    await act(async () => modal!.open());
+    expect(first.opened).toBe(false);
+    expect(second.opened).toBe(true);
+
+    rerender(<View showFirst showSecond={false} />);
+    expect(modal!.ready).toBe(true);
+    first.opened = false;
+    await act(async () => modal!.open());
+    expect(first.opened).toBe(true);
+
+    rerender(<View showFirst={false} showSecond={false} />);
+    expect(modal!.ready).toBe(false);
+    await expect(modal!.open()).rejects.toThrow(/no <WalletConnector> is registered/);
   });
 
-  it('updates and removes the wallet allowlist attribute on rerender', () => {
+  it('updates and removes the wallet allowlist attribute on rerender', async () => {
     function View({ wallets }: { wallets?: string[] }) {
       return (
         <XrplConnectProvider config={{ adapters: [makeAdapter()], autoConnect: false }}>
@@ -805,7 +913,10 @@ describe('<WalletConnector>', () => {
       );
     }
     const { rerender } = render(<View wallets={['first', 'second']} />);
-    const el = document.querySelector('xrpl-wallet-connector')!;
+    const el = document.querySelector('xrpl-wallet-connector') as HTMLElement & {
+      manager: unknown;
+    };
+    await waitFor(() => expect(el.manager).not.toBeNull());
     expect(el.getAttribute('wallets')).toBe('first,second');
 
     rerender(<View wallets={['third']} />);

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,72 +1,29 @@
-# Issue #141
-
-- [x] Validate GitHub access, repository, issue state, and default branch.
-- [x] Create a clean issue worktree and review repository guidance.
-- [x] Reproduce and trace the optional-chain constructor in the published bundles.
-- [x] Implement the minimal production fix.
-- [x] Add a packed-consumer Vite/Rollup build smoke test using the real umbrella tarball.
-- [x] Replace the raw Vite smoke build with a Nuxt 4 production regression that fails on the affected artifact.
-- [x] Re-run focused and repository-level verification after the review fix.
-- [x] Commit and push the review fix to PR #159.
-- [x] Verify the rebuilt ESM and UMD artifacts.
-- [x] Run focused and repository-level formatting, linting, and tests.
-- [x] Review the final diff against issue acceptance criteria.
-- [x] Commit, push, and open the pull request.
-
-## Review
-
-- Root cause: Rolldown normalizes `xumm-sdk`'s guarded constructor into a parenthesized optional-chain constructor in both umbrella artifacts.
-- Fix: normalize that exact final-bundle expression to the equivalent direct property constructor after the SDK's existing type guard.
-- Regression coverage: assert the ESM and UMD output syntax, then install the real tarballs into an isolated consumer and build the umbrella ESM with Nuxt 4 and its Vite production pipeline.
-- Fail-before proof: Nuxt 4.1.3 with pinned Vite 7.1.11 and Rollup 4.62.2 rejects the affected packed artifact with `Constructor in/after an optional chaining is not allowed`.
-- Verification: `pnpm exec vp check`, `pnpm test`, and `pnpm --filter xrpl-connect test:publish` pass. The publish test covers package builds, pack/dry-run checks, strict consumer install, type/runtime checks, both emitted artifact forms, and the Nuxt/Vite production build.
-- Documentation: the Unreleased changelog tells Nuxt/Vite consumers they can remove their `xrpl-connect.mjs` workaround after upgrading to the fixed release candidate.
-
----
-
-# Issue #151 PR
+# Issue #171
 
 ## Issue summary
 
-- The customization API accepts arbitrary Vue CSS-variable names even though the UI forwards a fixed whitelist, so misspellings compile but have no effect.
-- Wallet and account modals live in separate body-level shadow-root portals; consumers lack a documented, stable mapping from hosts to parts, variables, targets, and lifecycle.
-- The fix must establish one readonly runtime/type source of truth shared by UI and framework bindings, then document stable portal selectors and unscoped Vue/Nuxt usage.
-- Drift coverage must keep runtime forwarding, public declarations, documentation, portal hosts, and part names aligned.
+- The React modal hook drops the web component's readiness and asynchronous API, so consumers cannot safely call or await it.
+- `open` must preserve failures, `openAndWait` must return the selected `AccountInfo`, and pre-registration calls must reject with a clear namespaced setup error.
+- Connector registration remains last-mounted-owner-wins, with reactive readiness through registration and unregistration.
+- Tests, public type assertions, and React documentation must describe and enforce the complete contract.
 
 ## Plan
 
-- [x] Validate GitHub access, refresh `origin/develop`, inspect issue state/comments/linked PRs, and create a clean isolated worktree.
-- [x] Inventory the current CSS-variable forwarding, portal hosts, shadow parts, framework props, documentation, and existing tests.
-- [x] Design the smallest authoritative customization contract covering wallet and connected-account modal styling.
-- [x] Export exact readonly CSS-variable metadata and public `WalletConnectorCssVariable` / `WalletConnectorCssVars` types from the owning package.
-- [x] Adopt the exact contract in UI runtime forwarding and framework bindings without breaking supported customization paths.
-- [x] Document every supported host, part, target, lifecycle, forwarded variable, and global Vue/Nuxt selector with working examples.
-- [x] Add focused runtime, type-level, documentation, portal-host, and part-name drift regressions.
-- [x] Run formatting, linting, focused tests, builds/type checks, publish checks, and repository-level verification appropriate to the change.
+- [x] Validate GitHub access, refresh `origin/develop`, and confirm issue state, comments, linked PRs, and acceptance criteria.
+- [x] Create a clean isolated worktree from the refreshed default branch and review applicable repository guidance.
+- [x] Trace the React provider/hook/types lifecycle, Vue parity implementation, tests, public type checks, and documentation.
+- [x] Implement the smallest production-ready async modal context API while preserving connector ownership semantics.
+- [x] Add focused runtime and public type regressions for pre-registration calls, lifecycle readiness, rejected opens, and `openAndWait`.
+- [x] Update React documentation for readiness and awaitable modal usage.
+- [x] Run formatting, linting, focused tests, builds/type checks, and relevant repository-level verification.
 - [x] Review the final diff against every acceptance criterion and record results below.
-- [x] Commit only intentional files, push the branch, open the PR, and verify the remote PR metadata/checks.
+- [x] Commit only intentional files, push the branch, open the PR, and verify remote PR metadata/checks.
 
 ## Review
 
-- `WALLET_CONNECTOR_CSS_VARIABLES` is the UI runtime/type source of truth for all 36 supported tokens; the exact `WalletConnectorCssVariable` and `WalletConnectorCssVars` types flow through the umbrella, React, and Vue declarations.
-- Stable portal attributes/selectors and host-grouped part metadata now drive wallet and account modal markup, including connected-account overlay, modal, close, address, and disconnect styling hooks.
-- Canonical docs map every host/part to its target and lifecycle, provide typed overrides plus global Vue and Nuxt examples, and the published UI README/example no longer advertise the ineffective `--xrpl-*` prefix or incorrect modal shadow tree.
-- Runtime/type/documentation drift tests cover the stylesheet list, all-variable forwarding, typo filtering/rejection, direct-body portal placement, close/unmount lifecycle, exact host-to-part mappings, and packed ESM/CJS framework declarations.
-- `pnpm exec vp check`, UI/React/Vue focused checks, `pnpm build`, `pnpm docs:snapshot:check`, `pnpm --filter xrpl-connect test:publish`, `pnpm test`, and `git diff --check` pass.
-- Independent final review found three documentation/lifecycle/source-of-truth gaps; all were fixed and the exact final tree passed the focused UI suite and full monorepo pipeline.
-- Signed commit `58fd901` was pushed and opened as PR #167 targeting `develop`; the remote head, signature, issue linkage, and checks were verified after delivery.
-
-## Fix PR #167 review findings
-
-- [x] Verify the dedicated worktree is clean and matches the exact remote PR head.
-- [x] Make every exported customization token affect runtime styling or remove it from the contract.
-- [x] Correct the UI README portal topology and add drift coverage for direct-body sibling hosts.
-- [x] Run focused UI checks plus repository-level build, test, publish, and documentation verification.
-- [x] Review the final diff, commit, push, and verify the updated PR head and CI.
-
-### Fix review
-
-- The contract now contains 34 runtime-effective tokens: base radius feeds the modal fallback, focus colors keyboard outlines, danger colors error/destructive UI, and unsupported success/warning tokens are no longer advertised.
-- The package README renders the connector and both body-level portal hosts as siblings, with a drift test tied to the exported portal attributes.
-- Static consumption coverage fails for declared-but-unused tokens, and Chromium verifies radius, focus, and danger overrides against rendered wallet/account portal UI.
-- UI type/runtime tests, all nine Chromium tests, repository formatting/lint, the full monorepo build/test pipeline, documentation snapshot verification, and packed ESM/CJS/SSR/Nuxt consumer verification pass.
+- The provider now exposes connector registration as reactive `ready` state while preserving the insertion-ordered `Set` that gives the newest connector ownership and falls back when it unmounts.
+- `open()` and `openAndWait()` preserve native results and failures; missing registration and synchronous connector failures become rejected promises with a React-namespaced setup error, while `close()` remains a safe no-op.
+- Runtime tests cover pre-registration calls, lifecycle readiness, open failures, `openAndWait` success/close rejection, newest ownership, and fallback; source plus packed ESM/CJS type fixtures enforce the public contract.
+- The package README, React framework guide, API reference, and Unreleased changelog document readiness, async behavior, errors, and multi-connector ownership without changing versioned documentation.
+- `pnpm exec vp check`, `pnpm --filter @xrpl-commons/xrpl-connect-react... build`, focused React tests, `pnpm test`, `pnpm docs:snapshot:check`, `pnpm --filter xrpl-connect test:publish`, and `git diff --check` pass.
+- Independent final review found no correctness, lifecycle, declaration, documentation, or scope findings.


### PR DESCRIPTION
## Summary
- expose reactive connector readiness plus awaitable `open()` and `openAndWait()` through the React modal hook
- preserve newest-connector ownership/fallback, reject missing setup clearly, and cover runtime, published types, changelog, and React documentation

## Test plan
- [x] `pnpm exec vp check`
- [x] `pnpm --filter @xrpl-commons/xrpl-connect-react... build`
- [x] `pnpm --filter @xrpl-commons/xrpl-connect-react test`
- [x] `pnpm test`
- [x] `pnpm docs:snapshot:check`
- [x] `pnpm --filter xrpl-connect test:publish`
- [x] `git diff --check`

Fixes #171
