### PR TITLE
fix: eliminate wallet connector DOM XSS sinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- UI: render adapter- and provider-controlled wallet metadata, errors, accounts, and QR images through safe DOM APIs with validated image and deep-link URL schemes, eliminating connector DOM XSS sinks (#178).
 - React: ship the custom-element JSX and typed-ref declaration in the packed package, and verify the advertised React 18 and 19 runtime/type compatibility in isolated consumers (#170).
 - Documentation: pin current install commands to `xrpl@^4` so registry-latest v5 cannot drift outside the supported v3/v4 peer range; packed-consumer verification now executes the literal React dependency specifications and rejects stale install examples (#169).
 - xrpl-connect (meta-bundle): emit the Xaman mock-WebSocket constructor without an optional chain so Nuxt 4 and Vite/Rollup production builds can consume the published ESM artifact. Consumers can remove `patch-package` or transpilation workarounds for `xrpl-connect.mjs` (#141).

--- a/packages/ui/src/security.ts
+++ b/packages/ui/src/security.ts
@@ -1,0 +1,53 @@
+const EXECUTABLE_URL_PROTOCOLS = new Set(['blob:', 'data:', 'file:', 'javascript:', 'vbscript:']);
+const SAFE_DATA_IMAGE_TYPES = new Set([
+  'image/avif',
+  'image/gif',
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/svg+xml',
+  'image/webp',
+]);
+
+/** Return a non-executable absolute URL, including wallet-specific deep-link schemes. */
+export function getSafeDeepLinkUrl(value: string | undefined): string | null {
+  if (!value) return null;
+
+  try {
+    const url = new URL(value);
+    return EXECUTABLE_URL_PROTOCOLS.has(url.protocol) ? null : value;
+  } catch {
+    return null;
+  }
+}
+
+/** Return a safe HTTP(S) or image data URL for an image source. */
+export function getSafeImageUrl(value: string | undefined): string | null {
+  if (!value) return null;
+
+  if (value.slice(0, 5).toLowerCase() === 'data:') {
+    const separator = value.indexOf(',');
+    if (separator === -1) return null;
+
+    const [mediaType, ...parameters] = value
+      .slice(5, separator)
+      .split(';')
+      .map((part) => part.trim().toLowerCase());
+    if (!mediaType || !SAFE_DATA_IMAGE_TYPES.has(mediaType)) return null;
+    if (
+      parameters.some(
+        (parameter) => parameter !== 'base64' && !/^charset=[a-z0-9._-]+$/.test(parameter)
+      )
+    ) {
+      return null;
+    }
+    return value;
+  }
+
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/ui/src/services/EventHandler.ts
+++ b/packages/ui/src/services/EventHandler.ts
@@ -2,6 +2,7 @@ import { WalletService } from './WalletService';
 import { TIMINGS } from '../constants';
 import { createLogger, supportsDeepLink } from '@xrpl-connect/core';
 import type { WalletConnectorContext } from '../types';
+import { getSafeDeepLinkUrl } from '../security';
 import { getSafeExternalUrl, isMobile } from '../utils';
 
 const logger = createLogger('[EventHandler]');
@@ -89,10 +90,12 @@ export class EventHandler {
             '#copy-account-address'
           ) as HTMLButtonElement | null;
           if (!btn) return;
-          const originalHTML = btn.innerHTML;
-          btn.innerHTML = '<span>Copied!</span>';
+          const originalChildren = [...btn.childNodes];
+          const feedback = document.createElement('span');
+          feedback.textContent = 'Copied!';
+          btn.replaceChildren(feedback);
           setTimeout(() => {
-            if (btn) btn.innerHTML = originalHTML;
+            btn.replaceChildren(...originalChildren);
           }, TIMINGS.COPY_FEEDBACK_DURATION);
         } catch (error) {
           logger.error('Failed to copy address:', error);
@@ -171,12 +174,15 @@ export class EventHandler {
           deepLink = adapter.getDeepLinkURI(qrCodeData.uri);
         }
 
+        const safeDeepLink = getSafeDeepLinkUrl(deepLink);
+        if (!safeDeepLink) return;
+
         // Detect mobile and open deep link
         if (isMobile()) {
-          window.location.href = deepLink;
+          window.location.href = safeDeepLink;
         } else {
           // On desktop, still try to open (might open desktop app if installed)
-          window.open(deepLink, '_blank');
+          window.open(safeDeepLink, '_blank', 'noopener,noreferrer');
         }
       }
     });

--- a/packages/ui/src/services/EventHandler.ts
+++ b/packages/ui/src/services/EventHandler.ts
@@ -4,6 +4,7 @@ import { createLogger, supportsDeepLink } from '@xrpl-connect/core';
 import type { WalletConnectorContext } from '../types';
 import { getSafeDeepLinkUrl } from '../security';
 import { getSafeExternalUrl, isMobile } from '../utils';
+import { replaceViewChildren } from '../views/dom';
 
 const logger = createLogger('[EventHandler]');
 
@@ -93,9 +94,9 @@ export class EventHandler {
           const originalChildren = [...btn.childNodes];
           const feedback = document.createElement('span');
           feedback.textContent = 'Copied!';
-          btn.replaceChildren(feedback);
+          replaceViewChildren(btn, feedback);
           setTimeout(() => {
-            btn.replaceChildren(...originalChildren);
+            replaceViewChildren(btn, ...originalChildren);
           }, TIMINGS.COPY_FEEDBACK_DURATION);
         } catch (error) {
           logger.error('Failed to copy address:', error);

--- a/packages/ui/src/utils.ts
+++ b/packages/ui/src/utils.ts
@@ -3,6 +3,7 @@
  */
 
 import { LUMINANCE, COLOR_ADJUSTMENT, BROWSER_PATTERNS } from './constants';
+import { getSafeImageUrl } from './security';
 
 /**
  * Re-export the shared mobile/tablet detection (incl. iPadOS desktop-mode, #16)
@@ -86,7 +87,16 @@ export function isSafari(): boolean {
  * @returns true if Xaman QR code image URL
  */
 export function isXamanQRImage(uri: string): boolean {
-  return uri.includes('xumm.app/sign') && uri.includes('.png');
+  const safeUri = getSafeImageUrl(uri);
+  if (!safeUri || safeUri.startsWith('data:')) return false;
+
+  const url = new URL(safeUri);
+  return (
+    url.protocol === 'https:' &&
+    url.hostname === 'xumm.app' &&
+    url.pathname.startsWith('/sign/') &&
+    url.pathname.endsWith('.png')
+  );
 }
 
 /**

--- a/packages/ui/src/views/AccountModal.ts
+++ b/packages/ui/src/views/AccountModal.ts
@@ -1,25 +1,20 @@
 import { WALLET_CONNECTOR_PARTS } from '../customization';
+import { createStaticView, getViewElement } from './dom';
 
 export function renderAccountModal(
   account: { address: string } | null,
   accountBalance: string | null,
   truncateAddress: (address: string, chars?: number) => string,
   generateGradientFromAddress: (address: string) => { color1: string; color2: string }
-): string {
-  if (!account) return '';
+): DocumentFragment {
+  if (!account) return document.createDocumentFragment();
 
   const truncatedAddress = truncateAddress(account.address, 6);
   const { color1, color2 } = generateGradientFromAddress(account.address);
-
-  return `
-      <div
-        id="account-modal-overlay"
-        class="account-modal-overlay"
-        part="${WALLET_CONNECTOR_PARTS.accountModal.overlay}"
-      >
+  const view = createStaticView`
+      <div id="account-modal-overlay" class="account-modal-overlay">
         <div
           class="account-modal"
-          part="${WALLET_CONNECTOR_PARTS.accountModal.modal}"
           role="dialog"
           aria-modal="true"
           aria-labelledby="account-dialog-title"
@@ -30,23 +25,20 @@ export function renderAccountModal(
             <button
               class="account-modal-close"
               id="account-modal-close"
-              part="${WALLET_CONNECTOR_PARTS.accountModal.closeButton}"
               aria-label="Close"
             >×</button>
           </div>
 
           <div class="account-modal-content">
-            <div class="account-avatar-container" style="background: linear-gradient(135deg, ${color1}, ${color2});">
-            </div>
+            <div class="account-avatar-container"></div>
 
             <div class="account-info-section">
               <button
                 class="account-address-button"
                 id="copy-account-address"
-                part="${WALLET_CONNECTOR_PARTS.accountModal.addressButton}"
                 title="Click to copy full address"
               >
-                <span>${truncatedAddress}</span>
+                <span class="account-address-text"></span>
                 <svg
                   aria-hidden="true"
                   width="20"
@@ -60,23 +52,11 @@ export function renderAccountModal(
                   <rect x="10" y="10" width="9" height="9" rx="2" stroke="currentColor" stroke-width="2"></rect>
                 </svg>
               </button>
-
-              ${
-                accountBalance
-                  ? `
-                <div class="account-balance-display">
-                  <span class="account-balance-value">${accountBalance}</span>
-                  <span class="account-balance-unit">XRP</span>
-                </div>
-              `
-                  : ''
-              }
             </div>
 
             <button
               class="account-disconnect-button"
               id="account-modal-disconnect"
-              part="${WALLET_CONNECTOR_PARTS.accountModal.disconnectButton}"
             >
               <svg
                 aria-hidden="true"
@@ -101,4 +81,43 @@ export function renderAccountModal(
         </div>
       </div>
     `;
+
+  getViewElement(view, '.account-modal-overlay').setAttribute(
+    'part',
+    WALLET_CONNECTOR_PARTS.accountModal.overlay
+  );
+  getViewElement(view, '.account-modal').setAttribute(
+    'part',
+    WALLET_CONNECTOR_PARTS.accountModal.modal
+  );
+  getViewElement(view, '.account-modal-close').setAttribute(
+    'part',
+    WALLET_CONNECTOR_PARTS.accountModal.closeButton
+  );
+  getViewElement(view, '.account-address-button').setAttribute(
+    'part',
+    WALLET_CONNECTOR_PARTS.accountModal.addressButton
+  );
+  getViewElement(view, '.account-disconnect-button').setAttribute(
+    'part',
+    WALLET_CONNECTOR_PARTS.accountModal.disconnectButton
+  );
+  getViewElement<HTMLElement>(view, '.account-avatar-container').style.background =
+    `linear-gradient(135deg, ${color1}, ${color2})`;
+  getViewElement(view, '.account-address-text').textContent = truncatedAddress;
+
+  if (accountBalance) {
+    const balanceDisplay = document.createElement('div');
+    balanceDisplay.className = 'account-balance-display';
+    const balance = document.createElement('span');
+    balance.className = 'account-balance-value';
+    balance.textContent = accountBalance;
+    const unit = document.createElement('span');
+    unit.className = 'account-balance-unit';
+    unit.textContent = 'XRP';
+    balanceDisplay.append(balance, unit);
+    getViewElement(view, '.account-info-section').append(balanceDisplay);
+  }
+
+  return view;
 }

--- a/packages/ui/src/views/AccountSelectionView.ts
+++ b/packages/ui/src/views/AccountSelectionView.ts
@@ -1,47 +1,25 @@
 import { WALLET_CONNECTOR_PARTS } from '../customization';
+import { createStaticView, createWalletImage, getViewElement } from './dom';
 
 export function renderAccountSelectionView(
   walletName: string,
   walletIcon: string | undefined,
   accounts: Array<{ address: string; publicKey: string; path: string; index: number }>
-): string {
-  const accountButtons = accounts
-    .map(
-      (account) => `
-        <button class="account-button" data-account-index="${account.index}">
-          <div class="account-info">
-            <div class="account-address">Account ${account.index}</div>
-            <div class="account-address-value">${account.address}</div>
-          </div>
-        </button>
-      `
-    )
-    .join('');
-
-  return `
+): DocumentFragment {
+  const view = createStaticView`
       <div class="header">
         <div class="header-with-back">
           <button class="back-button" id="account-selection-back-button" aria-label="Back">←</button>
           <h2 class="title" id="wallet-dialog-title">Select Account</h2>
         </div>
-        <button class="close-button" part="${WALLET_CONNECTOR_PARTS.walletModal.closeButton}" aria-label="Close">×</button>
+        <button class="close-button" aria-label="Close">×</button>
       </div>
 
       <div class="content">
         <div class="account-selection-view">
-          ${
-            walletIcon
-              ? `
-          <div class="account-selection-wallet-icon">
-            <img src="${walletIcon}" alt="${walletName}" class="wallet-icon-small">
-          </div>
-          `
-              : ''
-          }
-          <p class="account-selection-description">Select which account to connect from your ${walletName}</p>
-          <div class="account-list">
-            ${accountButtons}
-          </div>
+          <div class="account-selection-wallet-icon"></div>
+          <p class="account-selection-description"></p>
+          <div class="account-list"></div>
           <div class="custom-path-section">
             <p class="custom-path-label">Or enter a custom derivation path:</p>
             <input
@@ -58,4 +36,41 @@ export function renderAccountSelectionView(
         </div>
       </div>
     `;
+  getViewElement(view, '.close-button').setAttribute(
+    'part',
+    WALLET_CONNECTOR_PARTS.walletModal.closeButton
+  );
+
+  const iconContainer = getViewElement(view, '.account-selection-wallet-icon');
+  const image = createWalletImage(walletIcon, walletName, { className: 'wallet-icon-small' });
+  if (image) {
+    iconContainer.append(image);
+  } else {
+    iconContainer.remove();
+  }
+
+  getViewElement(view, '.account-selection-description').append(
+    'Select which account to connect from your ',
+    walletName
+  );
+  const accountList = getViewElement(view, '.account-list');
+  for (const account of accounts) {
+    const button = document.createElement('button');
+    button.className = 'account-button';
+    button.dataset.accountIndex = String(account.index);
+
+    const information = document.createElement('div');
+    information.className = 'account-info';
+    const accountLabel = document.createElement('div');
+    accountLabel.className = 'account-address';
+    accountLabel.append('Account ', String(account.index));
+    const address = document.createElement('div');
+    address.className = 'account-address-value';
+    address.textContent = account.address;
+    information.append(accountLabel, address);
+    button.append(information);
+    accountList.append(button);
+  }
+
+  return view;
 }

--- a/packages/ui/src/views/ErrorView.ts
+++ b/packages/ui/src/views/ErrorView.ts
@@ -1,18 +1,19 @@
 import { WALLET_CONNECTOR_PARTS } from '../customization';
+import { createStaticView, getViewElement } from './dom';
 
-export function renderErrorView(walletName: string, error: Error): string {
-  return `
+export function renderErrorView(walletName: string, error: Error): DocumentFragment {
+  const view = createStaticView`
       <div class="header">
         <h2 class="title" id="wallet-dialog-title">Connection Failed</h2>
-        <button class="close-button" part="${WALLET_CONNECTOR_PARTS.walletModal.closeButton}" aria-label="Close">×</button>
+        <button class="close-button" aria-label="Close">×</button>
       </div>
 
       <div class="content">
         <div class="error-view">
           <div class="error-icon">⚠</div>
           <div class="error-text">
-            <div class="error-title">Failed to connect to ${walletName}</div>
-            <div class="error-message">${error.message}</div>
+            <div class="error-title"></div>
+            <div class="error-message"></div>
           </div>
           <div class="error-buttons">
             <button class="error-button error-button-secondary" id="error-back-button">
@@ -25,4 +26,11 @@ export function renderErrorView(walletName: string, error: Error): string {
         </div>
       </div>
     `;
+  getViewElement(view, '.close-button').setAttribute(
+    'part',
+    WALLET_CONNECTOR_PARTS.walletModal.closeButton
+  );
+  getViewElement(view, '.error-title').append('Failed to connect to ', walletName);
+  getViewElement(view, '.error-message').textContent = error.message;
+  return view;
 }

--- a/packages/ui/src/views/LoadingView.ts
+++ b/packages/ui/src/views/LoadingView.ts
@@ -1,26 +1,34 @@
 import { WALLET_CONNECTOR_PARTS } from '../customization';
+import { createStaticView, createWalletImage, getViewElement } from './dom';
 
-export function renderLoadingView(walletName: string, walletIcon?: string): string {
-  return `
+export function renderLoadingView(walletName: string, walletIcon?: string): DocumentFragment {
+  const view = createStaticView`
       <div class="header">
         <div class="header-with-back">
           <button class="back-button" id="loading-back-button" aria-label="Back">←</button>
           <h2 class="title" id="wallet-dialog-title">Connect Wallet</h2>
         </div>
-        <button class="close-button" part="${WALLET_CONNECTOR_PARTS.walletModal.closeButton}" aria-label="Close">×</button>
+        <button class="close-button" aria-label="Close">×</button>
       </div>
 
       <div class="content loading-content">
         <div class="loading-view">
           <div class="loading-logo-container">
-            ${walletIcon ? `<img src="${walletIcon}" alt="${walletName}" class="loading-logo">` : ''}
             <div class="loading-border"></div>
           </div>
           <div class="loading-text">
             <p>Requesting connection...</p>
-            <p style="margin-top: 8px; font-size: 14px; opacity: 0.7;">Check your ${walletName}</p>
+            <p class="loading-wallet-message" style="margin-top: 8px; font-size: 14px; opacity: 0.7;"></p>
           </div>
         </div>
       </div>
     `;
+  getViewElement(view, '.close-button').setAttribute(
+    'part',
+    WALLET_CONNECTOR_PARTS.walletModal.closeButton
+  );
+  const image = createWalletImage(walletIcon, walletName, { className: 'loading-logo' });
+  if (image) getViewElement(view, '.loading-logo-container').prepend(image);
+  getViewElement(view, '.loading-wallet-message').append('Check your ', walletName);
+  return view;
 }

--- a/packages/ui/src/views/QRView.ts
+++ b/packages/ui/src/views/QRView.ts
@@ -1,13 +1,14 @@
 import { WALLET_CONNECTOR_PARTS } from '../customization';
+import { createStaticView, getViewElement } from './dom';
 
-export function renderQRView(walletName: string): string {
-  return `
+export function renderQRView(walletName: string): DocumentFragment {
+  const view = createStaticView`
     <div class="header">
       <div class="header-with-back">
         <button class="back-button" id="back-button" aria-label="Back">←</button>
-        <h2 class="title" id="wallet-dialog-title">${walletName}</h2>
+        <h2 class="title" id="wallet-dialog-title"></h2>
       </div>
-      <button class="close-button" part="${WALLET_CONNECTOR_PARTS.walletModal.closeButton}" aria-label="Close">×</button>
+      <button class="close-button" aria-label="Close">×</button>
     </div>
 
     <div class="content">
@@ -24,4 +25,10 @@ export function renderQRView(walletName: string): string {
       </div>
     </div>
   `;
+  getViewElement(view, '.close-button').setAttribute(
+    'part',
+    WALLET_CONNECTOR_PARTS.walletModal.closeButton
+  );
+  getViewElement(view, '.title').textContent = walletName;
+  return view;
 }

--- a/packages/ui/src/views/WalletListView.ts
+++ b/packages/ui/src/views/WalletListView.ts
@@ -1,67 +1,90 @@
 import type { WalletAdapter } from '@xrpl-connect/core';
 import { WALLET_CONNECTOR_PARTS } from '../customization';
 import { getSafeExternalUrl } from '../utils';
+import { createStaticView, createWalletImage, getViewElement } from './dom';
 
-function escapeHtmlAttribute(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
+function createWalletButton(wallet: WalletAdapter, primary: boolean): HTMLButtonElement {
+  const button = document.createElement('button');
+  button.className = primary ? 'primary-button' : 'wallet-button';
+  button.dataset.walletId = wallet.id;
+
+  const label = document.createElement('span');
+  label.append(primary ? 'Continue with ' : '', wallet.name);
+  button.append(label);
+
+  const image = createWalletImage(wallet.icon, wallet.name, {
+    width: primary ? 24 : 28,
+    height: primary ? 24 : 28,
+  });
+  if (image) {
+    if (primary) button.prepend(image);
+    else button.append(image);
+  }
+  return button;
+}
+
+function createUnavailableWalletButton(wallet: WalletAdapter): HTMLButtonElement {
+  const installUrl = getSafeExternalUrl(wallet.url);
+  const label = installUrl ? 'Install' : 'Unavailable';
+  const button = document.createElement('button');
+  button.className = 'wallet-button wallet-button--unavailable';
+  button.setAttribute('aria-label', `${label} ${wallet.name}`);
+  if (installUrl) {
+    button.dataset.installUrl = installUrl;
+  } else {
+    button.disabled = true;
+    button.setAttribute('aria-disabled', 'true');
+  }
+
+  const name = document.createElement('span');
+  name.textContent = wallet.name;
+  const installLabel = document.createElement('span');
+  installLabel.className = 'wallet-install-label';
+  installLabel.textContent = label;
+  button.append(name, installLabel);
+
+  const image = createWalletImage(wallet.icon, wallet.name, { width: 28, height: 28 });
+  if (image) button.append(image);
+  return button;
 }
 
 export function renderWalletListView(
   primaryWallet: WalletAdapter | null,
   otherWallets: WalletAdapter[],
   unavailableWalletIds: ReadonlySet<string> = new Set()
-): string {
-  return `
+): DocumentFragment {
+  const view = createStaticView`
       <div class="header">
         <h2 class="title" id="wallet-dialog-title">Connect Wallet</h2>
-        <button class="close-button" part="${WALLET_CONNECTOR_PARTS.walletModal.closeButton}" aria-label="Close">×</button>
+        <button class="close-button" aria-label="Close">×</button>
       </div>
 
       <div class="content" role="region" aria-label="Wallet options" tabindex="0">
-        ${
-          primaryWallet
-            ? `
-          <button class="primary-button" data-wallet-id="${primaryWallet.id}">
-            ${primaryWallet.icon ? `<img src="${primaryWallet.icon}" width="24" height="24" alt="${primaryWallet.name}">` : ''}
-            <span>Continue with ${primaryWallet.name}</span>
-          </button>
-        `
-            : ''
-        }
-        <div class="wallet-list">
-          ${
-            !primaryWallet && otherWallets.length === 0
-              ? '<p class="wallet-empty">No wallets are currently available.</p>'
-              : otherWallets
-                  .map((wallet) => {
-                    if (unavailableWalletIds.has(wallet.id)) {
-                      const installUrl = getSafeExternalUrl(wallet.url);
-                      const installAttribute = installUrl
-                        ? `data-install-url="${escapeHtmlAttribute(installUrl)}"`
-                        : 'disabled aria-disabled="true"';
-                      const label = installUrl ? 'Install' : 'Unavailable';
-                      return `
-            <button class="wallet-button wallet-button--unavailable" ${installAttribute} aria-label="${label} ${wallet.name}">
-              <span>${wallet.name}</span>
-              <span class="wallet-install-label">${label}</span>
-              ${wallet.icon ? `<img src="${wallet.icon}" width="28" height="28" alt="${wallet.name}">` : ''}
-            </button>`;
-                    }
-
-                    return `
-            <button class="wallet-button" data-wallet-id="${wallet.id}">
-              <span>${wallet.name}</span>
-              ${wallet.icon ? `<img src="${wallet.icon}" width="28" height="28" alt="${wallet.name}">` : ''}
-            </button>`;
-                  })
-                  .join('')
-          }
-        </div>
+        <div class="wallet-list"></div>
       </div>
     `;
+  getViewElement(view, '.close-button').setAttribute(
+    'part',
+    WALLET_CONNECTOR_PARTS.walletModal.closeButton
+  );
+  const content = getViewElement(view, '.content');
+  const walletList = getViewElement(view, '.wallet-list');
+
+  if (primaryWallet) content.prepend(createWalletButton(primaryWallet, true));
+  if (!primaryWallet && otherWallets.length === 0) {
+    const emptyMessage = document.createElement('p');
+    emptyMessage.className = 'wallet-empty';
+    emptyMessage.textContent = 'No wallets are currently available.';
+    walletList.append(emptyMessage);
+  } else {
+    for (const wallet of otherWallets) {
+      walletList.append(
+        unavailableWalletIds.has(wallet.id)
+          ? createUnavailableWalletButton(wallet)
+          : createWalletButton(wallet, false)
+      );
+    }
+  }
+
+  return view;
 }

--- a/packages/ui/src/views/dom.ts
+++ b/packages/ui/src/views/dom.ts
@@ -14,6 +14,12 @@ export function getViewElement<T extends Element>(root: ParentNode, selector: st
   return element;
 }
 
+/** Replace child nodes using DOM methods supported by every advertised browser. */
+export function replaceViewChildren(parent: Node, ...children: Node[]): void {
+  while (parent.firstChild) parent.removeChild(parent.firstChild);
+  for (const child of children) parent.appendChild(child);
+}
+
 export function createWalletImage(
   source: string | undefined,
   alternativeText: string,

--- a/packages/ui/src/views/dom.ts
+++ b/packages/ui/src/views/dom.ts
@@ -1,0 +1,32 @@
+import { getSafeImageUrl } from '../security';
+
+/** Parse source-controlled markup that contains no runtime values. */
+export function createStaticView(markup: TemplateStringsArray): DocumentFragment {
+  if (markup.length !== 1) throw new Error('Static view templates cannot contain substitutions.');
+  const template = document.createElement('template');
+  template.innerHTML = markup[0];
+  return template.content;
+}
+
+export function getViewElement<T extends Element>(root: ParentNode, selector: string): T {
+  const element = root.querySelector<T>(selector);
+  if (!element) throw new Error(`View template is missing required element: ${selector}`);
+  return element;
+}
+
+export function createWalletImage(
+  source: string | undefined,
+  alternativeText: string,
+  options: { className?: string; width?: number; height?: number } = {}
+): HTMLImageElement | null {
+  const safeSource = getSafeImageUrl(source);
+  if (!safeSource) return null;
+
+  const image = document.createElement('img');
+  image.src = safeSource;
+  image.alt = alternativeText;
+  if (options.className) image.className = options.className;
+  if (options.width !== undefined) image.width = options.width;
+  if (options.height !== undefined) image.height = options.height;
+  return image;
+}

--- a/packages/ui/src/wallet-connector.ts
+++ b/packages/ui/src/wallet-connector.ts
@@ -18,6 +18,7 @@ import {
   WALLET_CONNECTOR_PORTAL_ATTRIBUTES,
 } from './customization';
 import { mainStyles } from './styles/main';
+import { getSafeImageUrl } from './security';
 import {
   SIZES,
   TIMINGS,
@@ -52,6 +53,12 @@ import { isXamanQRImage, adjustColorBrightness, orderWalletsByMru } from './util
  */
 const logger = createLogger('[WalletConnector]');
 const AVAILABILITY_TIMED_OUT = Symbol('availability-timed-out');
+
+function createMainStyleElement(): HTMLStyleElement {
+  const style = document.createElement('style');
+  style.textContent = mainStyles;
+  return style;
+}
 
 /** Public API exposed by the `<xrpl-wallet-connector>` custom element. */
 export interface WalletConnectorElementInstance extends HTMLElement {
@@ -794,7 +801,7 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
           height: QR_CONFIG.SIZE,
           type: 'svg',
           data: uri,
-          image: wallet?.icon,
+          image: getSafeImageUrl(wallet?.icon) ?? undefined,
           margin: QR_CONFIG.MARGIN,
           qrOptions: {
             errorCorrectionLevel: QR_CONFIG.ERROR_CORRECTION_LEVEL,
@@ -945,20 +952,21 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
         // Check if URI is already a QR code image URL (Xaman provides PNG directly)
         if (isXamanQRImage(uri)) {
           logger.debug('Using direct QR code image from Xaman');
-          container.innerHTML = `
-          <img
-            src="${uri}"
-            alt="QR Code"
-            style="width: ${SIZES.QR_CODE}px; height: ${SIZES.QR_CODE}px; border-radius: ${SIZES.QR_IMAGE_BORDER_RADIUS}px; display: block;"
-          />
-        `;
+          const image = document.createElement('img');
+          image.src = getSafeImageUrl(uri)!;
+          image.alt = 'QR Code';
+          image.style.width = `${SIZES.QR_CODE}px`;
+          image.style.height = `${SIZES.QR_CODE}px`;
+          image.style.borderRadius = `${SIZES.QR_IMAGE_BORDER_RADIUS}px`;
+          image.style.display = 'block';
+          container.replaceChildren(image);
           return;
         }
 
         // Check if we have a pre-generated QR code with matching URI
         if (this.preGeneratedQRCode && this.preGeneratedURI === uri) {
           logger.debug('Using pre-generated QR code - instant render!');
-          container.innerHTML = '';
+          container.replaceChildren();
           this.preGeneratedQRCode.append(container as HTMLElement);
           return;
         }
@@ -972,7 +980,7 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
           height: QR_CONFIG.SIZE,
           type: 'svg',
           data: uri,
-          image: wallet?.icon,
+          image: getSafeImageUrl(wallet?.icon) ?? undefined,
           margin: QR_CONFIG.MARGIN,
           qrOptions: {
             errorCorrectionLevel: QR_CONFIG.ERROR_CORRECTION_LEVEL,
@@ -992,16 +1000,16 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
         });
 
         // Clear container and append QR code
-        container.innerHTML = '';
+        container.replaceChildren();
         qrCode.append(container as HTMLElement);
         logger.debug('Modern QR code generated successfully');
       } catch (error) {
         logger.error('Failed to generate QR code:', error);
-        container.innerHTML = `
-        <div class="qr-loading" style="color: ${DEFAULT_THEME.DANGER_COLOR};">
-          Failed to generate QR code
-        </div>
-      `;
+        const message = document.createElement('div');
+        message.className = 'qr-loading';
+        message.style.color = DEFAULT_THEME.DANGER_COLOR;
+        message.textContent = 'Failed to generate QR code';
+        container.replaceChildren(message);
       }
     }
 
@@ -1091,23 +1099,23 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
       );
 
       // Render based on view state
-      let contentHTML = '';
+      let content: DocumentFragment;
       if (this.viewState === 'qr' && this.qrCodeData) {
         const wallet = this.walletManager?.wallets.find((w) => w.id === this.qrCodeData?.walletId);
         const walletName = wallet?.name || 'Wallet';
-        contentHTML = renderQRView(walletName);
+        content = renderQRView(walletName);
       } else if (this.viewState === 'loading' && this.loadingData) {
-        contentHTML = renderLoadingView(this.loadingData.walletName, this.loadingData.walletIcon);
+        content = renderLoadingView(this.loadingData.walletName, this.loadingData.walletIcon);
       } else if (this.viewState === 'error' && this.errorData) {
-        contentHTML = renderErrorView(this.errorData.walletName, this.errorData.error);
+        content = renderErrorView(this.errorData.walletName, this.errorData.error);
       } else if (this.viewState === 'account-selection' && this.accountSelectionData) {
-        contentHTML = renderAccountSelectionView(
+        content = renderAccountSelectionView(
           this.accountSelectionData.walletName,
           this.accountSelectionData.walletIcon,
           this.accountSelectionData.accounts
         );
       } else {
-        contentHTML = renderWalletListView(primaryWallet, otherWallets, unavailableWalletIds);
+        content = renderWalletListView(primaryWallet, otherWallets, unavailableWalletIds);
       }
 
       const overlayClass = this.isFirstOpen ? 'overlay fade-in' : 'overlay';
@@ -1119,50 +1127,46 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
       }
 
       // Connect button stays in the component's own shadow root
-      this.shadow.innerHTML = `
-    <style>
-      ${mainStyles}
-    </style>
-    <button class="connect-button" id="connect-wallet-button" part="${WALLET_CONNECTOR_PARTS.connector.connectButton}">${buttonText}</button>
-  `;
+      const connectButton = document.createElement('button');
+      connectButton.className = 'connect-button';
+      connectButton.id = 'connect-wallet-button';
+      connectButton.setAttribute('part', WALLET_CONNECTOR_PARTS.connector.connectButton);
+      connectButton.textContent = buttonText;
+      this.shadow.replaceChildren(createMainStyleElement(), connectButton);
 
       // Wallet connection overlay — rendered in a portal on document.body to guarantee
       // position: fixed is always relative to the viewport (not a transformed ancestor)
       if (this.isOpen) {
         const overlayRoot = this.ensureOverlayPortal();
-        overlayRoot.innerHTML = `
-    <style>${mainStyles}</style>
-    <div class="${overlayClass}" part="${WALLET_CONNECTOR_PARTS.walletModal.overlay}">
-      <div
-        class="${modalClass}"
-        part="${WALLET_CONNECTOR_PARTS.walletModal.modal}"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="wallet-dialog-title"
-        tabindex="-1"
-      >
-        ${contentHTML}
-      </div>
-    </div>
-  `;
+        const overlay = document.createElement('div');
+        overlay.className = overlayClass;
+        overlay.setAttribute('part', WALLET_CONNECTOR_PARTS.walletModal.overlay);
+        const modal = document.createElement('div');
+        modal.className = modalClass;
+        modal.setAttribute('part', WALLET_CONNECTOR_PARTS.walletModal.modal);
+        modal.setAttribute('role', 'dialog');
+        modal.setAttribute('aria-modal', 'true');
+        modal.setAttribute('aria-labelledby', 'wallet-dialog-title');
+        modal.tabIndex = -1;
+        modal.append(content);
+        overlay.append(modal);
+        overlayRoot.replaceChildren(createMainStyleElement(), overlay);
       } else if (this.overlayPortal) {
-        this.overlayPortal.shadowRoot!.innerHTML = '';
+        this.overlayPortal.shadowRoot!.replaceChildren();
       }
 
       // Account modal — same portal approach
       if (this.accountModalOpen) {
         const accountRoot = this.ensureAccountModalPortal();
-        accountRoot.innerHTML = `
-    <style>${mainStyles}</style>
-    ${renderAccountModal(
-      this.walletManager?.account ?? null,
-      this.accountBalance,
-      this.truncateAddress.bind(this),
-      this.generateGradientFromAddress.bind(this)
-    )}
-  `;
+        const accountModal = renderAccountModal(
+          this.walletManager?.account ?? null,
+          this.accountBalance,
+          this.truncateAddress.bind(this),
+          this.generateGradientFromAddress.bind(this)
+        );
+        accountRoot.replaceChildren(createMainStyleElement(), accountModal);
       } else if (this.accountModalPortal) {
-        this.accountModalPortal.shadowRoot!.innerHTML = '';
+        this.accountModalPortal.shadowRoot!.replaceChildren();
       }
 
       this.eventHandler?.attachEventListeners();

--- a/packages/ui/src/wallet-connector.ts
+++ b/packages/ui/src/wallet-connector.ts
@@ -36,6 +36,7 @@ import {
   renderAccountSelectionView,
   renderAccountModal,
 } from './views';
+import { replaceViewChildren } from './views/dom';
 import { WalletService, EventHandler } from './services';
 import {
   isXamanStateAdapter,
@@ -959,14 +960,14 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
           image.style.height = `${SIZES.QR_CODE}px`;
           image.style.borderRadius = `${SIZES.QR_IMAGE_BORDER_RADIUS}px`;
           image.style.display = 'block';
-          container.replaceChildren(image);
+          replaceViewChildren(container, image);
           return;
         }
 
         // Check if we have a pre-generated QR code with matching URI
         if (this.preGeneratedQRCode && this.preGeneratedURI === uri) {
           logger.debug('Using pre-generated QR code - instant render!');
-          container.replaceChildren();
+          replaceViewChildren(container);
           this.preGeneratedQRCode.append(container as HTMLElement);
           return;
         }
@@ -1000,7 +1001,7 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
         });
 
         // Clear container and append QR code
-        container.replaceChildren();
+        replaceViewChildren(container);
         qrCode.append(container as HTMLElement);
         logger.debug('Modern QR code generated successfully');
       } catch (error) {
@@ -1009,7 +1010,7 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
         message.className = 'qr-loading';
         message.style.color = DEFAULT_THEME.DANGER_COLOR;
         message.textContent = 'Failed to generate QR code';
-        container.replaceChildren(message);
+        replaceViewChildren(container, message);
       }
     }
 
