### PR TITLE
test: verify React 18 and 19 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- React: ship the custom-element JSX and typed-ref declaration in the packed package, and verify the advertised React 18 and 19 runtime/type compatibility in isolated consumers (#170).
 - Documentation: pin current install commands to `xrpl@^4` so registry-latest v5 cannot drift outside the supported v3/v4 peer range; packed-consumer verification now executes the literal React dependency specifications and rejects stale install examples (#169).
 - xrpl-connect (meta-bundle): emit the Xaman mock-WebSocket constructor without an optional chain so Nuxt 4 and Vite/Rollup production builds can consume the published ESM artifact. Consumers can remove `patch-package` or transpilation workarounds for `xrpl-connect.mjs` (#141).
 

--- a/packages/react/src/jsx.d.ts
+++ b/packages/react/src/jsx.d.ts
@@ -1,14 +1,15 @@
 import type { DetailedHTMLProps, HTMLAttributes } from 'react';
+import type { WalletConnectorElement } from './types';
 
 /** Attributes supported by the `<xrpl-wallet-connector>` custom element in React JSX. */
 export type WalletConnectorIntrinsicProps = DetailedHTMLProps<
-  HTMLAttributes<HTMLElement> & {
+  HTMLAttributes<WalletConnectorElement> & {
     'primary-wallet'?: string;
     wallets?: string;
     'show-unavailable'?: true | '';
     class?: string;
   },
-  HTMLElement
+  WalletConnectorElement
 >;
 
 declare module 'react' {

--- a/packages/react/tests/publish/runtime-dom.mjs
+++ b/packages/react/tests/publish/runtime-dom.mjs
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!doctype html><div id="root"></div>', {
+  pretendToBeVisual: true,
+  url: 'https://example.com',
+});
+dom.window.matchMedia = () => ({
+  matches: false,
+  addListener() {},
+  removeListener() {},
+  addEventListener() {},
+  removeEventListener() {},
+});
+
+for (const key of [
+  'CSSStyleSheet',
+  'CustomEvent',
+  'Document',
+  'Element',
+  'Event',
+  'HTMLElement',
+  'Node',
+  'ShadowRoot',
+  'customElements',
+]) {
+  globalThis[key] = dom.window[key];
+}
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+globalThis.localStorage = dom.window.localStorage;
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+Object.defineProperty(globalThis, 'navigator', {
+  configurable: true,
+  value: dom.window.navigator,
+});
+
+class StubWalletConnector extends HTMLElement {
+  manager = null;
+
+  setWalletManager(manager) {
+    this.manager = manager;
+  }
+
+  async open() {}
+
+  async openAndWait() {
+    throw new Error('No account selected');
+  }
+
+  close() {}
+
+  toggle() {}
+}
+
+customElements.define('xrpl-wallet-connector', StubWalletConnector);
+
+const [{ act, createElement }, { createRoot }, reactApi] = await Promise.all([
+  import('react'),
+  import('react-dom/client'),
+  import('@xrpl-commons/xrpl-connect-react'),
+]);
+const connectingWallets = [];
+const connectedAccounts = [];
+const reportedErrors = [];
+const root = createRoot(document.querySelector('#root'));
+
+await act(async () => {
+  root.render(
+    createElement(
+      reactApi.XrplConnectProvider,
+      { config: { adapters: [], autoConnect: false } },
+      createElement(reactApi.WalletConnector, {
+        primaryWallet: 'xaman',
+        onConnecting: (walletId) => connectingWallets.push(walletId),
+        onConnect: (account) => connectedAccounts.push(account),
+        onError: (error) => reportedErrors.push(error),
+      })
+    )
+  );
+  await Promise.resolve();
+});
+
+const connector = document.querySelector('xrpl-wallet-connector');
+assert(connector instanceof StubWalletConnector, 'React did not mount the connector element');
+assert(connector.manager, 'React did not bind the provider manager to the connector element');
+
+await act(async () => {
+  connector.dispatchEvent(
+    new CustomEvent('connecting', { detail: { walletId: 'xaman', connectionAttemptId: 1 } })
+  );
+});
+assert.deepEqual(connectingWallets, ['xaman']);
+
+await act(async () => {
+  connector.dispatchEvent(
+    new CustomEvent('error', {
+      detail: {
+        error: new Error('Connection rejected'),
+        errorType: 'rejected',
+        walletId: 'xaman',
+        connectionAttemptId: 1,
+      },
+    })
+  );
+});
+assert.equal(reportedErrors.length, 1);
+assert.equal(reportedErrors[0].code, reactApi.WalletErrorCode.CONNECTION_REJECTED);
+
+const account = {
+  address: 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
+  network: { id: 'testnet', name: 'Testnet', wss: 'wss://s.altnet.rippletest.net:51233' },
+};
+await act(async () => {
+  connector.manager.emit('connect', account);
+});
+assert.deepEqual(connectedAccounts, [account]);
+
+await act(async () => root.unmount());
+dom.window.close();

--- a/packages/react/tests/publish/tsconfig.react.json
+++ b/packages/react/tests/publish/tsconfig.react.json
@@ -3,11 +3,12 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "jsx": "react-jsx",
     "lib": ["ES2022", "DOM"],
     "types": ["node", "react", "react-dom"],
     "strict": true,
     "noEmit": true,
     "skipLibCheck": false
   },
-  "files": ["types-react-esm.mts", "types-react-cjs.cts"]
+  "files": ["types-react-esm.mts", "types-react-cjs.cts", "types-react-jsx.tsx"]
 }

--- a/packages/react/tests/publish/types-react-jsx.tsx
+++ b/packages/react/tests/publish/types-react-jsx.tsx
@@ -1,0 +1,45 @@
+import { createRef, type ComponentProps } from 'react';
+import {
+  WalletConnector,
+  XrplConnectProvider,
+  type WalletConnectorElement,
+} from '@xrpl-commons/xrpl-connect-react';
+import type { AccountInfo, WalletError, WalletIdentifier } from 'xrpl-connect';
+
+const connectorRef = createRef<WalletConnectorElement>();
+const connectorProps: ComponentProps<'xrpl-wallet-connector'> = {
+  ref: connectorRef,
+  'primary-wallet': 'xaman',
+  wallets: 'xaman,crossmark',
+  'show-unavailable': true,
+  class: 'wallet-connector',
+};
+const customElement = <xrpl-wallet-connector {...connectorProps} />;
+const invalidRef = (
+  <xrpl-wallet-connector
+    // @ts-expect-error The custom-element ref exposes WalletConnectorElement, not another host.
+    ref={createRef<HTMLButtonElement>()}
+  />
+);
+const provider = (
+  <XrplConnectProvider config={{ adapters: [], network: 'testnet' }}>
+    <WalletConnector
+      primaryWallet="xaman"
+      wallets={['xaman', 'crossmark']}
+      onConnecting={(walletId) => {
+        const typedWalletId: WalletIdentifier = walletId;
+        void typedWalletId;
+      }}
+      onConnect={(account) => {
+        const typedAccount: AccountInfo = account;
+        void typedAccount;
+      }}
+      onError={(error) => {
+        const typedError: WalletError = error;
+        void typedError;
+      }}
+    />
+  </XrplConnectProvider>
+);
+
+void [customElement, invalidRef, provider];

--- a/packages/react/tests/tsconfig.types.json
+++ b/packages/react/tests/tsconfig.types.json
@@ -6,5 +6,6 @@
     "strict": true,
     "skipLibCheck": false
   },
