### PR TITLE
fix: expose unavailable wallets in React

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - React: make `useWalletModal()` awaitable with connector readiness, `openAndWait()`, explicit missing-connector failures, and deterministic ownership when multiple connectors are mounted (#171).
+- React: expose unavailable-wallet rows through the typed `showUnavailable` wrapper prop and align direct custom-element JSX attributes (#168).
 - Vue: make `useWalletModal()` awaitable with connector readiness, `openAndWait()`, explicit missing-connector failures, and deterministic ownership when multiple connectors are mounted (#145).
 - Vue: expose the native unavailable-wallet display behavior through the typed `showUnavailable` component prop (#146).
 - UI: export the exact wallet-connector CSS-variable contract and stable modal portal/part metadata, with typed React and Vue overrides and connected-account modal styling hooks (#151).

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -492,8 +492,9 @@ when the active connector unmounts. `ready` remains `true` while any connector i
 ### WalletConnector
 
 `<WalletConnector />` wraps the web component. It accepts `primaryWallet`,
-`wallets`, `theme`, `cssVars`, `style`, `className`, `onConnecting`, `onConnect`,
-and `onError`. See the [React guide](/guide/frameworks/react) for a complete setup.
+`wallets`, `showUnavailable`, `theme`, `cssVars`, `style`, `className`, `onConnecting`,
+`onConnect`, and `onError`. `showUnavailable` maps to the native `show-unavailable` boolean
+attribute. See the [React guide](/guide/frameworks/react) for a complete setup.
 
 ## Vue API
 

--- a/docs/guide/frameworks/react.md
+++ b/docs/guide/frameworks/react.md
@@ -44,6 +44,7 @@ export function App() {
       <Header />
       <WalletConnector
         wallets={['xaman', 'crossmark', 'walletconnect', 'metamask-snap']}
+        showUnavailable
         theme="dark"
         onError={(error) => console.error(error.code, error.message)}
       />
@@ -136,9 +137,13 @@ back to the previous connector. `close()` is a safe no-op when none is registere
 `WalletConnector` accepts:
 
 - `primaryWallet` and ordered `wallets`
+- `showUnavailable` to include Install or disabled Unavailable wallet rows
 - `theme`: `dark`, `light`, or `purple`
 - typed `--xc-*` values through `cssVars`
 - `className`, `style`, `onConnecting`, `onConnect`, and `onError`
+
+Unavailable wallets are hidden by default. The camelCase `showUnavailable` prop maps to the native
+`show-unavailable` boolean attribute; setting the prop to `false` removes the attribute again.
 
 ## Next.js App Router
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -67,6 +67,7 @@ export function App() {
 
       {/* The modal itself — themeable, with typed event props */}
       <WalletConnector
+        showUnavailable
         theme="dark"
         cssVars={{ '--xc-primary-color': '#a78bfa' }}
         onConnect={(acct) => console.log('connected', acct.address)}
@@ -114,9 +115,13 @@ typed `CONFIGURATION_REQUIRED` error.
 
 ### `<WalletConnector />`
 
-React wrapper around the web component. Props: `primaryWallet`, `wallets`, `theme`
+React wrapper around the web component. Props: `primaryWallet`, `wallets`, `showUnavailable`, `theme`
 (`'dark' | 'light' | 'purple'`), `cssVars` (`--xc-*` overrides), `style`, `className`,
 and typed callbacks `onConnecting(walletId)`, `onConnect(account)`, `onError(WalletError)`.
+
+Unavailable wallets are hidden by default. Set `showUnavailable` to show an Install action when a
+wallet provides a download URL, or a disabled Unavailable row otherwise. Setting it to `false`
+removes the native `show-unavailable` boolean attribute.
 
 ### Errors
 

--- a/packages/react/scripts/prepare-types.mjs
+++ b/packages/react/scripts/prepare-types.mjs
@@ -1,4 +1,4 @@
-import { copyFileSync, unlinkSync } from 'node:fs';
+import { appendFileSync, copyFileSync, unlinkSync } from 'node:fs';
 import { Extractor, ExtractorConfig } from '@microsoft/api-extractor';
 
 const projectFolder = new URL('..', import.meta.url).pathname;
@@ -28,6 +28,28 @@ if (!result.succeeded || result.warningCount > 0) {
 }
 
 const rolledDeclaration = new URL('../dist/index.rollup.d.ts', import.meta.url);
+// API Extractor omits global JSX augmentations even when they are present in its
+// entry declaration. Restore the public merge against the rolled exported type.
+appendFileSync(
+  rolledDeclaration,
+  `
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'xrpl-wallet-connector': WalletConnectorIntrinsicProps;
+    }
+  }
+}
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'xrpl-wallet-connector': WalletConnectorIntrinsicProps;
+    }
+  }
+}
+`
+);
 copyFileSync(rolledDeclaration, new URL('../dist/index.d.ts', import.meta.url));
 copyFileSync(rolledDeclaration, new URL('../dist/index.d.mts', import.meta.url));
 unlinkSync(rolledDeclaration);

--- a/packages/react/src/WalletConnector.tsx
+++ b/packages/react/src/WalletConnector.tsx
@@ -42,6 +42,7 @@ const THEMES: Record<WalletConnectorTheme, Record<string, string>> = {
 export function WalletConnector({
   primaryWallet,
   wallets,
+  showUnavailable,
   theme,
   cssVars,
   style,
@@ -183,6 +184,7 @@ export function WalletConnector({
       ref={elRef}
       primary-wallet={primaryWallet}
       wallets={wallets?.join(',')}
+      show-unavailable={showUnavailable ? '' : undefined}
       class={className}
       style={mergedStyle}
     />

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,8 +4,7 @@
  * hooks to use it, and a `<WalletConnector>` modal component. (#33)
  *
  * `src/jsx.d.ts` provides the ambient `<xrpl-wallet-connector>` JSX typing used
- * internally by `<WalletConnector>`; it is compiled via tsconfig `include` and
- * intentionally not imported at runtime.
+ * internally by `<WalletConnector>` and by direct custom-element consumers.
  */
 export { XrplConnectProvider } from './provider';
 export { useWallet, useSigner, useWalletModal } from './hooks';
@@ -19,6 +18,7 @@ export type {
   WalletConnectorTheme,
   WalletConnectorElement,
 } from './types';
+export type { WalletConnectorIntrinsicProps } from './jsx';
 
 // Re-export the error primitives so consumers can branch on codes without a
 // second import from `xrpl-connect`.

--- a/packages/react/src/jsx.d.ts
+++ b/packages/react/src/jsx.d.ts
@@ -1,5 +1,24 @@
 import type { DetailedHTMLProps, HTMLAttributes } from 'react';
 
+/** Attributes supported by the `<xrpl-wallet-connector>` custom element in React JSX. */
+export type WalletConnectorIntrinsicProps = DetailedHTMLProps<
+  HTMLAttributes<HTMLElement> & {
+    'primary-wallet'?: string;
+    wallets?: string;
+    'show-unavailable'?: true | '';
+    class?: string;
+  },
+  HTMLElement
+>;
+
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'xrpl-wallet-connector': WalletConnectorIntrinsicProps;
+    }
+  }
+}
+
 /**
  * Declare the `<xrpl-wallet-connector>` custom element for JSX/TSX so it can be
  * rendered with typed attributes. The element itself is registered at runtime by
@@ -8,17 +27,7 @@ import type { DetailedHTMLProps, HTMLAttributes } from 'react';
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      'xrpl-wallet-connector': DetailedHTMLProps<
-        HTMLAttributes<HTMLElement> & {
-          'primary-wallet'?: string;
-          wallets?: string;
-          'background-color'?: string;
-          class?: string;
-        },
-        HTMLElement
-      >;
+      'xrpl-wallet-connector': WalletConnectorIntrinsicProps;
     }
   }
 }
-
-export {};

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -75,6 +75,8 @@ export interface WalletConnectorProps {
   primaryWallet?: WalletIdentifier;
   /** Restrict/order the wallet list (maps to the `wallets` attribute). */
   wallets?: WalletIdentifier[];
+  /** Show unavailable wallets (maps to the `show-unavailable` boolean attribute). */
+  showUnavailable?: boolean;
   /** Built-in theme preset. Overridden per-token by `cssVars`. */
   theme?: WalletConnectorTheme;
   /** Supported `--xc-*` custom properties to override modal styling. */

--- a/packages/react/tests/publish/types-react-cjs.cts
+++ b/packages/react/tests/publish/types-react-cjs.cts
@@ -1,4 +1,4 @@
-import type { ComponentProps, ComponentType } from 'react';
+import type { ComponentProps, ComponentType, JSX as ReactJSX } from 'react';
 import {
   WalletConnector,
   XrplConnectProvider,
@@ -29,6 +29,19 @@ declare module 'xrpl-connect' {
 const provider: ComponentType<ComponentProps<typeof XrplConnectProvider>> = XrplConnectProvider;
 const connector: ComponentType<WalletConnectorProps> = WalletConnector;
 const cssVarsProps: WalletConnectorProps = { cssVars: { '--xc-primary-color': '#7c3aed' } };
+const unavailableProps: WalletConnectorProps = { showUnavailable: true };
+const intrinsicProps: ReactJSX.IntrinsicElements['xrpl-wallet-connector'] = {
+  'show-unavailable': true,
+};
+const globalIntrinsicProps: JSX.IntrinsicElements['xrpl-wallet-connector'] = intrinsicProps;
+const invalidIntrinsicProps: ReactJSX.IntrinsicElements['xrpl-wallet-connector'] = {
+  // @ts-expect-error Published JSX types reject unsupported legacy attributes.
+  'background-color': '#000637',
+};
+const unsafeFalseIntrinsicProps: ReactJSX.IntrinsicElements['xrpl-wallet-connector'] = {
+  // @ts-expect-error React 18 would serialize false as a present boolean attribute.
+  'show-unavailable': false,
+};
 const invalidCssVarsProps: WalletConnectorProps = {
   cssVars: {
     // @ts-expect-error Published React props reject unsupported CSS variables.
@@ -58,6 +71,11 @@ void [
   provider,
   connector,
   cssVarsProps,
+  unavailableProps,
+  intrinsicProps,
+  globalIntrinsicProps,
+  invalidIntrinsicProps,
+  unsafeFalseIntrinsicProps,
   invalidCssVarsProps,
   signedTransaction,
   signedMessage,

--- a/packages/react/tests/publish/types-react-esm.mts
+++ b/packages/react/tests/publish/types-react-esm.mts
@@ -1,4 +1,4 @@
-import type { ComponentProps, ComponentType } from 'react';
+import type { ComponentProps, ComponentType, JSX as ReactJSX } from 'react';
 import {
   WalletConnector,
   XrplConnectProvider,
@@ -41,6 +41,19 @@ const invalidNetworkConfig: XrplConnectConfig = {
 const provider: ComponentType<ComponentProps<typeof XrplConnectProvider>> = XrplConnectProvider;
 const connector: ComponentType<WalletConnectorProps> = WalletConnector;
 const cssVarsProps: WalletConnectorProps = { cssVars: { '--xc-primary-color': '#7c3aed' } };
+const unavailableProps: WalletConnectorProps = { showUnavailable: true };
+const intrinsicProps: ReactJSX.IntrinsicElements['xrpl-wallet-connector'] = {
+  'show-unavailable': true,
+};
+const globalIntrinsicProps: JSX.IntrinsicElements['xrpl-wallet-connector'] = intrinsicProps;
+const invalidIntrinsicProps: ReactJSX.IntrinsicElements['xrpl-wallet-connector'] = {
+  // @ts-expect-error Published JSX types reject unsupported legacy attributes.
+  'background-color': '#000637',
+};
+const unsafeFalseIntrinsicProps: ReactJSX.IntrinsicElements['xrpl-wallet-connector'] = {
+  // @ts-expect-error React 18 would serialize false as a present boolean attribute.
+  'show-unavailable': false,
+};
 const invalidCssVarsProps: WalletConnectorProps = {
   cssVars: {
     // @ts-expect-error Published React props reject unsupported CSS variables.
@@ -70,6 +83,11 @@ void [
   provider,
   connector,
   cssVarsProps,
+  unavailableProps,
+  intrinsicProps,
+  globalIntrinsicProps,
+  invalidIntrinsicProps,
+  unsafeFalseIntrinsicProps,
   invalidCssVarsProps,
   signedTransaction,
   signedMessage,

--- a/packages/react/tests/react.test.tsx
+++ b/packages/react/tests/react.test.tsx
@@ -460,6 +460,13 @@ describe('<WalletConnector>', () => {
     expectTypeOf<WalletModal['close']>().toEqualTypeOf<() => void>();
   });
 
+  it('exposes showUnavailable through the wrapper and direct custom-element JSX', () => {
+    const wrapperElement = <WalletConnector showUnavailable />;
+    const customElement = <xrpl-wallet-connector show-unavailable />;
+
+    expectTypeOf(wrapperElement).toEqualTypeOf(customElement);
+  });
+
   it('rejects modal calls until a connector is registered', async () => {
     const { result } = renderHook(() => useWalletModal(), {
       wrapper: wrapper([makeAdapter()]),
@@ -923,5 +930,26 @@ describe('<WalletConnector>', () => {
     expect(el.getAttribute('wallets')).toBe('third');
     rerender(<View />);
     expect(el.hasAttribute('wallets')).toBe(false);
+  });
+
+  it('enables and disables unavailable-wallet rendering on rerender', async () => {
+    function View({ showUnavailable }: { showUnavailable?: boolean }) {
+      return (
+        <XrplConnectProvider config={{ adapters: [makeAdapter()], autoConnect: false }}>
+          <WalletConnector showUnavailable={showUnavailable} />
+        </XrplConnectProvider>
+      );
+    }
+    const { rerender } = render(<View />);
+    const el = document.querySelector('xrpl-wallet-connector') as HTMLElement & {
+      manager: unknown;
+    };
+    await waitFor(() => expect(el.manager).not.toBeNull());
+    expect(el.hasAttribute('show-unavailable')).toBe(false);
+
+    rerender(<View showUnavailable />);
+    expect(el.getAttribute('show-unavailable')).toBe('');
+    rerender(<View showUnavailable={false} />);
+    expect(el.hasAttribute('show-unavailable')).toBe(false);
   });
 });

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,29 +1,30 @@
-# Issue #171
+# Issue #168
 
 ## Issue summary
 
-- The React modal hook drops the web component's readiness and asynchronous API, so consumers cannot safely call or await it.
-- `open` must preserve failures, `openAndWait` must return the selected `AccountInfo`, and pre-registration calls must reject with a clear namespaced setup error.
-- Connector registration remains last-mounted-owner-wins, with reactive readiness through registration and unregistration.
-- Tests, public type assertions, and React documentation must describe and enforce the complete contract.
+- The React wrapper cannot expose the UI connector's supported `show-unavailable` behavior because `WalletConnectorProps` has no corresponding prop and unknown props are not forwarded.
+- `showUnavailable` must use boolean-attribute presence/removal semantics so unavailable wallet rows can be enabled and disabled after mount.
+- React's direct custom-element JSX declaration is stale: it omits `show-unavailable` and advertises unsupported legacy attributes such as `background-color`.
+- Focused runtime, source and packed public type, and documentation coverage must keep the wrapper and intrinsic-element APIs aligned.
 
 ## Plan
 
 - [x] Validate GitHub access, refresh `origin/develop`, and confirm issue state, comments, linked PRs, and acceptance criteria.
 - [x] Create a clean isolated worktree from the refreshed default branch and review applicable repository guidance.
-- [x] Trace the React provider/hook/types lifecycle, Vue parity implementation, tests, public type checks, and documentation.
-- [x] Implement the smallest production-ready async modal context API while preserving connector ownership semantics.
-- [x] Add focused runtime and public type regressions for pre-registration calls, lifecycle readiness, rejected opens, and `openAndWait`.
-- [x] Update React documentation for readiness and awaitable modal usage.
-- [x] Run formatting, linting, focused tests, builds/type checks, and relevant repository-level verification.
+- [x] Trace the React wrapper, UI boolean-attribute behavior, Vue parity implementation, tests, public type checks, and documentation.
+- [x] Implement the minimal production-ready React prop and exact intrinsic custom-element JSX declaration.
+- [x] Add focused runtime regressions for enabling, disabling, and updating unavailable-wallet rendering.
+- [x] Add source and packed public type regressions for the wrapper prop and direct custom-element JSX.
+- [x] Document the React prop and align any generated or mirrored documentation required by the repository.
+- [x] Run formatting, linting, focused tests, builds/type checks, publish checks, and relevant repository-level verification.
 - [x] Review the final diff against every acceptance criterion and record results below.
 - [x] Commit only intentional files, push the branch, open the PR, and verify remote PR metadata/checks.
 
 ## Review
 
-- The provider now exposes connector registration as reactive `ready` state while preserving the insertion-ordered `Set` that gives the newest connector ownership and falls back when it unmounts.
-- `open()` and `openAndWait()` preserve native results and failures; missing registration and synchronous connector failures become rejected promises with a React-namespaced setup error, while `close()` remains a safe no-op.
-- Runtime tests cover pre-registration calls, lifecycle readiness, open failures, `openAndWait` success/close rejection, newest ownership, and fallback; source plus packed ESM/CJS type fixtures enforce the public contract.
-- The package README, React framework guide, API reference, and Unreleased changelog document readiness, async behavior, errors, and multi-connector ownership without changing versioned documentation.
-- `pnpm exec vp check`, `pnpm --filter @xrpl-commons/xrpl-connect-react... build`, focused React tests, `pnpm test`, `pnpm docs:snapshot:check`, `pnpm --filter xrpl-connect test:publish`, and `git diff --check` pass.
-- Independent final review found no correctness, lifecycle, declaration, documentation, or scope findings.
+- `WalletConnector` now maps the typed `showUnavailable` prop to `show-unavailable=""` when true and omission when false or undefined, matching the native component and Vue parity without React 18's unsafe `"false"` serialization.
+- Direct custom-element JSX types expose only the real `primary-wallet`, `wallets`, `show-unavailable`, and host attributes; the stale `background-color` declaration is gone and `show-unavailable` rejects the unsafe explicit false form.
+- The React declaration rollup restores both `React.JSX` and legacy global `JSX` augmentations after API Extractor, with packed ESM and CommonJS fixtures proving the wrapper prop, supported intrinsic attribute, legacy rejection, and React 18/19 namespace coverage.
+- Runtime coverage verifies omitted, enabled, and disabled attribute states across rerenders; the package README, React framework guide, API reference, and Unreleased changelog document the public behavior.
+- `pnpm exec vp check`, the full React build/type/SSR/runtime suite, strict packed declaration checks, `pnpm docs:snapshot:check`, `pnpm --filter xrpl-connect test:publish`, `pnpm test`, and `git diff --check` pass.
+- Independent final review found one stale API-reference omission, which was fixed; the updated diff has no remaining runtime, declaration, test, documentation, compatibility, or scope findings.


### PR DESCRIPTION
## Summary
- expose the native unavailable-wallet rows through a typed, presence-safe React `showUnavailable` prop
- publish aligned direct custom-element JSX attributes for React 18 and 19, removing the unsupported legacy `background-color` declaration
- cover runtime toggling and packed ESM/CommonJS declarations, and document the React API

## Test plan
- [x] `pnpm exec vp check`
- [x] `pnpm --filter @xrpl-commons/xrpl-connect-react test`
- [x] `pnpm docs:snapshot:check`
- [x] `pnpm --filter xrpl-connect test:publish`
- [x] `pnpm test`
- [x] `git diff --check`

Fixes #168