@@ -1132,7 +1133,7 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
       connectButton.id = 'connect-wallet-button';
       connectButton.setAttribute('part', WALLET_CONNECTOR_PARTS.connector.connectButton);
       connectButton.textContent = buttonText;
-      this.shadow.replaceChildren(createMainStyleElement(), connectButton);
+      replaceViewChildren(this.shadow, createMainStyleElement(), connectButton);
 
       // Wallet connection overlay — rendered in a portal on document.body to guarantee
       // position: fixed is always relative to the viewport (not a transformed ancestor)
@@ -1150,9 +1151,9 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
         modal.tabIndex = -1;
         modal.append(content);
         overlay.append(modal);
-        overlayRoot.replaceChildren(createMainStyleElement(), overlay);
+        replaceViewChildren(overlayRoot, createMainStyleElement(), overlay);
       } else if (this.overlayPortal) {
-        this.overlayPortal.shadowRoot!.replaceChildren();
+        replaceViewChildren(this.overlayPortal.shadowRoot!);
       }
 
       // Account modal — same portal approach
@@ -1164,9 +1165,9 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
           this.truncateAddress.bind(this),
           this.generateGradientFromAddress.bind(this)
         );
-        accountRoot.replaceChildren(createMainStyleElement(), accountModal);
+        replaceViewChildren(accountRoot, createMainStyleElement(), accountModal);
       } else if (this.accountModalPortal) {
-        this.accountModalPortal.shadowRoot!.replaceChildren();
+        replaceViewChildren(this.accountModalPortal.shadowRoot!);
       }
 
       this.eventHandler?.attachEventListeners();

