### PR TITLE
fix: pin documented xrpl install range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Documentation: pin current install commands to `xrpl@^4` so registry-latest v5 cannot drift outside the supported v3/v4 peer range; packed-consumer verification now executes the literal React dependency specifications and rejects stale install examples (#169).
 - xrpl-connect (meta-bundle): emit the Xaman mock-WebSocket constructor without an optional chain so Nuxt 4 and Vite/Rollup production builds can consume the published ESM artifact. Consumers can remove `patch-package` or transpilation workarounds for `xrpl-connect.mjs` (#141).
 
 ## [1.0.0-rc.0] - 2026-08-17

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Please read the documentation here [DOCS](https://xrpl-commons.github.io/xrpl-co
 ### Installation
 
 ```bash
-npm install xrpl-connect@rc xrpl
+npm install xrpl-connect@rc xrpl@^4
 ```
 
 That's it! Everything you need in one package.

--- a/docs/guide/frameworks/nuxt.md
+++ b/docs/guide/frameworks/nuxt.md
@@ -11,7 +11,7 @@ Vue composables must also run only on the client.
 ## Installation
 
 ```bash
-npm install @xrpl-commons/xrpl-connect-vue@rc xrpl-connect@rc xrpl vue
+npm install @xrpl-commons/xrpl-connect-vue@rc xrpl-connect@rc xrpl@^4 vue
 ```
 
 ## Client plugin

--- a/docs/guide/frameworks/react.md
+++ b/docs/guide/frameworks/react.md
@@ -9,7 +9,7 @@ Use the official React bindings instead of building a custom context around the 
 ## Install
 
 ```bash
-pnpm add xrpl-connect@rc @xrpl-commons/xrpl-connect-react@rc xrpl react react-dom
+pnpm add xrpl-connect@rc @xrpl-commons/xrpl-connect-react@rc xrpl@^4 react react-dom
 ```
 
 ## Configure the provider

--- a/docs/guide/frameworks/vue.md
+++ b/docs/guide/frameworks/vue.md
@@ -11,7 +11,7 @@ in the application.
 ## Installation
 
 ```bash
-npm install @xrpl-commons/xrpl-connect-vue@rc xrpl-connect@rc xrpl vue
+npm install @xrpl-commons/xrpl-connect-vue@rc xrpl-connect@rc xrpl@^4 vue
 ```
 
 ## Configure the plugin

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -11,7 +11,7 @@ Get up and running with XRPL-Connect in minutes.
 ### Using npm
 
 ```bash
-npm install xrpl-connect@rc xrpl
+npm install xrpl-connect@rc xrpl@^4
 ```
 
 Add the official bindings for your framework:
@@ -27,13 +27,13 @@ npm install @xrpl-commons/xrpl-connect-vue@rc vue
 ### Using pnpm
 
 ```bash
-pnpm add xrpl-connect@rc xrpl
+pnpm add xrpl-connect@rc xrpl@^4
 ```
 
 ### Using yarn
 
 ```bash
-yarn add xrpl-connect@rc xrpl
+yarn add xrpl-connect@rc xrpl@^4
 ```
 
 The `xrpl-connect` package includes:

--- a/docs/guide/migration-v1.md
+++ b/docs/guide/migration-v1.md
@@ -16,13 +16,13 @@ Do not install both framework bindings. Upgrade the umbrella package and only th
 
 ```bash
 # Vanilla JavaScript or a custom framework integration
-pnpm add xrpl-connect@rc xrpl
+pnpm add xrpl-connect@rc xrpl@^4
 
 # React
-pnpm add xrpl-connect@rc @xrpl-commons/xrpl-connect-react@rc xrpl react react-dom
+pnpm add xrpl-connect@rc @xrpl-commons/xrpl-connect-react@rc xrpl@^4 react react-dom
 
 # Vue 3 or Nuxt
-pnpm add xrpl-connect@rc @xrpl-commons/xrpl-connect-vue@rc xrpl vue
+pnpm add xrpl-connect@rc @xrpl-commons/xrpl-connect-vue@rc xrpl@^4 vue
 ```
 
 The coordinated release candidate contains these three artifacts:

--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -52,7 +52,7 @@ The monorepo uses workspace links. When copying this example into a standalone p
 the published release candidates explicitly:
 
 ```bash
-pnpm add @xrpl-commons/xrpl-connect-react@rc xrpl-connect@rc xrpl react react-dom
+pnpm add @xrpl-commons/xrpl-connect-react@rc xrpl-connect@rc xrpl@^4 react react-dom
 ```
 
 ### 4. Run Development Server

--- a/examples/vanilla-js/README.md
+++ b/examples/vanilla-js/README.md
@@ -51,7 +51,7 @@ The monorepo uses workspace links. When copying this example into a standalone p
 published release candidate and its XRPL peer explicitly:
 
 ```bash
-pnpm add xrpl-connect@rc xrpl
+pnpm add xrpl-connect@rc xrpl@^4
 ```
 
 ### 4. Run Development Server

--- a/packages/adapters/README.md
+++ b/packages/adapters/README.md
@@ -886,7 +886,7 @@ export class YourWalletAdapter implements WalletAdapter, SupportsFetchAccount {
     "@xrpl-connect/core": "workspace:*"
   },
   "peerDependencies": {
-    "xrpl": "^2.0.0"
+    "xrpl": "^3.0.0 || ^4.0.0"
   }
 }
 ```

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -7,7 +7,7 @@ modal component — so you configure your wallets once and never re-create objec
 ## Install
 
 ```bash
-npm install @xrpl-commons/xrpl-connect-react@rc xrpl-connect@rc xrpl react react-dom
+npm install @xrpl-commons/xrpl-connect-react@rc xrpl-connect@rc xrpl@^4 react react-dom
 ```
 
 > `react` / `react-dom` are peer dependencies. Importing any named export from

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -6,7 +6,7 @@ composables, and a typed `<WalletConnector>` modal component.
 ## Install
 
 ```bash
-npm install @xrpl-commons/xrpl-connect-vue@rc xrpl-connect@rc xrpl vue
+npm install @xrpl-commons/xrpl-connect-vue@rc xrpl-connect@rc xrpl@^4 vue
 ```
 
 ## Usage

--- a/packages/xrpl-connect/scripts/test-publish.mjs
+++ b/packages/xrpl-connect/scripts/test-publish.mjs
@@ -13,6 +13,19 @@ import { run } from './run-command.mjs';
 const FRAMEWORK_PEER_RANGE = '^1.0.0-rc.0';
 const NPM_ORGANIZATION = 'xrpl-commons';
 const SUPPORTED_NODE_RANGE = '^20.19.0 || ^22.18.0 || >=24.11.0';
+const DOCUMENTED_XRPL_SPEC = 'xrpl@^4';
+const DOCUMENTED_INSTALL_PATHS = [
+  'README.md',
+  'packages/react/README.md',
+  'packages/vue/README.md',
+  'examples/react/README.md',
+  'examples/vanilla-js/README.md',
+  'docs/guide/getting-started.md',
+  'docs/guide/frameworks/react.md',
+  'docs/guide/frameworks/vue.md',
+  'docs/guide/frameworks/nuxt.md',
+  'docs/guide/migration-v1.md',
+];
 const PUBLISH_CONFIG = {
   access: 'public',
   registry: NPM_REGISTRY,
@@ -96,6 +109,56 @@ function parseJson(command, args, options) {
   return JSON.parse(run(command, args, { ...options, capture: true }));
 }
 
+function readInstallCommands(markdownPath) {
+  return readFileSync(markdownPath, 'utf-8')
+    .split(/\r?\n/)
+    .map((line) => line.trim().match(/^(?:npm install|pnpm add|yarn add)\s+(.+)$/)?.[1])
+    .filter(Boolean)
+    .map((dependencies) => dependencies.split(/\s+/));
+}
+
+function findInstallCommand(markdownPath, packageName) {
+  const command = readInstallCommands(markdownPath).find((dependencies) =>
+    dependencies.some(
+      (dependency) => dependency === packageName || dependency.startsWith(`${packageName}@`)
+    )
+  );
+  assert(command, `${path.relative(repositoryRoot, markdownPath)} has no ${packageName} install`);
+  return command;
+}
+
+function verifyDocumentedXrplSpecs() {
+  for (const relativePath of DOCUMENTED_INSTALL_PATHS) {
+    const markdownPath = path.join(repositoryRoot, relativePath);
+    const xrplSpecs = readInstallCommands(markdownPath)
+      .flat()
+      .filter((dependency) => /^xrpl(?:@.+)?$/.test(dependency));
+    assert(xrplSpecs.length > 0, `${relativePath} has no documented xrpl dependency`);
+    for (const spec of xrplSpecs) {
+      assert.equal(
+        spec,
+        DOCUMENTED_XRPL_SPEC,
+        `${relativePath} does not pin documented xrpl to v4`
+      );
+    }
+  }
+
+  console.log('✓ Current install documentation consistently pins xrpl to v4');
+  return findInstallCommand(
+    path.join(repositoryRoot, 'packages', 'react', 'README.md'),
+    '@xrpl-commons/xrpl-connect-react'
+  );
+}
+
+function resolveCandidateSpecs(dependencies, tarballsByName) {
+  return dependencies.map((dependency) => {
+    const candidate = candidatePackages.find(
+      ({ name }) => dependency === name || dependency.startsWith(`${name}@`)
+    );
+    return candidate ? tarballsByName.get(candidate.name) : dependency;
+  });
+}
+
 function verifyNpmAccess() {
   const username = run('npm', ['whoami', '--registry', NPM_REGISTRY], {
     ...registryRunOptions,
@@ -177,6 +240,7 @@ if (modes.has('--check-prepublish')) verifyPrepublishRegistryState();
 if (modes.has('--check-registry')) verifyRegistryTags();
 if (modes.size > 0) process.exit(0);
 
+const documentedReactInstall = verifyDocumentedXrplSpecs();
 const temporaryRoot = mkdtempSync(path.join(os.tmpdir(), 'xrpl-connect-publish-'));
 const runOptions = {
   env: { npm_config_cache: path.join(temporaryRoot, '.npm-cache') },
@@ -193,7 +257,7 @@ const publishRunOptions = (tag, registry) => ({
 });
 
 try {
-  const tarballs = [];
+  const tarballsByName = new Map();
   for (const candidate of candidatePackages) {
     const [packMetadata] = parseJson(
       'npm',
@@ -208,7 +272,7 @@ try {
       assert(packedFiles.has(requiredFile), `${candidate.name} is missing ${requiredFile}`);
     }
 
-    tarballs.push(path.join(temporaryRoot, packMetadata.filename));
+    tarballsByName.set(candidate.name, path.join(temporaryRoot, packMetadata.filename));
     console.log(`→ Dry-running ${candidate.name}@${CANDIDATE_VERSION}`);
     run(
       'npm',
@@ -250,14 +314,12 @@ try {
       '--no-audit',
       '--no-fund',
       '--package-lock=false',
-      ...tarballs,
+      ...resolveCandidateSpecs(documentedReactInstall, tarballsByName),
+      tarballsByName.get('@xrpl-commons/xrpl-connect-vue'),
       '@types/react@^18.3.0',
       '@types/react-dom@^18.3.0',
-      'xrpl@^4.0.0',
       'jsdom@^22.1.0',
       'nuxt@4.1.3',
-      'react@^18.3.1',
-      'react-dom@^18.3.1',
       'rollup@4.62.2',
       'vite@7.1.11',
       'vue@^3.5.22',
@@ -274,6 +336,15 @@ try {
         readFileSync(path.join(consumerFolder, 'node_modules', name, 'package.json'), 'utf-8')
       ),
     ])
+  );
+  const packedReactInstall = findInstallCommand(
+    path.join(consumerFolder, 'node_modules', '@xrpl-commons', 'xrpl-connect-react', 'README.md'),
+    '@xrpl-commons/xrpl-connect-react'
+  );
+  assert.deepEqual(
+    packedReactInstall,
+    documentedReactInstall,
+    'Packed React README changed the verified install command'
   );
 
   for (const [name, manifest] of Object.entries(installedManifests)) {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -70,3 +70,33 @@
 - The package README renders the connector and both body-level portal hosts as siblings, with a drift test tied to the exported portal attributes.
 - Static consumption coverage fails for declared-but-unused tokens, and Chromium verifies radius, focus, and danger overrides against rendered wallet/account portal UI.
 - UI type/runtime tests, all nine Chromium tests, repository formatting/lint, the full monorepo build/test pipeline, documentation snapshot verification, and packed ESM/CJS/SSR/Nuxt consumer verification pass.
+
+---
+
+# Issue #169 PR
+
+## Issue summary
+
+- The documented React install command leaves `xrpl` unpinned even though the React and umbrella packages support only `xrpl` v3/v4 peers.
+- A clean install can therefore request or resolve registry-latest `xrpl` v5, producing peer failures or warnings depending on the package manager.
+- The implementation must either prove and advertise v5 support or consistently document v4, then exercise the literal documented dependency specifications in packed-consumer verification.
+- React, umbrella, examples, and canonical documentation must remain aligned.
+
+## Plan
+
+- [x] Validate GitHub access, refresh `origin/develop`, inspect issue state/comments/linked PRs, and create a clean isolated worktree.
+- [x] Inventory all `xrpl` peer ranges, React/framework install commands, examples, and packed-consumer dependency construction.
+- [x] Determine the supported `xrpl` major range from source compatibility, existing policy, and verification coverage.
+- [x] Implement the smallest consistent documentation/package/test change and add a literal-spec clean-install regression.
+- [x] Prove the regression against the pre-fix behavior, then run focused formatting, linting, build, test, publish, and documentation checks.
+- [x] Review the final diff against every acceptance criterion and record results below.
+- [ ] Commit only intentional files, push the branch, open the PR, and verify remote PR metadata/checks.
+
+## Review
+
+- Supported direction: retain the packages' `xrpl@^3 || ^4` peer policy and recommend v4 to new consumers; v5 changes wallet seed/signing semantics and is not covered by the current compatibility suite.
+- Documentation: every current root, framework, package, example, getting-started, and migration install command now uses `xrpl@^4`; immutable 0.8.2 snapshots remain unchanged, and the adapter authoring template matches the actual v3/v4 peer range.
+- Regression coverage: publish verification scans all ten current install surfaces, parses the literal React README dependencies, replaces only local candidate packages with their tarballs, installs under strict peer checks, and confirms the packed README preserves the verified command.
+- Fail-before proof: the new guard rejected the original tree at `README.md` with `xrpl !== xrpl@^4` before packing or network installation.
+- Verification: `pnpm exec vp check`, `pnpm --filter xrpl-connect test:publish`, `pnpm docs:snapshot:check`, `pnpm docs:build`, `pnpm test`, `node --check packages/xrpl-connect/scripts/test-publish.mjs`, and `git diff --check` pass.
+- Independent acceptance and test-logic reviews found no implementation defects; the parser's intentional scope is the one-line npm, pnpm, and Yarn command forms used by current release documentation.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -90,7 +90,7 @@
 - [x] Implement the smallest consistent documentation/package/test change and add a literal-spec clean-install regression.
 - [x] Prove the regression against the pre-fix behavior, then run focused formatting, linting, build, test, publish, and documentation checks.
 - [x] Review the final diff against every acceptance criterion and record results below.
-- [ ] Commit only intentional files, push the branch, open the PR, and verify remote PR metadata/checks.
+- [x] Commit only intentional files, push the branch, open the PR, and verify remote PR metadata/checks.
 
 ## Review
 
@@ -100,3 +100,4 @@
 - Fail-before proof: the new guard rejected the original tree at `README.md` with `xrpl !== xrpl@^4` before packing or network installation.
 - Verification: `pnpm exec vp check`, `pnpm --filter xrpl-connect test:publish`, `pnpm docs:snapshot:check`, `pnpm docs:build`, `pnpm test`, `node --check packages/xrpl-connect/scripts/test-publish.mjs`, and `git diff --check` pass.
 - Independent acceptance and test-logic reviews found no implementation defects; the parser's intentional scope is the one-line npm, pnpm, and Yarn command forms used by current release documentation.
+- Delivery: signed commit `5a74500` was pushed and opened as PR #174 targeting `develop`; the remote head, title, body, issue linkage, and initial CI job creation were verified.


### PR DESCRIPTION
## Summary
- pin current umbrella, framework, and example install commands to `xrpl@^4`, matching the supported v3/v4 peer policy
- verify every current install surface and drive the strict packed React consumer from the literal README dependency specifications
- align the adapter authoring template and document the fix in the changelog

## Test plan
- [x] `pnpm exec vp check`
- [x] `pnpm --filter xrpl-connect test:publish`
- [x] `pnpm docs:snapshot:check`
- [x] `pnpm docs:build`
- [x] `pnpm test`
- [x] `git diff --check`

Fixes #169
