### PR TITLE
feat: forward React connector refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- React: forward typed `WalletConnectorElement` refs and safe host attributes through `<WalletConnector>`, with explicit managed-prop precedence (#172).
 - React: make `useWalletModal()` awaitable with connector readiness, `openAndWait()`, explicit missing-connector failures, and deterministic ownership when multiple connectors are mounted (#171).
 - Vue: make `useWalletModal()` awaitable with connector readiness, `openAndWait()`, explicit missing-connector failures, and deterministic ownership when multiple connectors are mounted (#145).
 - Vue: expose the native unavailable-wallet display behavior through the typed `showUnavailable` component prop (#146).

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -493,7 +493,11 @@ when the active connector unmounts. `ready` remains `true` while any connector i
 
 `<WalletConnector />` wraps the web component. It accepts `primaryWallet`,
 `wallets`, `theme`, `cssVars`, `style`, `className`, `onConnecting`, `onConnect`,
-and `onError`. See the [React guide](/guide/frameworks/react) for a complete setup.
+and `onError`, plus standard host attributes such as `id`, `title`, `data-*`, and `aria-*`.
+Its forwarded `WalletConnectorElement` ref exposes `open()`, `openAndWait()`, `close()`, and
+`toggle()`. Explicit connector props take precedence over overlapping raw host attributes; inline
+`style` overrides `cssVars`, which overrides `theme`. See the
+[React guide](/guide/frameworks/react) for a complete setup.
 
 ## Vue API
 

--- a/docs/guide/frameworks/react.md
+++ b/docs/guide/frameworks/react.md
@@ -139,6 +139,30 @@ back to the previous connector. `close()` is a safe no-op when none is registere
 - `theme`: `dark`, `light`, or `purple`
 - typed `--xc-*` values through `cssVars`
 - `className`, `style`, `onConnecting`, `onConnect`, and `onError`
+- standard host attributes such as `id`, `title`, `data-*`, and `aria-*`
+- a typed `WalletConnectorElement` ref exposing `open()`, `openAndWait()`, `close()`, and `toggle()`
+
+```tsx
+import { useRef } from 'react';
+import { WalletConnector, type WalletConnectorElement } from '@xrpl-commons/xrpl-connect-react';
+
+function WalletModal() {
+  const connectorRef = useRef<WalletConnectorElement>(null);
+
+  return (
+    <WalletConnector
+      ref={connectorRef}
+      id="wallet-modal"
+      aria-label="Choose a wallet"
+      data-testid="wallet-connector"
+    />
+  );
+}
+```
+
+Explicit `primaryWallet`, `wallets`, and `className` values take precedence over overlapping raw
+host attributes. For each CSS property, `style` takes precedence over `cssVars`, which takes
+precedence over the selected `theme`.
 
 ## Next.js App Router
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -116,7 +116,40 @@ typed `CONFIGURATION_REQUIRED` error.
 
 React wrapper around the web component. Props: `primaryWallet`, `wallets`, `theme`
 (`'dark' | 'light' | 'purple'`), `cssVars` (`--xc-*` overrides), `style`, `className`,
-and typed callbacks `onConnecting(walletId)`, `onConnect(account)`, `onError(WalletError)`.
+typed callbacks `onConnecting(walletId)`, `onConnect(account)`, `onError(WalletError)`, and
+standard host attributes such as `id`, `title`, `data-*`, and `aria-*`.
+
+The wrapper forwards a `WalletConnectorElement` ref for direct access to `open()`,
+`openAndWait()`, `close()`, and `toggle()`:
+
+```tsx
+import { useRef } from 'react';
+import { WalletConnector, type WalletConnectorElement } from '@xrpl-commons/xrpl-connect-react';
+
+function WalletModal() {
+  const connectorRef = useRef<WalletConnectorElement>(null);
+  const connect = async () => {
+    const account = await connectorRef.current?.openAndWait();
+    if (account) console.log('connected', account.address);
+  };
+
+  return (
+    <>
+      <button onClick={() => void connect()}>Connect wallet</button>
+      <WalletConnector
+        ref={connectorRef}
+        id="wallet-modal"
+        aria-label="Choose a wallet"
+        data-testid="wallet-connector"
+      />
+    </>
+  );
+}
+```
+
+Explicit connector props are authoritative when raw forwarded attributes overlap: `primaryWallet`,
+`wallets`, and `className` set their native host attributes after passthrough. Per CSS property,
+inline `style` overrides `cssVars`, which overrides the selected `theme`.
 
 ### Errors
 

--- a/packages/react/src/WalletConnector.tsx
+++ b/packages/react/src/WalletConnector.tsx
@@ -71,7 +71,7 @@ export const WalletConnector = forwardRef<WalletConnectorElement, WalletConnecto
           const cleanup = (
             forwardedRef as (instance: WalletConnectorElement | null) => void | (() => void)
           )(element);
-          if (cleanup) {
+          if (typeof cleanup === 'function') {
             return () => {
               elRef.current = null;
               cleanup();

--- a/packages/react/src/WalletConnector.tsx
+++ b/packages/react/src/WalletConnector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type CSSProperties } from 'react';
+import { forwardRef, useCallback, useEffect, useRef, type CSSProperties } from 'react';
 import {
   createWalletError,
   getErrorMessage,
@@ -39,155 +39,181 @@ const THEMES: Record<WalletConnectorTheme, Record<string, string>> = {
  * The web component registers itself when `xrpl-connect` is imported; ensure your
  * app imports it once (e.g. at the entry point). (#33)
  */
-export function WalletConnector({
-  primaryWallet,
-  wallets,
-  theme,
-  cssVars,
-  style,
-  className,
-  onConnecting,
-  onConnect,
-  onError,
-}: WalletConnectorProps) {
-  const {
-    manager,
-    registerConnector,
-    unregisterConnector,
-    reportModalConnecting,
-    reportModalError,
-    reportModalClosed,
-  } = useXrplConnectContext();
-  const elRef = useRef<WalletConnectorElement | null>(null);
-
-  // Keep the latest callbacks in a ref so the binding effect can stay stable
-  // (subscribe once) without going stale.
-  const callbacksRef = useRef({ onConnecting, onConnect, onError });
-  callbacksRef.current = { onConnecting, onConnect, onError };
-
-  useEffect(() => {
-    let active = true;
-    let detach: (() => void) | undefined;
-    let registeredElement: WalletConnectorElement | null = null;
-    let notifiedAccountKey: string | null = null;
-    const modalAttempts = new Map<number, symbol>();
-    let legacyModalAttempt: symbol | null = null;
-
-    const cancelModalAttempts = () => {
-      const attempts = [...modalAttempts.values()];
-      if (legacyModalAttempt) attempts.push(legacyModalAttempt);
-      modalAttempts.clear();
-      legacyModalAttempt = null;
-      if (attempts.length > 0) reportModalClosed(attempts);
-    };
-
-    const onMgrConnect = (account: AccountInfo) => {
-      const accountKey = `${account.address}:${account.network.id}`;
-      if (notifiedAccountKey === accountKey) return;
-      notifiedAccountKey = accountKey;
-      callbacksRef.current.onConnect?.(account);
-    };
-    const onMgrDisconnect = () => {
-      notifiedAccountKey = null;
-    };
-    manager.on('connect', onMgrConnect);
-    manager.on('disconnect', onMgrDisconnect);
-
-    // Reconcile a connection that completed before this component's effect.
-    if (manager.connected && manager.account) onMgrConnect(manager.account);
-
-    void customElements.whenDefined('xrpl-wallet-connector').then(() => {
-      const el = elRef.current;
-      if (!active || !el || typeof el.setWalletManager !== 'function') return;
-
-      el.setWalletManager(manager);
-      registerConnector(el);
-      registeredElement = el;
-
-      const onWcConnecting = (e: Event) => {
-        const detail = (e as CustomEvent<{ walletId?: string; connectionAttemptId?: number }>)
-          .detail;
-        const walletId = detail?.walletId;
-        if (walletId) {
-          const attempt = reportModalConnecting();
-          if (detail?.connectionAttemptId === undefined) {
-            if (legacyModalAttempt) reportModalClosed([legacyModalAttempt]);
-            legacyModalAttempt = attempt;
-          } else {
-            const previousAttempt = modalAttempts.get(detail.connectionAttemptId);
-            if (previousAttempt) reportModalClosed([previousAttempt]);
-            modalAttempts.set(detail.connectionAttemptId, attempt);
+export const WalletConnector = forwardRef<WalletConnectorElement, WalletConnectorProps>(
+  function WalletConnector(
+    {
+      primaryWallet,
+      wallets,
+      theme,
+      cssVars,
+      style,
+      className,
+      onConnecting,
+      onConnect,
+      onError,
+      ...hostAttributes
+    },
+    forwardedRef
+  ) {
+    const {
+      manager,
+      registerConnector,
+      unregisterConnector,
+      reportModalConnecting,
+      reportModalError,
+      reportModalClosed,
+    } = useXrplConnectContext();
+    const elRef = useRef<WalletConnectorElement | null>(null);
+    const setElementRef = useCallback(
+      (element: WalletConnectorElement | null) => {
+        elRef.current = element;
+        if (typeof forwardedRef === 'function') {
+          const cleanup = (
+            forwardedRef as (instance: WalletConnectorElement | null) => void | (() => void)
+          )(element);
+          if (cleanup) {
+            return () => {
+              elRef.current = null;
+              cleanup();
+            };
           }
-          callbacksRef.current.onConnecting?.(walletId);
+        } else if (forwardedRef) {
+          forwardedRef.current = element;
         }
+      },
+      [forwardedRef]
+    );
+
+    // Keep the latest callbacks in a ref so the binding effect can stay stable
+    // (subscribe once) without going stale.
+    const callbacksRef = useRef({ onConnecting, onConnect, onError });
+    callbacksRef.current = { onConnecting, onConnect, onError };
+
+    useEffect(() => {
+      let active = true;
+      let detach: (() => void) | undefined;
+      let registeredElement: WalletConnectorElement | null = null;
+      let notifiedAccountKey: string | null = null;
+      const modalAttempts = new Map<number, symbol>();
+      let legacyModalAttempt: symbol | null = null;
+
+      const cancelModalAttempts = () => {
+        const attempts = [...modalAttempts.values()];
+        if (legacyModalAttempt) attempts.push(legacyModalAttempt);
+        modalAttempts.clear();
+        legacyModalAttempt = null;
+        if (attempts.length > 0) reportModalClosed(attempts);
       };
-      const onWcError = (e: Event) => {
-        const detail = (
-          e as CustomEvent<{
-            error?: unknown;
-            errorType?: 'rejected' | 'unavailable' | 'failed';
-            walletId?: string;
-            connectionAttemptId?: number;
-          }>
-        ).detail;
-        const error = normalizeModalError(detail?.error, detail?.errorType, detail?.walletId);
-        let attempt: symbol | null;
-        if (detail?.connectionAttemptId === undefined) {
-          attempt = legacyModalAttempt;
-          legacyModalAttempt = null;
-        } else {
-          attempt = modalAttempts.get(detail.connectionAttemptId) ?? null;
-          if (attempt === null) return;
-          modalAttempts.delete(detail.connectionAttemptId);
-        }
-        if (reportModalError(attempt, error)) callbacksRef.current.onError?.(error);
+
+      const onMgrConnect = (account: AccountInfo) => {
+        const accountKey = `${account.address}:${account.network.id}`;
+        if (notifiedAccountKey === accountKey) return;
+        notifiedAccountKey = accountKey;
+        callbacksRef.current.onConnect?.(account);
       };
-      const onWcClose = () => cancelModalAttempts();
-
-      el.addEventListener('connecting', onWcConnecting);
-      el.addEventListener('error', onWcError);
-      el.addEventListener('close', onWcClose);
-
-      detach = () => {
-        el.removeEventListener('connecting', onWcConnecting);
-        el.removeEventListener('error', onWcError);
-        el.removeEventListener('close', onWcClose);
-        cancelModalAttempts();
+      const onMgrDisconnect = () => {
+        notifiedAccountKey = null;
       };
-    });
+      manager.on('connect', onMgrConnect);
+      manager.on('disconnect', onMgrDisconnect);
 
-    return () => {
-      active = false;
-      manager.off('connect', onMgrConnect);
-      manager.off('disconnect', onMgrDisconnect);
-      if (registeredElement) unregisterConnector(registeredElement);
-      detach?.();
-    };
-  }, [
-    manager,
-    registerConnector,
-    unregisterConnector,
-    reportModalConnecting,
-    reportModalError,
-    reportModalClosed,
-  ]);
+      // Reconcile a connection that completed before this component's effect.
+      if (manager.connected && manager.account) onMgrConnect(manager.account);
 
-  const mergedStyle = {
-    ...(theme ? THEMES[theme] : {}),
-    ...(cssVars ?? {}),
-    ...(style ?? {}),
-  } as CSSProperties;
+      void customElements.whenDefined('xrpl-wallet-connector').then(() => {
+        const el = elRef.current;
+        if (!active || !el || typeof el.setWalletManager !== 'function') return;
 
-  return (
-    <xrpl-wallet-connector
-      ref={elRef}
-      primary-wallet={primaryWallet}
-      wallets={wallets?.join(',')}
-      class={className}
-      style={mergedStyle}
-    />
-  );
-}
+        el.setWalletManager(manager);
+        registerConnector(el);
+        registeredElement = el;
+
+        const onWcConnecting = (e: Event) => {
+          const detail = (e as CustomEvent<{ walletId?: string; connectionAttemptId?: number }>)
+            .detail;
+          const walletId = detail?.walletId;
+          if (walletId) {
+            const attempt = reportModalConnecting();
+            if (detail?.connectionAttemptId === undefined) {
+              if (legacyModalAttempt) reportModalClosed([legacyModalAttempt]);
+              legacyModalAttempt = attempt;
+            } else {
+              const previousAttempt = modalAttempts.get(detail.connectionAttemptId);
+              if (previousAttempt) reportModalClosed([previousAttempt]);
+              modalAttempts.set(detail.connectionAttemptId, attempt);
+            }
+            callbacksRef.current.onConnecting?.(walletId);
+          }
+        };
+        const onWcError = (e: Event) => {
+          const detail = (
+            e as CustomEvent<{
+              error?: unknown;
+              errorType?: 'rejected' | 'unavailable' | 'failed';
+              walletId?: string;
+              connectionAttemptId?: number;
+            }>
+          ).detail;
+          const error = normalizeModalError(detail?.error, detail?.errorType, detail?.walletId);
+          let attempt: symbol | null;
+          if (detail?.connectionAttemptId === undefined) {
+            attempt = legacyModalAttempt;
+            legacyModalAttempt = null;
+          } else {
+            attempt = modalAttempts.get(detail.connectionAttemptId) ?? null;
+            if (attempt === null) return;
+            modalAttempts.delete(detail.connectionAttemptId);
+          }
+          if (reportModalError(attempt, error)) callbacksRef.current.onError?.(error);
+        };
+        const onWcClose = () => cancelModalAttempts();
+
+        el.addEventListener('connecting', onWcConnecting);
+        el.addEventListener('error', onWcError);
+        el.addEventListener('close', onWcClose);
+
+        detach = () => {
+          el.removeEventListener('connecting', onWcConnecting);
+          el.removeEventListener('error', onWcError);
+          el.removeEventListener('close', onWcClose);
+          cancelModalAttempts();
+        };
+      });
+
+      return () => {
+        active = false;
+        manager.off('connect', onMgrConnect);
+        manager.off('disconnect', onMgrDisconnect);
+        if (registeredElement) unregisterConnector(registeredElement);
+        detach?.();
+      };
+    }, [
+      manager,
+      registerConnector,
+      unregisterConnector,
+      reportModalConnecting,
+      reportModalError,
+      reportModalClosed,
+    ]);
+
+    const mergedStyle = {
+      ...(theme ? THEMES[theme] : {}),
+      ...(cssVars ?? {}),
+      ...(style ?? {}),
+    } as CSSProperties;
+
+    return (
+      <xrpl-wallet-connector
+        {...hostAttributes}
+        ref={setElementRef}
+        primary-wallet={primaryWallet}
+        wallets={wallets?.join(',')}
+        class={className}
+        style={mergedStyle}
+      />
+    );
+  }
+);
 
 function normalizeModalError(
   error: unknown,

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -6,7 +6,7 @@ import type {
   WalletError,
 } from '@xrpl-connect/core';
 import type { ConnectOptionsFor, WalletConnectorCssVars, WalletIdentifier } from 'xrpl-connect';
-import type { CSSProperties, ReactNode } from 'react';
+import type { CSSProperties, HTMLAttributes, ReactNode } from 'react';
 
 /**
  * Configuration for {@link XrplConnectProvider}. Identical to the core
@@ -70,7 +70,17 @@ export interface XrplConnectProviderProps {
 /** Built-in theme presets applied as `--xc-*` custom properties. */
 export type WalletConnectorTheme = 'dark' | 'light' | 'purple';
 
-export interface WalletConnectorProps {
+type WalletConnectorHostAttributes = Omit<
+  HTMLAttributes<WalletConnectorElement>,
+  'children' | 'dangerouslySetInnerHTML' | 'className' | 'style' | 'onError'
+>;
+
+interface WalletConnectorDataAttributes {
+  [attribute: `data-${string}`]: string | number | undefined;
+}
+
+export interface WalletConnectorProps
+  extends WalletConnectorHostAttributes, WalletConnectorDataAttributes {
   /** Pre-select a wallet in the modal (maps to the `primary-wallet` attribute). */
   primaryWallet?: WalletIdentifier;
   /** Restrict/order the wallet list (maps to the `wallets` attribute). */
@@ -81,6 +91,7 @@ export interface WalletConnectorProps {
   cssVars?: WalletConnectorCssVars;
   /** Extra inline styles forwarded to the host element. */
   style?: CSSProperties;
+  /** CSS class forwarded to the host element's native `class` attribute. */
   className?: string;
   /** Fired (with the wallet id) when a connection attempt starts. */
   onConnecting?: (walletId: WalletIdentifier) => void;

--- a/packages/react/tests/public-api.types.ts
+++ b/packages/react/tests/public-api.types.ts
@@ -1,5 +1,7 @@
 import type { AccountInfo } from '@xrpl-connect/core';
+import { createRef, type ComponentPropsWithRef } from 'react';
 import {
+  WalletConnector,
   useWalletModal,
   type WalletConnectorElement,
   type WalletConnectorProps,
@@ -7,6 +9,16 @@ import {
 
 declare const connector: WalletConnectorElement;
 declare const manager: Parameters<WalletConnectorElement['setWalletManager']>[0];
+
+const connectorRef = createRef<WalletConnectorElement>();
+const wrapperProps: ComponentPropsWithRef<typeof WalletConnector> = {
+  ref: connectorRef,
+  id: 'wallet-modal',
+  title: 'Choose a wallet',
+  'data-testid': 'wallet-connector',
+  'aria-label': 'Wallet connector',
+};
+const wrapperElement: WalletConnectorElement | null = connectorRef.current;
 
 const managerResult: void = connector.setWalletManager(manager);
 const openResult: Promise<void> = connector.open();
@@ -33,6 +45,8 @@ connector.openAccountModal();
 connector.closeAccountModal();
 
 void managerResult;
+void wrapperProps;
+void wrapperElement;
 void openResult;
 void accountResult;
 void closeResult;

--- a/packages/react/tests/publish/runtime-ssr.mjs
+++ b/packages/react/tests/publish/runtime-ssr.mjs
@@ -6,27 +6,28 @@ import * as reactEsm from '@xrpl-commons/xrpl-connect-react';
 
 const require = createRequire(import.meta.url);
 const reactCjs = require('@xrpl-commons/xrpl-connect-react');
-const publicExports = [
-  'XrplConnectProvider',
-  'WalletConnector',
-  'useWallet',
-  'useSigner',
-  'useWalletModal',
-];
+const publicExports = ['XrplConnectProvider', 'useWallet', 'useSigner', 'useWalletModal'];
 
 for (const api of [reactEsm, reactCjs]) {
   for (const exportName of publicExports) {
     assert.equal(typeof api[exportName], 'function', `React package is missing ${exportName}`);
   }
+  assert.ok(api.WalletConnector, 'React package is missing WalletConnector');
 
   const html = renderToString(
     createElement(
       api.XrplConnectProvider,
       { config: { adapters: [] } },
-      createElement('main', null, 'XRPL Connect SSR')
+      createElement(
+        'main',
+        null,
+        'XRPL Connect SSR',
+        createElement(api.WalletConnector, { id: 'wallet-connector' })
+      )
     )
   );
   assert.match(html, /XRPL Connect SSR/);
+  assert.match(html, /<xrpl-wallet-connector id="wallet-connector"/);
 }
 
 const umbrella = await import('xrpl-connect');

--- a/packages/react/tests/publish/types-react-cjs.cts
+++ b/packages/react/tests/publish/types-react-cjs.cts
@@ -1,4 +1,9 @@
-import type { ComponentProps, ComponentType } from 'react';
+import {
+  createRef,
+  type ComponentProps,
+  type ComponentPropsWithRef,
+  type ComponentType,
+} from 'react';
 import {
   WalletConnector,
   XrplConnectProvider,
@@ -6,6 +11,7 @@ import {
   useSigner,
   useWallet,
   useWalletModal,
+  type WalletConnectorElement,
   type WalletConnectorProps,
 } from '@xrpl-commons/xrpl-connect-react';
 import type {
@@ -27,7 +33,15 @@ declare module 'xrpl-connect' {
 }
 
 const provider: ComponentType<ComponentProps<typeof XrplConnectProvider>> = XrplConnectProvider;
-const connector: ComponentType<WalletConnectorProps> = WalletConnector;
+const connectorRef = createRef<WalletConnectorElement>();
+const connectorProps: ComponentPropsWithRef<typeof WalletConnector> = {
+  ref: connectorRef,
+  id: 'wallet-modal',
+  title: 'Choose a wallet',
+  'data-testid': 'wallet-connector',
+  'aria-label': 'Wallet connector',
+};
+const connectorElement: WalletConnectorElement | null = connectorRef.current;
 const cssVarsProps: WalletConnectorProps = { cssVars: { '--xc-primary-color': '#7c3aed' } };
 const invalidCssVarsProps: WalletConnectorProps = {
   cssVars: {
@@ -56,7 +70,8 @@ const errorGuard: (error: unknown) => error is WalletError = isWalletError;
 
 void [
   provider,
-  connector,
+  connectorProps,
+  connectorElement,
   cssVarsProps,
   invalidCssVarsProps,
   signedTransaction,

--- a/packages/react/tests/publish/types-react-esm.mts
+++ b/packages/react/tests/publish/types-react-esm.mts
@@ -1,4 +1,9 @@
-import type { ComponentProps, ComponentType } from 'react';
+import {
+  createRef,
+  type ComponentProps,
+  type ComponentPropsWithRef,
+  type ComponentType,
+} from 'react';
 import {
   WalletConnector,
   XrplConnectProvider,
@@ -6,6 +11,7 @@ import {
   useSigner,
   useWallet,
   useWalletModal,
+  type WalletConnectorElement,
   type WalletConnectorProps,
   type XrplConnectConfig,
 } from '@xrpl-commons/xrpl-connect-react';
@@ -39,7 +45,15 @@ const invalidNetworkConfig: XrplConnectConfig = {
 };
 
 const provider: ComponentType<ComponentProps<typeof XrplConnectProvider>> = XrplConnectProvider;
-const connector: ComponentType<WalletConnectorProps> = WalletConnector;
+const connectorRef = createRef<WalletConnectorElement>();
+const connectorProps: ComponentPropsWithRef<typeof WalletConnector> = {
+  ref: connectorRef,
+  id: 'wallet-modal',
+  title: 'Choose a wallet',
+  'data-testid': 'wallet-connector',
+  'aria-label': 'Wallet connector',
+};
+const connectorElement: WalletConnectorElement | null = connectorRef.current;
 const cssVarsProps: WalletConnectorProps = { cssVars: { '--xc-primary-color': '#7c3aed' } };
 const invalidCssVarsProps: WalletConnectorProps = {
   cssVars: {
@@ -68,7 +82,8 @@ const errorGuard: (error: unknown) => error is WalletError = isWalletError;
 
 void [
   provider,
-  connector,
+  connectorProps,
+  connectorElement,
   cssVarsProps,
   invalidCssVarsProps,
   signedTransaction,

--- a/packages/react/tests/react.test.tsx
+++ b/packages/react/tests/react.test.tsx
@@ -500,6 +500,28 @@ describe('<WalletConnector>', () => {
     expect(connectorRef.current).toBeNull();
   });
 
+  it('does not reinterpret non-function callback ref returns as cleanups', async () => {
+    let connector: WalletConnectorElement | null = null;
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      const { unmount } = render(
+        <XrplConnectProvider config={{ adapters: [makeAdapter()], autoConnect: false }}>
+          <WalletConnector ref={(element) => (connector = element)} />
+        </XrplConnectProvider>
+      );
+
+      await waitFor(() => expect(connector).not.toBeNull());
+      unmount();
+      expect(connector).toBeNull();
+      expect(consoleError.mock.calls.flat().join('\n')).not.toContain(
+        'Unexpected return value from a callback ref'
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it('forwards host attributes while managed connector props retain precedence', async () => {
     const onClick = vi.fn();
     const conflictingHostAttributes = {

--- a/packages/react/tests/react.test.tsx
+++ b/packages/react/tests/react.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, expectTypeOf, beforeAll, vi } from 'vite-plus/test';
 import { render, act, waitFor, renderHook } from '@testing-library/react';
-import { StrictMode, useRef } from 'react';
+import { createRef, StrictMode, useRef } from 'react';
 import { renderToString } from 'react-dom/server';
 import {
   WalletManager,
@@ -17,6 +17,8 @@ import {
   useWalletModal,
   WalletConnector,
   WalletErrorCode,
+  type WalletConnectorElement,
+  type WalletConnectorProps,
 } from '../src';
 
 const ACCOUNT: AccountInfo = { address: 'rTEST', network: STANDARD_NETWORKS.testnet };
@@ -436,6 +438,9 @@ describe('<WalletConnector>', () => {
           this.opened = false;
           this.rejectWaiters(new Error('Modal closed before a wallet was connected.'));
         }
+        toggle() {
+          this.opened = !this.opened;
+        }
         resolveConnection(account: AccountInfo) {
           for (const waiter of this.waiters) waiter.resolve(account);
           this.waiters.clear();
@@ -458,6 +463,88 @@ describe('<WalletConnector>', () => {
     expectTypeOf<WalletModal['open']>().toEqualTypeOf<() => Promise<void>>();
     expectTypeOf<WalletModal['openAndWait']>().toEqualTypeOf<() => Promise<AccountInfo>>();
     expectTypeOf<WalletModal['close']>().toEqualTypeOf<() => void>();
+  });
+
+  it('forwards the custom element ref and its imperative methods', async () => {
+    const connectorRef = createRef<WalletConnectorElement>();
+    const { unmount } = render(
+      <XrplConnectProvider config={{ adapters: [makeAdapter()], autoConnect: false }}>
+        <WalletConnector ref={connectorRef} />
+      </XrplConnectProvider>
+    );
+
+    await waitFor(() => expect(connectorRef.current).not.toBeNull());
+    const element = document.querySelector('xrpl-wallet-connector') as WalletConnectorElement & {
+      manager: unknown;
+      opened: boolean;
+      resolveConnection(account: AccountInfo): void;
+    };
+    await waitFor(() => expect(element.manager).not.toBeNull());
+    expect(connectorRef.current).toBe(element);
+
+    await act(async () => connectorRef.current!.open());
+    expect(element.opened).toBe(true);
+
+    const connected = connectorRef.current!.openAndWait();
+    act(() => element.resolveConnection(ACCOUNT));
+    await expect(connected).resolves.toEqual(ACCOUNT);
+
+    act(() => connectorRef.current!.close());
+    expect(element.opened).toBe(false);
+    act(() => connectorRef.current!.toggle());
+    expect(element.opened).toBe(true);
+    act(() => connectorRef.current!.toggle());
+    expect(element.opened).toBe(false);
+
+    unmount();
+    expect(connectorRef.current).toBeNull();
+  });
+
+  it('forwards host attributes while managed connector props retain precedence', async () => {
+    const onClick = vi.fn();
+    const conflictingHostAttributes = {
+      class: 'forwarded-class',
+      'primary-wallet': 'forwarded-wallet',
+    } as unknown as WalletConnectorProps;
+
+    render(
+      <XrplConnectProvider config={{ adapters: [makeAdapter()], autoConnect: false }}>
+        <WalletConnector
+          {...conflictingHostAttributes}
+          id="wallet-modal"
+          title="Choose a wallet"
+          data-testid="wallet-connector"
+          aria-label="Wallet connector"
+          role="dialog"
+          tabIndex={0}
+          onClick={onClick}
+          primaryWallet="fake"
+          wallets={['fake']}
+          className="managed-class"
+          theme="dark"
+          cssVars={{ '--xc-primary-color': '#112233' }}
+          style={{ '--xc-primary-color': '#445566' } as React.CSSProperties}
+        />
+      </XrplConnectProvider>
+    );
+
+    const element = document.querySelector('xrpl-wallet-connector') as HTMLElement & {
+      manager: unknown;
+    };
+    await waitFor(() => expect(element.manager).not.toBeNull());
+    expect(element.getAttribute('id')).toBe('wallet-modal');
+    expect(element.getAttribute('title')).toBe('Choose a wallet');
+    expect(element.getAttribute('data-testid')).toBe('wallet-connector');
+    expect(element.getAttribute('aria-label')).toBe('Wallet connector');
+    expect(element.getAttribute('role')).toBe('dialog');
+    expect(element.getAttribute('tabindex')).toBe('0');
+    expect(element.getAttribute('primary-wallet')).toBe('fake');
+    expect(element.getAttribute('wallets')).toBe('fake');
+    expect(element.getAttribute('class')).toBe('managed-class');
+    expect(element.style.getPropertyValue('--xc-primary-color')).toBe('#445566');
+
+    act(() => element.click());
+    expect(onClick).toHaveBeenCalledOnce();
   });
 
   it('rejects modal calls until a connector is registered', async () => {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,29 +1,32 @@
-# Issue #171
+# Issue #172
 
 ## Issue summary
 
-- The React modal hook drops the web component's readiness and asynchronous API, so consumers cannot safely call or await it.
-- `open` must preserve failures, `openAndWait` must return the selected `AccountInfo`, and pre-registration calls must reject with a clear namespaced setup error.
-- Connector registration remains last-mounted-owner-wins, with reactive readiness through registration and unregistration.
-- Tests, public type assertions, and React documentation must describe and enforce the complete contract.
+- The React `WalletConnector` keeps its custom-element ref private, so consumers cannot use the exported `WalletConnectorElement` imperative API through the wrapper.
+- The wrapper destructures a closed SDK-specific prop set and drops ordinary host metadata such as `id`, `title`, `data-*`, and `aria-*` instead of forwarding it to `<xrpl-wallet-connector>`.
+- The fix must preserve provider registration, SDK callbacks, `className`, merged theme/CSS-variable/inline styles, and React 18/19 support while making managed-prop precedence explicit.
+- Runtime and source/packed declaration tests must prove the ref contract, imperative methods, host passthrough, collision precedence, and unsupported CSS-variable rejection.
 
 ## Plan
 
 - [x] Validate GitHub access, refresh `origin/develop`, and confirm issue state, comments, linked PRs, and acceptance criteria.
-- [x] Create a clean isolated worktree from the refreshed default branch and review applicable repository guidance.
-- [x] Trace the React provider/hook/types lifecycle, Vue parity implementation, tests, public type checks, and documentation.
-- [x] Implement the smallest production-ready async modal context API while preserving connector ownership semantics.
-- [x] Add focused runtime and public type regressions for pre-registration calls, lifecycle readiness, rejected opens, and `openAndWait`.
-- [x] Update React documentation for readiness and awaitable modal usage.
-- [x] Run formatting, linting, focused tests, builds/type checks, and relevant repository-level verification.
+- [x] Create a clean isolated worktree from the refreshed default branch and review applicable repository guidance and lessons.
+- [x] Trace the React wrapper, custom-element contract, Vue passthrough behavior, runtime tests, public declarations, and publish fixtures.
+- [x] Define the narrowest idiomatic React host-prop/ref contract and explicit precedence for managed connector attributes.
+- [x] Implement typed `WalletConnectorElement` ref forwarding and safe host-attribute passthrough without changing existing lifecycle or style semantics.
+- [x] Add focused runtime regressions for ref lifecycle, `open`, `openAndWait`, `close`, `toggle`, host attributes, callback isolation, and managed-attribute precedence.
+- [x] Add source and packed ESM/CJS type regressions for typed refs and host attributes under the supported React contract.
+- [x] Update current React documentation, API reference, and Unreleased changelog to describe the new contract and precedence.
+- [x] Run formatting/linting, focused React tests/type checks/builds, publish verification, and repository-level verification appropriate to the diff.
 - [x] Review the final diff against every acceptance criterion and record results below.
 - [x] Commit only intentional files, push the branch, open the PR, and verify remote PR metadata/checks.
 
 ## Review
 
-- The provider now exposes connector registration as reactive `ready` state while preserving the insertion-ordered `Set` that gives the newest connector ownership and falls back when it unmounts.
-- `open()` and `openAndWait()` preserve native results and failures; missing registration and synchronous connector failures become rejected promises with a React-namespaced setup error, while `close()` remains a safe no-op.
-- Runtime tests cover pre-registration calls, lifecycle readiness, open failures, `openAndWait` success/close rejection, newest ownership, and fallback; source plus packed ESM/CJS type fixtures enforce the public contract.
-- The package README, React framework guide, API reference, and Unreleased changelog document readiness, async behavior, errors, and multi-connector ownership without changing versioned documentation.
-- `pnpm exec vp check`, `pnpm --filter @xrpl-commons/xrpl-connect-react... build`, focused React tests, `pnpm test`, `pnpm docs:snapshot:check`, `pnpm --filter xrpl-connect test:publish`, and `git diff --check` pass.
-- Independent final review found no correctness, lifecycle, declaration, documentation, or scope findings.
+- `WalletConnector` is now an idiomatic `forwardRef` component that exposes the exact `WalletConnectorElement` instance while retaining its private lifecycle ref; callback-ref cleanup is preserved for React 19 and object/callback refs clear on unmount.
+- Standard React host attributes flow to `<xrpl-wallet-connector>` through a typed HTML-attribute contract, including explicit `data-*` support, while children/HTML injection and the conflicting native `onError` signature remain excluded.
+- SDK callbacks remain internal, `className` still maps to native `class`, and managed `primaryWallet`, `wallets`, class, and merged styles are applied after passthrough. Per-token style precedence remains `theme < cssVars < style`.
+- Runtime tests obtain the exact host through a ref, exercise `open`, `openAndWait`, `close`, and `toggle`, verify ref cleanup, host metadata/event passthrough, and raw collision precedence. Source plus packed ESM/CJS fixtures enforce the ref and host-prop declarations.
+- The package README, current React guide, API reference, and Unreleased changelog document refs, host attributes, and precedence; versioned documentation remains unchanged.
+- Under Node 24.11.0, `pnpm exec vp check`, the dependency-inclusive React build, focused and full React tests, `pnpm test`, `pnpm docs:snapshot:check`, `pnpm --filter xrpl-connect test:publish`, and `git diff --check` pass.
+- Self-review corrected an invalid module-scope hook in the first README example draft; an independent final review found no remaining correctness, lifecycle, type, test, documentation, or scope defects.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -30,3 +30,18 @@
 - The package README, current React guide, API reference, and Unreleased changelog document refs, host attributes, and precedence; versioned documentation remains unchanged.
 - Under Node 24.11.0, `pnpm exec vp check`, the dependency-inclusive React build, focused and full React tests, `pnpm test`, `pnpm docs:snapshot:check`, `pnpm --filter xrpl-connect test:publish`, and `git diff --check` pass.
 - Self-review corrected an invalid module-scope hook in the first README example draft; an independent final review found no remaining correctness, lifecycle, type, test, documentation, or scope defects.
+
+## Fix PR #176 review finding
+
+- [x] Reconfirm the dedicated worktree and remote PR head are clean and identical.
+- [x] Guard callback-ref cleanup returns by function type while preserving React 18/19 behavior.
+- [x] Add a regression for concise callback refs that return the assigned element.
+- [x] Run focused React checks and repository-level verification appropriate to the fix.
+- [x] Review the final diff, commit, push, and verify the updated PR head and CI.
+
+### Fix review
+
+- Callback-ref returns are treated as React 19 cleanup callbacks only when they are functions; truthy assignment results are ignored so React can deliver the normal `null` detach callback.
+- The new React 18 regression failed against the original PR code with `Unexpected return value from a callback ref` and passes with the function guard.
+- The rebuilt packed artifact passes the original React 19.2.8 unmount reproduction for both native and wrapped refs.
+- Focused and full React checks, dependency-inclusive build, repository formatting/lint, documentation snapshot verification, full monorepo tests, packed publish/consumer verification, and `git diff --check` pass.


### PR DESCRIPTION
## Summary
- expose the underlying `WalletConnectorElement` through an idiomatic React 18/19-compatible forwarded ref
- forward typed host attributes while preserving SDK callbacks, style merging, and explicit managed-prop precedence
- cover runtime, source declarations, packed ESM/CJS consumers, SSR loading, and current documentation

## Test plan
- [x] `pnpm exec vp check`
- [x] `pnpm --filter @xrpl-commons/xrpl-connect-react... build`
- [x] `pnpm --filter @xrpl-commons/xrpl-connect-react test`
- [x] `pnpm test`
- [x] `pnpm docs:snapshot:check`
- [x] `pnpm --filter xrpl-connect test:publish`
- [x] `git diff --check`

Fixes #172