--- a/packages/ui/tests/Customization.test.ts
+++ b/packages/ui/tests/Customization.test.ts
@@ -107,11 +107,13 @@ describe('wallet connector customization contract', () => {
       );
 
       const accountMarkup = document.createElement('div');
-      accountMarkup.innerHTML = renderAccountModal(
-        { address: 'rAccount' },
-        '1',
-        (address) => address,
-        () => ({ color1: '#000000', color2: '#ffffff' })
+      accountMarkup.append(
+        renderAccountModal(
+          { address: 'rAccount' },
+          '1',
+          (address) => address,
+          () => ({ color1: '#000000', color2: '#ffffff' })
+        )
       );
       expect(partNames(accountMarkup)).toEqual(
         Object.values(WALLET_CONNECTOR_PARTS.accountModal).sort()

--- a/packages/ui/tests/Security.test.ts
+++ b/packages/ui/tests/Security.test.ts
@@ -30,6 +30,38 @@ afterEach(() => {
 });
 
 describe('safe wallet connector rendering', () => {
+  it('renders without the newer ParentNode.replaceChildren API', async () => {
+    const prototypes = [Element.prototype, DocumentFragment.prototype];
+    const descriptors = prototypes.map((prototype) =>
+      Object.getOwnPropertyDescriptor(prototype, 'replaceChildren')
+    );
+
+    try {
+      for (const prototype of prototypes) {
+        Object.defineProperty(prototype, 'replaceChildren', {
+          configurable: true,
+          value: undefined,
+        });
+      }
+
+      const connector = document.createElement('xrpl-wallet-connector') as HTMLElement & {
+        open(): Promise<void>;
+        getOverlayRoot(): ShadowRoot | null;
+      };
+      document.body.append(connector);
+
+      expect(connector.shadowRoot?.querySelector('#connect-wallet-button')).not.toBeNull();
+      await connector.open();
+      expect(connector.getOverlayRoot()?.querySelector('[role="dialog"]')).not.toBeNull();
+    } finally {
+      prototypes.forEach((prototype, index) => {
+        const descriptor = descriptors[index];
+        if (descriptor) Object.defineProperty(prototype, 'replaceChildren', descriptor);
+        else Reflect.deleteProperty(prototype, 'replaceChildren');
+      });
+    }
+  });
+
   it('renders hostile provider text as text across every view', () => {
     const error = mount(renderErrorView(HOSTILE_TEXT, new Error(HOSTILE_TEXT)));
     expect(error.querySelector('.error-title')?.textContent).toBe(

--- a/packages/ui/tests/Security.test.ts
+++ b/packages/ui/tests/Security.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import type { WalletAdapter } from '@xrpl-connect/core';
+import { TIMINGS } from '../src/constants';
+import { getSafeDeepLinkUrl, getSafeImageUrl } from '../src/security';
+import { isXamanQRImage } from '../src/utils';
+import { renderAccountModal } from '../src/views/AccountModal';
+import { renderAccountSelectionView } from '../src/views/AccountSelectionView';
+import { renderErrorView } from '../src/views/ErrorView';
+import { renderLoadingView } from '../src/views/LoadingView';
+import { renderQRView } from '../src/views/QRView';
+import { renderWalletListView } from '../src/views/WalletListView';
+import '../src/wallet-connector';
+
+const HOSTILE_TEXT = `"><img data-xss onerror="globalThis.__xssExecuted=true"><script data-xss></script>`;
+
+function mount(fragment: DocumentFragment): HTMLDivElement {
+  const host = document.createElement('div');
+  host.append(fragment);
+  return host;
+}
+
+function expectNoInjectedMarkup(root: ParentNode): void {
+  expect(root.querySelector('[data-xss]')).toBeNull();
+  expect(root.querySelector('[onerror], [onfocus], [onclick]')).toBeNull();
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  document.body.replaceChildren();
+});
+
+describe('safe wallet connector rendering', () => {
+  it('renders hostile provider text as text across every view', () => {
+    const error = mount(renderErrorView(HOSTILE_TEXT, new Error(HOSTILE_TEXT)));
+    expect(error.querySelector('.error-title')?.textContent).toBe(
+      `Failed to connect to ${HOSTILE_TEXT}`
+    );
+    expect(error.querySelector('.error-message')?.textContent).toBe(HOSTILE_TEXT);
+
+    const loading = mount(renderLoadingView(HOSTILE_TEXT));
+    expect(loading.querySelector('.loading-wallet-message')?.textContent).toBe(
+      `Check your ${HOSTILE_TEXT}`
+    );
+
+    const qr = mount(renderQRView(HOSTILE_TEXT));
+    expect(qr.querySelector('.title')?.textContent).toBe(HOSTILE_TEXT);
+
+    const selection = mount(
+      renderAccountSelectionView(HOSTILE_TEXT, undefined, [
+        {
+          address: HOSTILE_TEXT,
+          publicKey: HOSTILE_TEXT,
+          path: HOSTILE_TEXT,
+          index: HOSTILE_TEXT as unknown as number,
+        },
+      ])
+    );
+    expect(selection.querySelector('.account-selection-description')?.textContent).toBe(
+      `Select which account to connect from your ${HOSTILE_TEXT}`
+    );
+    expect(selection.querySelector('.account-address-value')?.textContent).toBe(HOSTILE_TEXT);
+    expect((selection.querySelector('.account-button') as HTMLElement).dataset.accountIndex).toBe(
+      HOSTILE_TEXT
+    );
+
+    const account = mount(
+      renderAccountModal(
+        { address: HOSTILE_TEXT },
+        HOSTILE_TEXT,
+        (address) => address,
+        () => ({ color1: '#000000', color2: '#ffffff' })
+      )
+    );
+    expect(account.querySelector('.account-address-text')?.textContent).toBe(HOSTILE_TEXT);
+    expect(account.querySelector('.account-balance-value')?.textContent).toBe(HOSTILE_TEXT);
+
+    for (const view of [error, loading, qr, selection, account]) expectNoInjectedMarkup(view);
+  });
+
+  it('sets hostile wallet metadata through DOM properties without creating attributes', () => {
+    const wallet = {
+      id: HOSTILE_TEXT,
+      name: HOSTILE_TEXT,
+      icon: `javascript:${HOSTILE_TEXT}`,
+    } as unknown as WalletAdapter;
+    const unavailable = {
+      ...wallet,
+      id: `unavailable-${HOSTILE_TEXT}`,
+      url: `https://example.com/\" autofocus onfocus=\"${HOSTILE_TEXT}`,
+    } as unknown as WalletAdapter;
+    const host = mount(renderWalletListView(wallet, [unavailable], new Set([unavailable.id])));
+
+    const primary = host.querySelector<HTMLElement>('.primary-button');
+    const install = host.querySelector<HTMLElement>('.wallet-button--unavailable');
+    expect(primary?.dataset.walletId).toBe(HOSTILE_TEXT);
+    expect(primary?.textContent).toContain(HOSTILE_TEXT);
+    expect(install?.getAttribute('aria-label')).toBe(`Install ${HOSTILE_TEXT}`);
+    expect(host.querySelector('img')).toBeNull();
+    expectNoInjectedMarkup(host);
+  });
+
+  it('allows supported image URLs and rejects executable or unexpected schemes', () => {
+    const bundledSvg =
+      'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%2F%3E';
+    const png = 'data:image/png;base64,iVBORw0KGgo=';
+    expect(getSafeImageUrl('https://example.com/icon.png')).toBe('https://example.com/icon.png');
+    expect(getSafeImageUrl('http://example.com/icon.png')).toBe('http://example.com/icon.png');
+    expect(getSafeImageUrl(bundledSvg)).toBe(bundledSvg);
+    expect(getSafeImageUrl(png)).toBe(png);
+
+    for (const unsafe of [
+      'javascript:alert(1)',
+      'vbscript:msgbox(1)',
+      'data:text/html,<script>alert(1)</script>',
+      'data:image/png;evil=value,AAAA',
+      'blob:https://example.com/id',
+      'file:///tmp/icon.png',
+      '/relative/icon.png',
+    ]) {
+      expect(getSafeImageUrl(unsafe)).toBeNull();
+      expect(mount(renderLoadingView('Wallet', unsafe)).querySelector('img')).toBeNull();
+    }
+
+    expect(mount(renderLoadingView('Wallet', bundledSvg)).querySelector('img')?.src).toBe(
+      bundledSvg
+    );
+  });
+
+  it('recognizes only HTTPS Xaman QR image URLs on the expected origin and path', () => {
+    expect(isXamanQRImage('https://xumm.app/sign/request.png')).toBe(true);
+    expect(isXamanQRImage('https://xumm.app/sign/request.png?cache=1')).toBe(true);
+    expect(isXamanQRImage('http://xumm.app/sign/request.png')).toBe(false);
+    expect(isXamanQRImage('https://evil.example/xumm.app/sign/request.png')).toBe(false);
+    expect(isXamanQRImage('https://xumm.app.evil.example/sign/request.png')).toBe(false);
+    expect(isXamanQRImage('javascript://xumm.app/sign/request.png')).toBe(false);
+  });
+
+  it('preserves wallet deep-link schemes while rejecting executable URLs', () => {
+    expect(getSafeDeepLinkUrl('https://xumm.app/sign/request')).toBe(
+      'https://xumm.app/sign/request'
+    );
+    expect(getSafeDeepLinkUrl('xumm://xumm.app/sign/request')).toBe('xumm://xumm.app/sign/request');
+    expect(getSafeDeepLinkUrl('wc:topic@2?relay-protocol=irn')).toBe(
+      'wc:topic@2?relay-protocol=irn'
+    );
+    for (const unsafe of [
+      'javascript:alert(1)',
+      'java\nscript:alert(1)',
+      'data:text/html,<script>alert(1)</script>',
+      'vbscript:msgbox(1)',
+      'blob:https://example.com/id',
+      'file:///tmp/payload',
+      '/relative/path',
+    ]) {
+      expect(getSafeDeepLinkUrl(unsafe)).toBeNull();
+    }
+  });
+
+  it('renders direct QR images with DOM APIs and refuses origin-confusion payloads', async () => {
+    vi.useFakeTimers();
+    const connector = document.createElement('xrpl-wallet-connector') as HTMLElement & {
+      open(): Promise<void>;
+      showQRCodeView(walletId: string, uri?: string): void;
+      setQRCode(walletId: string, uri: string): void;
+      getOverlayRoot(): ShadowRoot | null;
+    };
+    document.body.append(connector);
+    await connector.open();
+    connector.showQRCodeView('xaman');
+
+    const safeImage = 'https://xumm.app/sign/request.png';
+    connector.setQRCode('xaman', safeImage);
+    await vi.advanceTimersByTimeAsync(TIMINGS.QR_RENDER_DELAY);
+    const qrImage = connector
+      .getOverlayRoot()
+      ?.querySelector<HTMLImageElement>('#qr-container img');
+    expect(qrImage?.src).toBe(safeImage);
+    expect(qrImage?.getAttribute('onerror')).toBeNull();
+
+    connector.showQRCodeView('xaman');
+    connector.setQRCode('xaman', 'https://evil.example/xumm.app/sign/request.png');
+    await vi.advanceTimersByTimeAsync(TIMINGS.QR_RENDER_DELAY);
+    expect(connector.getOverlayRoot()?.querySelector('#qr-container img')).toBeNull();
+  });
+});

--- a/packages/ui/tests/WalletListView.test.ts
+++ b/packages/ui/tests/WalletListView.test.ts
@@ -6,12 +6,22 @@ import { renderWalletListView } from '../src/views/WalletListView';
 const wallet = (id: string, url?: string): WalletAdapter =>
   ({ id, name: id, url }) as unknown as WalletAdapter;
 
+function renderWallets(
+  primaryWallet: WalletAdapter | null,
+  otherWallets: WalletAdapter[],
+  unavailableWalletIds: ReadonlySet<string> = new Set()
+): HTMLDivElement {
+  const host = document.createElement('div');
+  host.append(renderWalletListView(primaryWallet, otherWallets, unavailableWalletIds));
+  return host;
+}
+
 describe('renderWalletListView', () => {
   it('renders available wallets as connectable buttons', () => {
-    const html = renderWalletListView(null, [wallet('xaman'), wallet('crossmark')]);
-    expect(html).toContain('data-wallet-id="xaman"');
-    expect(html).toContain('data-wallet-id="crossmark"');
-    expect(html).not.toContain('data-install-url');
+    const host = renderWallets(null, [wallet('xaman'), wallet('crossmark')]);
+    expect(host.querySelector('[data-wallet-id="xaman"]')).not.toBeNull();
+    expect(host.querySelector('[data-wallet-id="crossmark"]')).not.toBeNull();
+    expect(host.querySelector('[data-install-url]')).toBeNull();
   });
 
   it('inherits the configured primary and secondary button colors into wallet labels', () => {
@@ -28,7 +38,7 @@ describe('renderWalletListView', () => {
 
     const host = document.createElement('div');
     host.className = 'wallet-connector-host';
-    host.innerHTML = renderWalletListView(wallet('primary'), [wallet('secondary')]);
+    host.append(renderWalletListView(wallet('primary'), [wallet('secondary')]));
     document.body.appendChild(host);
 
     try {
@@ -46,39 +56,39 @@ describe('renderWalletListView', () => {
   });
 
   it('renders no install rows by default (unavailable omitted)', () => {
-    const html = renderWalletListView(null, [wallet('xaman')]);
-    expect(html).not.toContain('wallet-button--unavailable');
-    expect(html).not.toContain('Install');
+    const host = renderWallets(null, [wallet('xaman')]);
+    expect(host.querySelector('.wallet-button--unavailable')).toBeNull();
+    expect(host.textContent).not.toContain('Install');
   });
 
   it('renders unavailable wallets with an Install link pointing at their url', () => {
-    const html = renderWalletListView(
+    const host = renderWallets(
       null,
       [wallet('xaman'), wallet('crossmark', 'https://crossmark.io')],
       new Set(['crossmark'])
     );
-    expect(html).toContain('data-install-url="https://crossmark.io/"');
-    expect(html).toContain('wallet-button--unavailable');
-    expect(html).toContain('Install');
+    expect(host.querySelector('[data-install-url="https://crossmark.io/"]')).not.toBeNull();
+    expect(host.querySelector('.wallet-button--unavailable')).not.toBeNull();
+    expect(host.textContent).toContain('Install');
     // Unavailable wallets must not be connectable.
-    expect(html).not.toContain('data-wallet-id="crossmark"');
+    expect(host.querySelector('[data-wallet-id="crossmark"]')).toBeNull();
   });
 
   it('disables unavailable wallets that have no install URL', () => {
-    const html = renderWalletListView(null, [wallet('ledger')], new Set(['ledger']));
-    expect(html).toContain('disabled aria-disabled="true"');
-    expect(html).toContain('Unavailable');
-    expect(html).not.toContain('data-install-url=""');
+    const host = renderWallets(null, [wallet('ledger')], new Set(['ledger']));
+    const button = host.querySelector<HTMLButtonElement>('.wallet-button--unavailable');
+    expect(button?.disabled).toBe(true);
+    expect(button?.getAttribute('aria-disabled')).toBe('true');
+    expect(host.textContent).toContain('Unavailable');
+    expect(button?.hasAttribute('data-install-url')).toBe(false);
   });
 
   it('preserves mixed available and unavailable wallet order', () => {
-    const html = renderWalletListView(
+    const host = renderWallets(
       null,
       [wallet('missing', 'https://example.com'), wallet('installed')],
       new Set(['missing'])
     );
-    const host = document.createElement('div');
-    host.innerHTML = html;
     const labels = [...host.querySelectorAll('.wallet-button > span:first-child')].map(
       (label) => label.textContent
     );
@@ -87,13 +97,11 @@ describe('renderWalletListView', () => {
 
   it('disables unsafe install URLs without injecting attributes', () => {
     const maliciousUrl = 'https://example.com/" autofocus onfocus="globalThis.pwned=true';
-    const html = renderWalletListView(
+    const host = renderWallets(
       null,
       [wallet('malicious', maliciousUrl), wallet('script', 'javascript:alert(1)')],
       new Set(['malicious', 'script'])
     );
-    const host = document.createElement('div');
-    host.innerHTML = html;
     const buttons = host.querySelectorAll('.wallet-button--unavailable');
     expect(buttons).toHaveLength(2);
     expect(buttons[0].hasAttribute('autofocus')).toBe(false);

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -124,3 +124,18 @@
 - Security regressions cover hostile markup, quote-breaking wallet/account attributes, error messages, wallet names and icons, account addresses and balances, unsafe URL schemes, Xaman origin confusion, and direct QR-image rendering. Existing customization assertions continue to prove stable parts, and the browser suite proves styling, dialog semantics, focus, scrolling, and portal behavior.
 - The UI dependency-inclusive build, source/public type checks, lint, all 134 UI tests, all 9 wallet-dialog browser tests, `pnpm exec vp check`, the full monorepo `pnpm test`, packed publish/consumer verification, and `git diff --check` pass.
 - Independent surface and final reviews found no remaining actionable security, compatibility, accessibility, styling, or test gaps. The intentional residual policies are a deep-link denylist that preserves wallet-specific schemes and continued support for bundled SVG data icons as image sources.
+
+## Fix PR #184 review finding
+
+- [x] Reconfirm the dedicated worktree is clean and matches the exact remote PR head.
+- [x] Replace unsupported `replaceChildren()` calls with one compatible DOM helper without reintroducing HTML parsing.
+- [x] Add a regression that fails against the reviewed PR head when native `replaceChildren()` is unavailable.
+- [x] Run focused UI checks, browser tests, repository checks, and packed-artifact verification appropriate to the fix.
+- [x] Review the final diff, commit, push, and verify the updated PR head and CI state.
+
+### Fix review
+
+- A single `replaceViewChildren()` helper now removes and appends nodes through long-supported DOM primitives; every connector, portal, QR, error, and copy-feedback replacement path uses it without reintroducing HTML parsing.
+- The compatibility regression temporarily masks native `replaceChildren()` on both affected DOM prototypes, then proves the connector renders its host button and opens its dialog. Against the reviewed PR head it failed with `TypeError: this.shadow.replaceChildren is not a function` before the button rendered.
+- The rebuilt UI ESM and CommonJS artifacts contain no `replaceChildren` calls.
+- All 135 UI tests, UI type-check/build, repository formatting/lint, all 9 Chromium wallet-dialog tests, the full monorepo build/test pipeline, packed ESM/CJS/SSR/React 18/React 19/Vue/Nuxt consumer verification, and `git diff --check` pass.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -94,3 +94,33 @@
 - The rebuilt packed artifact passes the original React 19.2.8 unmount reproduction for both native and wrapped refs.
 - Focused and full React checks, dependency-inclusive build, repository formatting/lint, documentation snapshot verification, full monorepo tests, packed publish/consumer verification, and `git diff --check` pass.
 - Merged the latest `origin/develop`, resolved the overlapping React API, documentation, and publish fixtures with `showUnavailable` intact, and repeated the full monorepo and packed-consumer verification on the combined tree.
+
+---
+
+# Issue #178
+
+## Issue summary
+
+- Provider- and adapter-controlled values are interpolated into HTML strings used by the wallet connector, allowing hostile text, attributes, or URLs to create executable DOM.
+- Dynamic text and attributes must be rendered through safe DOM APIs, and wallet/QR image URLs must reject executable or unexpected schemes while retaining bundled icons.
+- The fix must cover errors, wallet lists, loading, account selection/details, and QR images without changing styling, accessibility semantics, or customization parts.
+- Regression tests must prove markup, quote-breaking, event-handler, and unsafe-URL payloads remain inert and cannot create unexpected elements or execute code.
+
+## Plan
+
+- [x] Validate GitHub access, refresh `origin/develop`, and confirm issue state, comments, linked PRs, and acceptance criteria.
+- [x] Create a clean isolated worktree from the refreshed default branch and review applicable repository guidance and lessons.
+- [x] Inventory every UI rendering sink and define one consistent safe DOM boundary and URL policy.
+- [x] Implement the minimal production-ready rendering change while preserving public behavior, styles, ARIA, and `part` hooks.
+- [x] Add focused regressions for every affected view, account details, and QR image rendering.
+- [x] Run formatting, linting, type checks, focused UI tests, browser coverage where relevant, and repository-level verification.
+- [x] Review the final diff against every acceptance criterion and record results below.
+- [x] Commit only intentional files, push the branch, open the PR, and verify remote PR metadata/checks.
+
+## Review
+
+- All adapter- and provider-controlled text and attributes now reach the DOM through text, property, dataset, attribute, or CSSOM APIs. Source-controlled markup is isolated behind a tagged static-template helper that rejects substitutions, while connector and portal roots use `replaceChildren`.
+- Wallet and QR logo sources accept absolute HTTP(S) and supported `data:image/*` formats, including bundled SVG icons, while executable and unexpected schemes are rejected. Direct Xaman QR images additionally require HTTPS, the exact `xumm.app` host, `/sign/`, and a PNG path; adapter-produced deep links reject executable protocols.
+- Security regressions cover hostile markup, quote-breaking wallet/account attributes, error messages, wallet names and icons, account addresses and balances, unsafe URL schemes, Xaman origin confusion, and direct QR-image rendering. Existing customization assertions continue to prove stable parts, and the browser suite proves styling, dialog semantics, focus, scrolling, and portal behavior.
+- The UI dependency-inclusive build, source/public type checks, lint, all 134 UI tests, all 9 wallet-dialog browser tests, `pnpm exec vp check`, the full monorepo `pnpm test`, packed publish/consumer verification, and `git diff --check` pass.
+- Independent surface and final reviews found no remaining actionable security, compatibility, accessibility, styling, or test gaps. The intentional residual policies are a deep-link denylist that preserves wallet-specific schemes and continued support for bundled SVG data icons as image sources.


### PR DESCRIPTION
## Summary
- render provider- and adapter-controlled wallet metadata, errors, accounts, and connector state through safe DOM APIs instead of dynamic HTML parsing
- validate wallet/QR image and deep-link URL schemes, with regressions for hostile text, attribute breaking, handlers, and unsafe URLs across every affected view

## Test plan
- [x] `pnpm --filter @xrpl-connect/ui test`
- [x] `pnpm --filter @xrpl-connect/ui type-check`
- [x] `pnpm test:browser -- packages/ui/tests/browser/wallet-dialog.spec.ts`
- [x] `pnpm exec vp check`
- [x] `pnpm test`
- [x] `pnpm --filter xrpl-connect test:publish`
- [x] `git diff --check`

Fixes #178