-  "files": ["public-api.types.ts"]
+  "files": ["public-api.types.ts"],
+  "include": []
 }

--- a/packages/xrpl-connect/scripts/test-publish.mjs
+++ b/packages/xrpl-connect/scripts/test-publish.mjs
@@ -159,6 +159,64 @@ function resolveCandidateSpecs(dependencies, tarballsByName) {
   });
 }
 
+function resolveReactCandidateSpecs(dependencies, tarballsByName, reactMajor) {
+  return resolveCandidateSpecs(dependencies, tarballsByName).map((dependency) => {
+    for (const packageName of ['react', 'react-dom']) {
+      if (dependency === packageName || dependency.startsWith(`${packageName}@`)) {
+        return `${packageName}@${reactMajor}`;
+      }
+    }
+    return dependency;
+  });
+}
+
+function writeConsumerManifest(consumerFolder, name) {
+  mkdirSync(consumerFolder);
+  writeFileSync(
+    path.join(consumerFolder, 'package.json'),
+    JSON.stringify({ name, private: true, type: 'module' }, null, 2)
+  );
+}
+
+function verifyInstalledReactMajor(consumerFolder, reactMajor) {
+  for (const dependency of ['react', 'react-dom', '@types/react', '@types/react-dom']) {
+    const manifest = JSON.parse(
+      readFileSync(path.join(consumerFolder, 'node_modules', dependency, 'package.json'), 'utf-8')
+    );
+    assert.equal(
+      manifest.version.split('.')[0],
+      String(reactMajor),
+      `${dependency}@${manifest.version} does not match the React ${reactMajor} consumer`
+    );
+  }
+  console.log(`✓ React ${reactMajor} consumer uses matching runtime and type-package majors`);
+}
+
+function copyReactFixtures(consumerFolder) {
+  for (const fixture of [
+    'runtime-dom.mjs',
+    'runtime-ssr.mjs',
+    'types-react-esm.mts',
+    'types-react-cjs.cts',
+    'types-react-jsx.tsx',
+    'tsconfig.react.json',
+  ]) {
+    copyFileSync(path.join(reactFixturesFolder, fixture), path.join(consumerFolder, fixture));
+  }
+}
+
+function verifyPackedReactConsumer(consumerFolder, reactMajor, tscPath, options) {
+  console.log(`→ Type-checking packed React ${reactMajor} ESM, CommonJS, and JSX consumers`);
+  run(process.execPath, [tscPath, '--project', 'tsconfig.react.json'], {
+    ...options,
+    cwd: consumerFolder,
+  });
+  console.log(`→ Loading packed React ${reactMajor} ESM and CommonJS entries in SSR`);
+  run(process.execPath, ['runtime-ssr.mjs'], { ...options, cwd: consumerFolder });
+  console.log(`→ Mounting packed React ${reactMajor} connector and verifying callbacks`);
+  run(process.execPath, ['runtime-dom.mjs'], { ...options, cwd: consumerFolder });
+}
+
 function verifyNpmAccess() {
   const username = run('npm', ['whoami', '--registry', NPM_REGISTRY], {
     ...registryRunOptions,
@@ -294,16 +352,8 @@ try {
     );
   }
 
-  const consumerFolder = path.join(temporaryRoot, 'consumer');
-  mkdirSync(consumerFolder);
-  writeFileSync(
-    path.join(consumerFolder, 'package.json'),
-    JSON.stringify(
-      { name: 'xrpl-connect-publish-consumer', private: true, type: 'module' },
-      null,
-      2
-    )
-  );
+  const consumerFolder = path.join(temporaryRoot, 'consumer-react-18');
+  writeConsumerManifest(consumerFolder, 'xrpl-connect-publish-consumer-react-18');
 
   run(
     'npm',
@@ -314,10 +364,10 @@ try {
       '--no-audit',
       '--no-fund',
       '--package-lock=false',
-      ...resolveCandidateSpecs(documentedReactInstall, tarballsByName),
+      ...resolveReactCandidateSpecs(documentedReactInstall, tarballsByName, 18),
       tarballsByName.get('@xrpl-commons/xrpl-connect-vue'),
-      '@types/react@^18.3.0',
-      '@types/react-dom@^18.3.0',
+      '@types/react@18',
+      '@types/react-dom@18',
       'jsdom@^22.1.0',
       'nuxt@4.1.3',
       'rollup@4.62.2',
@@ -328,6 +378,7 @@ try {
     { ...runOptions, cwd: consumerFolder }
   );
   console.log('✓ Candidate install completed with strict peer dependency checks');
+  verifyInstalledReactMajor(consumerFolder, 18);
 
   const installedManifests = Object.fromEntries(
     candidatePackages.map(({ name }) => [
@@ -519,14 +570,7 @@ try {
   const nuxtAppFolder = path.join(consumerFolder, 'app');
   mkdirSync(nuxtAppFolder);
   copyFileSync(path.join(fixturesFolder, 'nuxt-app.vue'), path.join(nuxtAppFolder, 'app.vue'));
-  for (const fixture of [
-    'runtime-ssr.mjs',
-    'types-react-esm.mts',
-    'types-react-cjs.cts',
-    'tsconfig.react.json',
-  ]) {
-    copyFileSync(path.join(reactFixturesFolder, fixture), path.join(consumerFolder, fixture));
-  }
+  copyReactFixtures(consumerFolder);
   for (const fixture of ['types-vue-esm.mts', 'types-vue-cjs.cts', 'tsconfig.vue.json']) {
     copyFileSync(path.join(vueFixturesFolder, fixture), path.join(consumerFolder, fixture));
   }
@@ -546,11 +590,30 @@ try {
     ...runOptions,
     cwd: consumerFolder,
   });
-  console.log('→ Type-checking packed React ESM and CommonJS consumers');
-  run(process.execPath, [tscPath, '--project', 'tsconfig.react.json'], {
-    ...runOptions,
-    cwd: consumerFolder,
-  });
+  verifyPackedReactConsumer(consumerFolder, 18, tscPath, runOptions);
+
+  const react19ConsumerFolder = path.join(temporaryRoot, 'consumer-react-19');
+  writeConsumerManifest(react19ConsumerFolder, 'xrpl-connect-publish-consumer-react-19');
+  run(
+    'npm',
+    [
+      'install',
+      '--strict-peer-deps',
+      '--ignore-scripts',
+      '--no-audit',
+      '--no-fund',
+      '--package-lock=false',
+      ...resolveReactCandidateSpecs(documentedReactInstall, tarballsByName, 19),
+      '@types/react@19',
+      '@types/react-dom@19',
+      'jsdom@^22.1.0',
+    ],
+    { ...runOptions, cwd: react19ConsumerFolder }
+  );
+  verifyInstalledReactMajor(react19ConsumerFolder, 19);
+  copyReactFixtures(react19ConsumerFolder);
+  verifyPackedReactConsumer(react19ConsumerFolder, 19, tscPath, runOptions);
+
   console.log('→ Type-checking packed Vue ESM and CommonJS consumers');
   run(process.execPath, [tscPath, '--project', 'tsconfig.vue.json'], {
     ...runOptions,
@@ -564,8 +627,6 @@ try {
   run(process.execPath, ['runtime-esm.mjs'], { ...runOptions, cwd: consumerFolder });
   console.log('→ Loading packed CommonJS runtime');
   run(process.execPath, ['runtime-cjs.cjs'], { ...runOptions, cwd: consumerFolder });
-  console.log('→ Loading packed React ESM and CommonJS entries in SSR');
-  run(process.execPath, ['runtime-ssr.mjs'], { ...runOptions, cwd: consumerFolder });
   console.log('→ Loading packed Vue ESM and CommonJS entries in SSR');
   run(process.execPath, ['vue-runtime-ssr.mjs'], { ...runOptions, cwd: consumerFolder });
   console.log('→ Building packed umbrella ESM with Nuxt and Vite');

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,51 @@
+# Issue #170
+
+## Issue summary
+
+- The React package advertises React 18 and 19 peer compatibility, but its packed-consumer verification installs and exercises React 18 only.
+- Each supported major must use matching React, React DOM, and type-package versions while checking the complete public React surface.
+- Both versions must prove mounted custom-event/callback behavior plus ESM, CJS, and SSR-safe package imports.
+- Any genuine React 19 incompatibility must be fixed; otherwise the existing peer range remains justified by executable coverage.
+
+## Plan
+
+- [x] Validate GitHub access, refresh `origin/develop`, and confirm issue state, comments, linked PRs, and acceptance criteria.
+- [x] Create a clean isolated worktree from the refreshed default branch and review applicable repository guidance.
+- [x] Trace the current React publish fixture, public contract, mount/event behavior, import checks, and version assumptions.
+- [x] Design the smallest packed-consumer matrix with isolated React 18 and React 19 dependency sets.
+- [x] Implement type, mounted-runtime, ESM/CJS, and SSR verification for both supported majors.
+- [x] Run focused fail-before/proof checks, formatting, linting, builds, and repository-level verification.
+- [x] Review the final diff against every acceptance criterion and record results below.
+- [x] Commit only intentional files, push the branch, open the PR, and verify remote PR metadata/checks.
+
+## Review
+
+- The packed fixture previously used one uncontrolled runtime install with React 18 type packages, so it could not prove matching React 18/19 dependency sets; the global-only custom-element JSX declaration was also removed by the API Extractor rollup.
+- The publish test now creates isolated strict-peer React 18 and React 19 consumers, asserts matching `react`, `react-dom`, `@types/react`, and `@types/react-dom` majors, and preserves both `React.JSX` and React 18 global `JSX` augmentations in the published declarations.
+- Packed public-contract fixtures cover hooks, provider, wrapper callback inference, custom JSX attributes, and a typed custom-element ref; runtime fixtures cover ESM, CommonJS, SSR-safe loading, a real DOM mount, normalized custom events, callbacks, and manager-driven connection state in both majors.
+- A React 19 packed-consumer fail-before check produced `TS2339` for the missing `xrpl-wallet-connector` intrinsic; the new fixture passes with the generated declaration.
+- `pnpm --filter @xrpl-commons/xrpl-connect-react type-check`, `pnpm --filter @xrpl-commons/xrpl-connect-react test:types`, the React test suite, `pnpm exec vp check`, `pnpm test`, two exact-head `pnpm --filter xrpl-connect test:publish` runs, and `git diff --check` pass.
+- Independent review found two declaration defects after PR #175 merged: the branch dropped React 18's global `JSX` augmentation and replaced the supported `show-unavailable` attribute with inert `background-color`. Both are resolved below.
+
+## Fix PR #177 review findings
+
+- [x] Rebase the PR branch onto current `origin/develop` and resolve overlapping PR #175 changes without regressing its public contract.
+- [x] Preserve both `React.JSX` and React 18 global `JSX` custom-element augmentation in source and packed declarations.
+- [x] Keep the intrinsic attribute contract aligned with the runtime: support `show-unavailable` and reject inert `background-color`.
+- [x] Extend the React 18/19 packed fixtures to prove the merged declaration and attribute contract.
+- [x] Run focused React checks, the full packed publish matrix, repository checks, and `git diff --check`.
+- [x] Review the final diff, commit, push with lease protection, and verify PR head and CI state.
+
+### Fix review
+
+- The branch is rebased onto `develop` at `36edb79`; the conflict resolution preserves PR #175's unavailable-wallet contract, PR #176's forwarded wrapper ref/host attributes, and the dual `React.JSX` / React 18 global `JSX` augmentation.
+- `WalletConnectorIntrinsicProps` now targets `WalletConnectorElement`, so object refs expose the connector methods while refs to unrelated hosts are rejected in both React majors.
+- The isolated packed-consumer matrix verifies matching React/React DOM/runtime type-package majors, ESM, CommonJS, JSX, SSR, mounted callbacks, and the exact raw-element attribute/ref contract for React 18 and 19.
+- The React build, source and packed type checks, SSR smoke, all 33 React tests, `pnpm exec vp check`, `pnpm test`, `pnpm --filter xrpl-connect test:publish`, and `git diff --check` pass after the final rebase over PR #176.
+- Independent final declaration review found no remaining actionable findings.
+
+---
+
 # Issue #172
 
 ## Issue summary


### PR DESCRIPTION
## Summary

- verify the packed React package with isolated, matching React 18 and React 19 runtime and type dependencies
- publish the React.JSX custom-element and typed-ref declarations, then exercise ESM, CommonJS, SSR, and mounted callbacks in both versions

## Test plan

- [x] `pnpm --filter @xrpl-commons/xrpl-connect-react type-check`
- [x] `pnpm --filter @xrpl-commons/xrpl-connect-react test:types`
- [x] `pnpm --filter @xrpl-commons/xrpl-connect-react test`
- [x] `pnpm --filter xrpl-connect test:publish`
- [x] `pnpm exec vp check`
- [x] `pnpm test`
- [x] `git diff --check`

Fixes #170
