### PR TITLE
fix: normalize Xaman network metadata IDs

### DIFF
--- a/packages/adapters/xaman/src/xaman-adapter.ts
+++ b/packages/adapters/xaman/src/xaman-adapter.ts
@@ -109,6 +109,14 @@ interface ActivePayloadOperation {
   resolveDone: () => void;
 }
 
+// OAuth userinfo can return decimal strings despite the upstream numeric declaration.
+function normalizeNetworkId(value: unknown): number | undefined {
+  if (typeof value === 'string' && /^(0|[1-9]\d*)$/.test(value)) {
+    value = Number(value);
+  }
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>((resolvePromise) => {
@@ -562,12 +570,12 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
       }
 
       const endpoint = jwtData?.network_endpoint;
-      const networkId = jwtData?.network_id;
+      const networkId = normalizeNetworkId(jwtData?.network_id);
       let network = this.currentAccount.network;
-      if (typeof endpoint === 'string' && typeof networkId === 'number') {
+      if (typeof endpoint === 'string' && endpoint.length > 0 && networkId !== undefined) {
         network = this.parseNetwork(endpoint, networkId);
-      } else if (endpoint !== undefined || networkId !== undefined) {
-        throw new Error('Xaman ping returned incomplete network information');
+      } else if (endpoint !== undefined || jwtData?.network_id !== undefined) {
+        throw new Error('Xaman ping returned missing or invalid network metadata');
       }
 
       this.currentAccount = {
@@ -911,12 +919,9 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
         : typeof userEndpoint === 'string' && userEndpoint.length > 0
           ? userEndpoint
           : undefined;
-    const networkId =
-      typeof authorizedMe?.networkId === 'number'
-        ? authorizedMe.networkId
-        : typeof userNetworkId === 'number'
-          ? userNetworkId
-          : undefined;
+    const networkId = normalizeNetworkId(
+      authorizedMe?.networkId !== undefined ? authorizedMe.networkId : userNetworkId
+    );
     const networkType =
       typeof authorizedMe?.networkType === 'string'
         ? authorizedMe.networkType
@@ -926,7 +931,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
 
     if (!endpoint || networkId === undefined) {
       throw new Error(
-        'Unable to determine network from Xaman. Make sure the API key and network are correct.'
+        'Xaman returned missing or invalid network metadata. Expected a network endpoint and a non-negative safe integer network ID.'
       );
     }
 

--- a/packages/adapters/xaman/tests/xaman-adapter.test.ts
+++ b/packages/adapters/xaman/tests/xaman-adapter.test.ts
@@ -9,7 +9,7 @@ const mockXummInstance = {
   user: {
     account: Promise.resolve<string | undefined>(undefined),
     networkEndpoint: Promise.resolve<string | undefined>(undefined),
-    networkId: Promise.resolve<number | undefined>(undefined),
+    networkId: Promise.resolve<unknown>(undefined),
     networkType: Promise.resolve<string | undefined>(undefined),
   },
   payload: {
@@ -222,6 +222,100 @@ async function signedAdapter(network: NetworkConfig = 'mainnet') {
 
   return { adapter, subscription: createSubscriptionHarness() };
 }
+
+const INVALID_NETWORK_IDS = [
+  undefined,
+  null,
+  '',
+  ' ',
+  '01',
+  '+1',
+  '-1',
+  '1.0',
+  '1.5',
+  '1e0',
+  '0x1',
+  '1junk',
+  '1\n',
+  ' 1',
+  '1 ',
+  'NaN',
+  'Infinity',
+  '9007199254740992',
+  -1,
+  1.5,
+  NaN,
+  Infinity,
+  -Infinity,
+  Number.MAX_SAFE_INTEGER + 1,
+  true,
+  {},
+  [],
+];
+
+describe.each(['authorization', 'restoration'] as const)(
+  'Xaman network metadata from %s',
+  (source) => {
+    async function connectWithId(networkId: unknown, requested: NetworkConfig = 'testnet') {
+      const adapter = new XamanAdapter({ apiKey: 'test-key' });
+      if (source === 'authorization') {
+        mockXummInstance.authorize.mockResolvedValue({
+          me: {
+            account: CONNECTED_ACCOUNT,
+            networkType: undefined,
+            networkEndpoint: 'wss://testnet.xrpl-labs.com',
+            networkId,
+          },
+        });
+        // An explicitly invalid OAuth ID must not fall back to the facade's valid ID.
+        mockXummInstance.user.networkId = Promise.resolve(networkId === undefined ? undefined : 1);
+        return { adapter, result: adapter.connect({ network: requested }) };
+      }
+      mockXummInstance.user.account = Promise.resolve(CONNECTED_ACCOUNT);
+      mockXummInstance.user.networkEndpoint = Promise.resolve('wss://testnet.xrpl-labs.com');
+      mockXummInstance.user.networkId = Promise.resolve(networkId);
+      return { adapter, result: adapter.checkXamanState({ network: requested }) };
+    }
+
+    it.each([0, '0', 1, '1', 2, '2'])('accepts network ID %s', async (networkId) => {
+      const network = (['mainnet', 'testnet', 'devnet'] as const)[Number(networkId)];
+      const { result } = await connectWithId(networkId, network);
+      await expect(result).resolves.toMatchObject({
+        network: { id: network, walletConnectId: `xrpl:${networkId}` },
+      });
+    });
+
+    it.each(INVALID_NETWORK_IDS)('rejects invalid network ID %j', async (networkId) => {
+      const { adapter, result } = await connectWithId(networkId);
+      await expect(result).rejects.toMatchObject({
+        code: WalletErrorCode.CONNECTION_FAILED,
+        message: expect.stringContaining('missing or invalid network metadata'),
+      });
+      await expect(adapter.getAccount()).resolves.toBeNull();
+    });
+
+    it.each([999, '999', Number.MAX_SAFE_INTEGER, String(Number.MAX_SAFE_INTEGER)])(
+      'rejects unsupported network ID %s',
+      async (networkId) => {
+        const { result } = await connectWithId(networkId);
+        await expect(result).rejects.toMatchObject({ code: WalletErrorCode.NETWORK_NOT_SUPPORTED });
+      }
+    );
+
+    it('rejects a network type that contradicts a string ID', async () => {
+      mockXummInstance.user.networkType = Promise.resolve('MAINNET');
+      const { adapter, result } = await connectWithId('1');
+      await expect(result).rejects.toMatchObject({ code: WalletErrorCode.NETWORK_MISMATCH });
+      await expect(adapter.getAccount()).resolves.toBeNull();
+    });
+
+    it('preserves requested-network mismatch validation for string IDs', async () => {
+      const { adapter, result } = await connectWithId('1', 'mainnet');
+      await expect(result).rejects.toMatchObject({ code: WalletErrorCode.NETWORK_MISMATCH });
+      await expect(adapter.getAccount()).resolves.toBeNull();
+    });
+  }
+);
 
 describe('XamanAdapter.isAvailable', () => {
   it('is always available regardless of options', async () => {
@@ -457,24 +551,27 @@ describe('XamanAdapter.connect', () => {
     expect(account.network).toMatchObject({ id: 'testnet', walletConnectId: 'xrpl:1' });
   });
 
-  it('uses network metadata returned by authorization when the user facade is incomplete', async () => {
-    mockXummInstance.user.networkEndpoint = Promise.resolve(undefined);
-    mockXummInstance.user.networkId = Promise.resolve(undefined);
-    mockXummInstance.user.networkType = Promise.resolve(undefined);
-    mockXummInstance.authorize.mockResolvedValue({
-      me: {
-        account: CONNECTED_ACCOUNT,
-        networkEndpoint: 'wss://s.altnet.rippletest.net:51233/',
-        networkId: 1,
-        networkType: 'TESTNET',
-      },
-    });
-    const adapter = new XamanAdapter({ apiKey: 'test-key' });
+  it.each([1, '1'])(
+    'uses authorization network ID %s when the user facade is incomplete',
+    async (networkId) => {
+      mockXummInstance.user.networkEndpoint = Promise.resolve(undefined);
+      mockXummInstance.user.networkId = Promise.resolve(undefined);
+      mockXummInstance.user.networkType = Promise.resolve(undefined);
+      mockXummInstance.authorize.mockResolvedValue({
+        me: {
+          account: CONNECTED_ACCOUNT,
+          networkEndpoint: 'wss://testnet.xrpl-labs.com',
+          networkId,
+          networkType: 'TESTNET',
+        },
+      });
+      const adapter = new XamanAdapter({ apiKey: 'test-key' });
 
-    const account = await adapter.connect({ network: 'testnet' });
+      const account = await adapter.connect({ network: 'testnet' });
 
-    expect(account.network).toMatchObject({ id: 'testnet', walletConnectId: 'xrpl:1' });
-  });
+      expect(account.network).toMatchObject({ id: 'testnet', walletConnectId: 'xrpl:1' });
+    }
+  );
 
   it('rejects an explicit network that differs from Xaman live metadata before caching', async () => {
     setLiveXamanNetwork('testnet');
@@ -1591,6 +1688,60 @@ describe('XamanAdapter.fetchAccount', () => {
     });
     expect(mockXummInstance.ping).toHaveBeenCalledTimes(1);
     await expect(adapter.getAccount()).resolves.toMatchObject({ address: changedAccount });
+  });
+
+  it.each([0, '0', 1, '1'])('refreshes network ID %s', async (networkId) => {
+    const adapter = await connected();
+    mockXummInstance.ping.mockResolvedValue({
+      jwtData: {
+        sub: CONNECTED_ACCOUNT,
+        network_endpoint: 'wss://testnet.xrpl-labs.com',
+        network_id: networkId,
+      },
+    });
+    await expect(adapter.fetchAccount()).resolves.toMatchObject({
+      network: {
+        id: Number(networkId) === 0 ? 'mainnet' : 'testnet',
+        walletConnectId: `xrpl:${networkId}`,
+      },
+    });
+  });
+
+  it.each(INVALID_NETWORK_IDS)(
+    'rejects invalid ping network ID %j without changing the account',
+    async (networkId) => {
+      const adapter = await connected();
+      mockXummInstance.ping.mockResolvedValue({
+        jwtData: {
+          sub: 'changed-account',
+          network_endpoint: 'wss://testnet.xrpl-labs.com',
+          network_id: networkId,
+        },
+      });
+      await expect(adapter.fetchAccount()).rejects.toMatchObject({
+        code: WalletErrorCode.CONNECTION_FAILED,
+        message: expect.stringContaining('missing or invalid network metadata'),
+      });
+      await expect(adapter.getAccount()).resolves.toMatchObject({
+        address: CONNECTED_ACCOUNT,
+        network: { id: 'mainnet' },
+      });
+    }
+  );
+
+  it.each([999, '999'])('rejects unsupported ping network ID %s', async (networkId) => {
+    const adapter = await connected();
+    mockXummInstance.ping.mockResolvedValue({
+      jwtData: {
+        sub: CONNECTED_ACCOUNT,
+        network_endpoint: 'wss://testnet.xrpl-labs.com',
+        network_id: networkId,
+      },
+    });
+    await expect(adapter.fetchAccount()).rejects.toMatchObject({
+      code: WalletErrorCode.NETWORK_NOT_SUPPORTED,
+    });
+    await expect(adapter.getNetwork()).resolves.toMatchObject({ id: 'mainnet' });
   });
 
   it('clears stale account state when ping has no authenticated subject', async () => {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -410,3 +410,19 @@
 - Repeated adversarial review of teardown ordering, shared-manager ownership, cancellation boundaries, and framework lifecycle behavior found no remaining correctness issue.
 - Production audit reports only the known low-severity `elliptic` advisory inherited through Crossmark typings; no patched dependency version is available.
 - Corrective commit `7468f6c` is GPG-verified by GitHub and is the remote PR head; documentation and the Node 20.19, 22.18, and 24.11 test/build jobs all passed.
+
+# Issue #191
+
+- [x] Inspect issue, repository guidance, and create isolated worktree.
+- [x] Inspect upstream metadata contracts and normalize canonical decimal IDs across authentication, restoration, and refresh.
+- [x] Add regressions for valid, invalid, unsupported, and mismatched network metadata.
+- [x] Verify regression failure before the fix; run package tests, build, formatting, and lint.
+- [ ] Review final diff, commit, push, and open PR against develop.
+
+## Review
+
+Canonical decimal strings and non-negative safe integer IDs now share strict normalization in OAuth/user metadata and live ping refresh. Explicitly invalid OAuth IDs are rejected rather than replaced by facade values; supported-network and mismatch checks remain intact. Missing/invalid metadata errors no longer suggest an API-key problem.
+
+The initial regression run failed 95 cases against the original implementation. All 205 final Xaman tests and 97 core tests pass, along with core/Xaman builds, Xaman TypeScript checks, repository formatting/lint (`pnpm exec vp check`), and `git diff --check`.
+
+Installed upstream source review confirmed that OAuth userinfo, the user facade, and ping forward raw metadata. Signed-payload network IDs retain their separate numeric-or-null contract and strict validation. Independent review found no missed metadata consumer or material implementation issue.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -417,7 +417,7 @@
 - [x] Inspect upstream metadata contracts and normalize canonical decimal IDs across authentication, restoration, and refresh.
 - [x] Add regressions for valid, invalid, unsupported, and mismatched network metadata.
 - [x] Verify regression failure before the fix; run package tests, build, formatting, and lint.
-- [ ] Review final diff, commit, push, and open PR against develop.
+- [x] Review final diff, commit, push, and open PR against develop.
 
 ## Review
 
@@ -426,3 +426,5 @@ Canonical decimal strings and non-negative safe integer IDs now share strict nor
 The initial regression run failed 95 cases against the original implementation. All 205 final Xaman tests and 97 core tests pass, along with core/Xaman builds, Xaman TypeScript checks, repository formatting/lint (`pnpm exec vp check`), and `git diff --check`.
 
 Installed upstream source review confirmed that OAuth userinfo, the user facade, and ping forward raw metadata. Signed-payload network IDs retain their separate numeric-or-null contract and strict validation. Independent review found no missed metadata consumer or material implementation issue.
+
+Opened [PR #192](https://github.com/XRPL-Commons/xrpl-connect/pull/192) against `develop`.


### PR DESCRIPTION
## Summary
- Accept canonical decimal string network IDs from Xaman OAuth userinfo, the user facade used for restoration, and live ping metadata, including mainnet `0`.
- Reject malformed and unsafe IDs before network validation, retain unsupported-network and mismatch errors, and distinguish missing/invalid metadata from API-key failures.
- Add regressions for the observed Testnet response, numeric/string IDs, invalid values, unsupported networks, mismatch checks, and refresh state preservation.

## Test plan
- [x] Confirmed 95 regression failures against the original implementation.
- [x] `pnpm --filter @xrpl-connect/adapter-xaman test` — TypeScript checks and 205 tests pass.
- [x] `pnpm --filter @xrpl-connect/core test` — 97 tests pass.
- [x] `pnpm --filter @xrpl-connect/core build` and `pnpm --filter @xrpl-connect/adapter-xaman build`.
- [x] `pnpm exec vp check` and `git diff --check`.

Fixes #191
