### PR TITLE
Support xrpl v5 with strict packed-consumer verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Expand the `xrpl` peer range to v3/v4/v5 across core, adapters, and framework bindings, with strict packed-consumer compatibility checks for v5. This does not change the peer metadata of already-published RC2 artifacts.
+
+### Fixed
+
+- Ledger: close the XRPL client when connection-time network discovery fails, including the stricter `server_info` validation introduced in xrpl.js v5.
+
 ## [1.0.0-rc.2] - 2026-09-08
 
 ### Fixed

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -25,6 +25,12 @@ commit and integrity hash rather than treating the version label as proof of its
 
 ### Using npm
 
+The upcoming release expands the `xrpl` peer range to v3, v4, and v5. Published
+`1.0.0-rc.2` artifacts still declare v3/v4 only, so the installation commands below
+remain pinned to v4 until the updated SDK and framework bindings are published.
+With the updated artifacts, applications already using v5 can retain it without
+pnpm compatibility overrides. Upgrade the SDK and framework binding together.
+
 ```bash
 npm install xrpl-connect@rc xrpl@^4
 ```

--- a/docs/guide/production.md
+++ b/docs/guide/production.md
@@ -36,6 +36,25 @@ template does not stop that component's setup function from running during SSR. 
 
 Supply a custom `StorageAdapter` when local storage is inappropriate, or `MemoryStorageAdapter` for non-persistent/test environments.
 
+## xrpl.js compatibility
+
+The upcoming SDK release accepts `xrpl` v3, v4, and v5; RC2 published before this
+change accepts v3/v4. V5 requires Node.js 20.19 or newer, consistent with this
+repository's supported Node release lines. The supported peer range does not make
+the upstream major versions interchangeable for application-owned code: v5 changes
+seed/mnemonic key derivation defaults and client network discovery error handling.
+Review the [upstream v5 release notes](https://github.com/XRPLF/xrpl.js/releases/tag/xrpl%405.0.0)
+when upgrading an existing application. XRPL Connect does not derive users' wallets
+from seeds or mnemonics.
+
+Packed-consumer verification covers the documented v4 dependency, the v5.0.0
+minimum, and the current v5 release with strict peers, transaction types,
+ESM/CommonJS, React/Vue, SSR, offline signing/codec checks, and a Nuxt build.
+This does not replace live-wallet acceptance tests. Upgrading the upstream
+dependency can also change browser assets: the tested v5.1.0 Nuxt build emits an
+additional WebAssembly asset, so review your application's bundle and deployment
+policies when upgrading.
+
 ## Browser support
 
 - Serve production applications over HTTPS.

--- a/packages/adapters/crossmark/package.json
+++ b/packages/adapters/crossmark/package.json
@@ -51,7 +51,7 @@
     "@types/node-forge": "^1.3.10"
   },
   "peerDependencies": {
-    "xrpl": "^3.0.0 || ^4.0.0"
+    "xrpl": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.0",

--- a/packages/adapters/gemwallet/package.json
+++ b/packages/adapters/gemwallet/package.json
@@ -48,7 +48,7 @@
     "@gemwallet/api": "^3.7.0"
   },
   "peerDependencies": {
-    "xrpl": "^3.0.0 || ^4.0.0"
+    "xrpl": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.0",

--- a/packages/adapters/ledger/package.json
+++ b/packages/adapters/ledger/package.json
@@ -55,7 +55,7 @@
     "buffer": "^6.0.3"
   },
   "peerDependencies": {
-    "xrpl": "^3.0.0 || ^4.0.0"
+    "xrpl": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.0",

--- a/packages/adapters/ledger/src/ledger-adapter.ts
+++ b/packages/adapters/ledger/src/ledger-adapter.ts
@@ -411,8 +411,8 @@ export class LedgerAdapter
     operation: (client: Client) => Promise<T>
   ): Promise<T> {
     const client = new Client(network.wss);
-    await client.connect();
     try {
+      await client.connect();
       return await operation(client);
     } finally {
       await client.disconnect();

--- a/packages/adapters/ledger/tests/ledger-adapter.test.ts
+++ b/packages/adapters/ledger/tests/ledger-adapter.test.ts
@@ -370,6 +370,22 @@ describe('LedgerAdapter.sign', () => {
     expect(client.disconnect).toHaveBeenCalledTimes(1);
   });
 
+  it.each(['sign', 'signAndSubmit'] as const)(
+    'closes the XRPL client when network discovery fails during %s',
+    async (method) => {
+      const adapter = await connected();
+      client.connect.mockRejectedValue(new Error('server_info response is missing network_id'));
+
+      await expect(adapter[method](SINGLE_TRANSACTION)).rejects.toMatchObject({
+        message: expect.stringContaining('server_info response is missing network_id'),
+      });
+      expect(client.disconnect).toHaveBeenCalledTimes(1);
+      expect(client.autofill).not.toHaveBeenCalled();
+      expect(xrpAppInstance.signTransaction).not.toHaveBeenCalled();
+      expect(client.submitAndWait).not.toHaveBeenCalled();
+    }
+  );
+
   it('returns an authoritative signer-bound multisign contribution', async () => {
     const adapter = await connected(LEDGER_SIGNER.Account, LEDGER_SIGNER.SigningPubKey);
     xrpAppInstance.signTransaction.mockResolvedValue(LEDGER_SIGNER.TxnSignature);

--- a/packages/adapters/metamask-snap/package.json
+++ b/packages/adapters/metamask-snap/package.json
@@ -47,7 +47,7 @@
     "@xrpl-connect/core": "workspace:*"
   },
   "peerDependencies": {
-    "xrpl": "^3.0.0 || ^4.0.0"
+    "xrpl": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.0",

--- a/packages/adapters/otsu/package.json
+++ b/packages/adapters/otsu/package.json
@@ -48,7 +48,7 @@
     "@xrpl-connect/core": "workspace:*"
   },
   "peerDependencies": {
-    "xrpl": "^3.0.0 || ^4.0.0"
+    "xrpl": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.0",

--- a/packages/adapters/walletconnect/package.json
+++ b/packages/adapters/walletconnect/package.json
@@ -52,7 +52,7 @@
     "@walletconnect/utils": "^2.23.10"
   },
   "peerDependencies": {
-    "xrpl": "^3.0.0 || ^4.0.0"
+    "xrpl": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.0",

--- a/packages/adapters/xaman/package.json
+++ b/packages/adapters/xaman/package.json
@@ -51,7 +51,7 @@
     "xumm-oauth2-pkce": "^2.6.0"
   },
   "peerDependencies": {
-    "xrpl": "^3.0.0 || ^4.0.0"
+    "xrpl": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.0",

--- a/packages/adapters/xyra/package.json
+++ b/packages/adapters/xyra/package.json
@@ -50,7 +50,7 @@
     "@xyrawallet/sdk": "^0.1.3"
   },
   "peerDependencies": {
-    "xrpl": "^3.0.0 || ^4.0.0"
+    "xrpl": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,7 @@
     "eventemitter3": "^5.0.1"
   },
   "peerDependencies": {
-    "xrpl": "^3.0.0 || ^4.0.0"
+    "xrpl": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -60,7 +60,7 @@
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
-    "xrpl": "^3.0.0 || ^4.0.0",
+    "xrpl": "^3.0.0 || ^4.0.0 || ^5.0.0",
     "xrpl-connect": "^1.0.0-rc.2"
   },
   "devDependencies": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "vue": "^3.5.0",
-    "xrpl": "^3.0.0 || ^4.0.0",
+    "xrpl": "^3.0.0 || ^4.0.0 || ^5.0.0",
     "xrpl-connect": "^1.0.0-rc.2"
   },
   "devDependencies": {

--- a/packages/xrpl-connect/package.json
+++ b/packages/xrpl-connect/package.json
@@ -83,7 +83,7 @@
     "@xrpl-connect/ui": "workspace:*"
   },
   "peerDependencies": {
-    "xrpl": "^3.0.0 || ^4.0.0"
+    "xrpl": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-inject": "^5.0.5",

--- a/packages/xrpl-connect/scripts/test-publish.mjs
+++ b/packages/xrpl-connect/scripts/test-publish.mjs
@@ -16,6 +16,10 @@ import { readLocalReleaseConfig } from './publish-release.mjs';
 import { run } from './run-command.mjs';
 
 const cliArgs = process.argv.slice(2);
+const xrplVersionIndex = cliArgs.indexOf('--xrpl-version');
+const xrplVersion = xrplVersionIndex === -1 ? '^4' : cliArgs[xrplVersionIndex + 1];
+assert(['^4', '5.0.0', '^5'].includes(xrplVersion), 'Unsupported xrpl compatibility version');
+if (xrplVersionIndex !== -1) cliArgs.splice(xrplVersionIndex, 2);
 const channelIndex = cliArgs.indexOf('--channel');
 const requestedChannel =
   channelIndex === -1 ? process.env.XRPL_RELEASE_CHANNEL : cliArgs[channelIndex + 1];
@@ -181,6 +185,7 @@ function resolveCandidateSpecs(dependencies, tarballsByName) {
 
 function resolveReactCandidateSpecs(dependencies, tarballsByName, reactMajor) {
   return resolveCandidateSpecs(dependencies, tarballsByName).map((dependency) => {
+    if (dependency === DOCUMENTED_XRPL_SPEC) return `xrpl@${xrplVersion}`;
     for (const packageName of ['react', 'react-dom']) {
       if (dependency === packageName || dependency.startsWith(`${packageName}@`)) {
         return `${packageName}@${reactMajor}`;
@@ -210,6 +215,15 @@ function verifyInstalledReactMajor(consumerFolder, reactMajor) {
     );
   }
   console.log(`✓ React ${reactMajor} consumer uses matching runtime and type-package majors`);
+}
+
+function verifyInstalledXrpl(consumerFolder) {
+  const { version } = JSON.parse(
+    readFileSync(path.join(consumerFolder, 'node_modules', 'xrpl', 'package.json'), 'utf-8')
+  );
+  if (xrplVersion === '5.0.0') assert.equal(version, '5.0.0');
+  else assert.equal(version.split('.')[0], xrplVersion.slice(1));
+  console.log(`✓ Consumer resolved xrpl@${version} for ${xrplVersion}`);
 }
 
 function copyReactFixtures(consumerFolder) {
@@ -376,6 +390,7 @@ try {
     [
       'install',
       '--strict-peer-deps',
+      '--legacy-peer-deps=false',
       '--ignore-scripts',
       '--no-audit',
       '--no-fund',
@@ -394,6 +409,7 @@ try {
     { ...runOptions, cwd: consumerFolder }
   );
   console.log('✓ Candidate install completed with strict peer dependency checks');
+  verifyInstalledXrpl(consumerFolder);
   verifyInstalledReactMajor(consumerFolder, 18);
 
   const installedManifests = Object.fromEntries(
@@ -524,17 +540,17 @@ try {
     FRAMEWORK_PEER_RANGE
   );
   assert.deepEqual(installedManifests['xrpl-connect'].peerDependencies, {
-    xrpl: '^3.0.0 || ^4.0.0',
+    xrpl: '^3.0.0 || ^4.0.0 || ^5.0.0',
   });
   assert.deepEqual(installedManifests['@xrpl-commons/xrpl-connect-react'].peerDependencies, {
     react: '^18.0.0 || ^19.0.0',
     'react-dom': '^18.0.0 || ^19.0.0',
-    xrpl: '^3.0.0 || ^4.0.0',
+    xrpl: '^3.0.0 || ^4.0.0 || ^5.0.0',
     'xrpl-connect': FRAMEWORK_PEER_RANGE,
   });
   assert.deepEqual(installedManifests['@xrpl-commons/xrpl-connect-vue'].peerDependencies, {
     vue: '^3.5.0',
-    xrpl: '^3.0.0 || ^4.0.0',
+    xrpl: '^3.0.0 || ^4.0.0 || ^5.0.0',
     'xrpl-connect': FRAMEWORK_PEER_RANGE,
   });
 
@@ -572,6 +588,7 @@ try {
     'runtime-env.cjs',
     'runtime-esm.mjs',
     'runtime-cjs.cjs',
+    'runtime-xrpl-compat.mjs',
     'runtime-ssr-esm.mjs',
     'runtime-ssr-cjs.cjs',
     'types-esm.mts',
@@ -615,6 +632,7 @@ try {
     [
       'install',
       '--strict-peer-deps',
+      '--legacy-peer-deps=false',
       '--ignore-scripts',
       '--no-audit',
       '--no-fund',
@@ -627,6 +645,7 @@ try {
     { ...runOptions, cwd: react19ConsumerFolder }
   );
   verifyInstalledReactMajor(react19ConsumerFolder, 19);
+  verifyInstalledXrpl(react19ConsumerFolder);
   copyReactFixtures(react19ConsumerFolder);
   verifyPackedReactConsumer(react19ConsumerFolder, 19, tscPath, runOptions);
 
@@ -643,6 +662,12 @@ try {
   run(process.execPath, ['runtime-esm.mjs'], { ...runOptions, cwd: consumerFolder });
   console.log('→ Loading packed CommonJS runtime');
   run(process.execPath, ['runtime-cjs.cjs'], { ...runOptions, cwd: consumerFolder });
+  for (const format of ['esm', 'cjs']) {
+    run(process.execPath, ['runtime-xrpl-compat.mjs', format], {
+      ...runOptions,
+      cwd: consumerFolder,
+    });
+  }
   console.log('→ Loading packed Vue ESM and CommonJS entries in SSR');
   run(process.execPath, ['vue-runtime-ssr.mjs'], { ...runOptions, cwd: consumerFolder });
   console.log('→ Building packed umbrella ESM with Nuxt and Vite');
@@ -661,4 +686,21 @@ try {
   );
 } finally {
   rmSync(temporaryRoot, { recursive: true, force: true });
+}
+
+// Reuse all consumer checks for the v5 floor and current v5 release, not just imports.
+if (xrplVersionIndex === -1) {
+  for (const version of ['5.0.0', '^5']) {
+    run(
+      process.execPath,
+      [
+        fileURLToPath(import.meta.url),
+        '--channel',
+        releaseConfig.channel,
+        '--xrpl-version',
+        version,
+      ],
+      registryRunOptions
+    );
+  }
 }

--- a/packages/xrpl-connect/tests/publish/runtime-xrpl-compat.mjs
+++ b/packages/xrpl-connect/tests/publish/runtime-xrpl-compat.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+require('./runtime-env.cjs');
+const commonjs = process.argv[2] === 'cjs';
+const api = commonjs ? require('xrpl-connect') : await import('xrpl-connect');
+const xrpl = commonjs ? require('xrpl') : await import('xrpl');
+
+// Public test-vector keys only; no wallet service or ledger is contacted.
+const wallet = new xrpl.Wallet(
+  '030E58CDD076E798C84755590AAF6237CA8FAE821070A59F648B517A30DC6F589D',
+  '00141BA006D3363D2FB2785E8DF4E44D3A49908780CB4FB51F6D217C08C021429F'
+);
+const account = {
+  address: wallet.classicAddress,
+  publicKey: wallet.publicKey,
+  network: {
+    id: 'testnet',
+    name: 'Testnet',
+    wss: 'wss://testnet.xrpl-labs.com',
+    walletConnectId: 'xrpl:1',
+  },
+};
+const transaction = {
+  TransactionType: 'Payment',
+  Account: account.address,
+  Destination: 'rQ3PTWGLCbPz8ZCicV5tCX3xuymojTng5r',
+  Amount: '20000000',
+  Sequence: 1,
+  Fee: '12',
+};
+const manager = new api.WalletManager({
+  network: 'testnet',
+  autoConnect: false,
+  storage: new api.MemoryStorageAdapter(),
+  adapters: [
+    {
+      id: 'crossmark',
+      name: 'Test vector signer',
+      icon: '',
+      isAvailable: async () => true,
+      connect: async () => account,
+      disconnect: async () => {},
+      sign: async (tx) => wallet.sign(tx),
+    },
+  ],
+});
+try {
+  await manager.connect('crossmark');
+  const signed = await manager.sign(transaction);
+  assert.equal(signed.signerAddress, account.address);
+  assert.equal(xrpl.verifySignature(signed.tx_blob), true);
+  assert.equal(xrpl.hashes.hashSignedTx(signed.tx_blob), signed.hash);
+  const decoded = xrpl.decode(signed.tx_blob);
+  assert.equal(decoded.Account, transaction.Account);
+  assert.equal(decoded.Amount, transaction.Amount);
+  assert.equal(xrpl.encode(decoded), signed.tx_blob);
+} finally {
+  await manager.disconnect();
+}
+console.log(`✓ Packed ${commonjs ? 'CommonJS' : 'ESM'} signing/codec compatibility`);
+process.exit(0);

--- a/packages/xrpl-connect/tests/publish/types-cjs.cts
+++ b/packages/xrpl-connect/tests/publish/types-cjs.cts
@@ -54,6 +54,9 @@ const packagedAdapters = createAdapters({
   walletconnect: { projectId: 'project-id' },
 });
 const manager = new WalletManager({ adapters: packagedAdapters });
+declare const preparedTransaction: import('xrpl').SubmittableTransaction;
+void manager.sign(preparedTransaction);
+void manager.signAndSubmit(preparedTransaction);
 const configuredXaman = new XamanAdapter({ apiKey: 'api-key' });
 const deferredXaman = new XamanAdapter();
 const configuredWalletConnect = new WalletConnectAdapter({ projectId: 'project-id' });

--- a/packages/xrpl-connect/tests/publish/types-esm.mts
+++ b/packages/xrpl-connect/tests/publish/types-esm.mts
@@ -59,6 +59,9 @@ const packagedAdapters = createAdapters({
   ledger: { accountIndex: 1 },
 });
 const manager = new WalletManager({ adapters: packagedAdapters });
+declare const preparedTransaction: import('xrpl').SubmittableTransaction;
+void manager.sign(preparedTransaction);
+void manager.signAndSubmit(preparedTransaction);
 const configuredXaman = new XamanAdapter({ apiKey: 'api-key' });
 const deferredXaman = new XamanAdapter();
 const configuredWalletConnect = new WalletConnectAdapter({ projectId: 'project-id' });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,7 +184,7 @@ importers:
         specifier: workspace:*
         version: link:../../core
       xrpl:
-        specifier: ^3.0.0 || ^4.0.0
+        specifier: ^3.0.0 || ^4.0.0 || ^5.0.0
         version: 4.4.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     devDependencies:
       '@types/node':
@@ -203,7 +203,7 @@ importers:
         specifier: workspace:*
         version: link:../../core
       xrpl:
-        specifier: ^3.0.0 || ^4.0.0
+        specifier: ^3.0.0 || ^4.0.0 || ^5.0.0
         version: 4.4.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     devDependencies:
       '@types/node':
@@ -237,7 +237,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       xrpl:
-        specifier: ^3.0.0 || ^4.0.0
+        specifier: ^3.0.0 || ^4.0.0 || ^5.0.0
         version: 4.4.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     devDependencies:
       '@types/node':
@@ -253,7 +253,7 @@ importers:
         specifier: workspace:*
         version: link:../../core
       xrpl:
-        specifier: ^3.0.0 || ^4.0.0
+        specifier: ^3.0.0 || ^4.0.0 || ^5.0.0
         version: 4.4.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     devDependencies:
       '@types/node':
@@ -272,7 +272,7 @@ importers:
         specifier: workspace:*
         version: link:../../core
       xrpl:
-        specifier: ^3.0.0 || ^4.0.0
+        specifier: ^3.0.0 || ^4.0.0 || ^5.0.0
         version: 4.4.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     devDependencies:
       '@types/node':
@@ -300,7 +300,7 @@ importers:
         specifier: workspace:*
         version: link:../../core
       xrpl:
-        specifier: ^3.0.0 || ^4.0.0
+        specifier: ^3.0.0 || ^4.0.0 || ^5.0.0
         version: 4.4.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     devDependencies:
       '@types/node':
@@ -316,7 +316,7 @@ importers:
         specifier: workspace:*
         version: link:../../core
       xrpl:
-        specifier: ^3.0.0 || ^4.0.0
+        specifier: ^3.0.0 || ^4.0.0 || ^5.0.0
         version: 4.4.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       xumm:
         specifier: ^1.8.0
@@ -341,7 +341,7 @@ importers:
         specifier: ^0.1.3
         version: 0.1.4
       xrpl:
-        specifier: ^3.0.0 || ^4.0.0
+        specifier: ^3.0.0 || ^4.0.0 || ^5.0.0
         version: 4.4.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     devDependencies:
       '@types/node':
@@ -357,7 +357,7 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1
       xrpl:
-        specifier: ^3.0.0 || ^4.0.0
+        specifier: ^3.0.0 || ^4.0.0 || ^5.0.0
         version: 4.4.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     devDependencies:
       '@types/node':
@@ -370,7 +370,7 @@ importers:
   packages/react:
     dependencies:
       xrpl:
-        specifier: ^3.0.0 || ^4.0.0
+        specifier: ^3.0.0 || ^4.0.0 || ^5.0.0
         version: 4.4.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     devDependencies:
       '@microsoft/api-extractor':
@@ -426,7 +426,7 @@ importers:
   packages/vue:
     dependencies:
       xrpl:
-        specifier: ^3.0.0 || ^4.0.0
+        specifier: ^3.0.0 || ^4.0.0 || ^5.0.0
         version: 4.4.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     devDependencies:
       '@xrpl-connect/core':
@@ -478,7 +478,7 @@ importers:
         specifier: workspace:*
         version: link:../ui
       xrpl:
-        specifier: ^3.0.0 || ^4.0.0
+        specifier: ^3.0.0 || ^4.0.0 || ^5.0.0
         version: 4.4.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     devDependencies:
       '@microsoft/api-extractor':

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -454,3 +454,19 @@ Opened [PR #192](https://github.com/XRPL-Commons/xrpl-connect/pull/192) against 
 - [x] Identify merged task-log formatting failures on Node 22/24 and an npm download `ECONNRESET` on Node 20.
 - [x] Format the merged log and run repository checks.
 - [x] Prepare the formatting correction for push; require all remote CI jobs to pass before reporting completion.
+
+# xrpl v5 compatibility
+
+- [x] Review upstream v5 changes and runtime/type usage.
+- [x] Add strict packed-consumer v4/v5 coverage without weakening existing checks.
+- [x] Widen supported peer ranges and refresh the lockfile after compatibility checks.
+- [x] Verify builds, adapter tests, packed consumers, and docs; record limitations.
+
+Review: full existing build/unit suite passes on the workspace v4 graph. Ledger's
+51 tests include connect-time discovery cleanup for both signing methods. The
+expanded packed-consumer suite passes with xrpl 4.6.0, 5.0.0, and 5.1.0: strict
+peers (legacy-peer overrides disabled), transaction type interoperability, React
+18/19, Vue, ESM/CommonJS, SSR, offline signing/codec verification, and Nuxt builds.
+Formatting/lint, docs build, frozen lockfile validation, and diff checks pass.
+No live wallet or ledger submission is claimed. No artifacts were published;
+existing RC2 metadata is unchanged and a new release is required.


### PR DESCRIPTION
## Summary
- Expand xrpl peer support to v3/v4/v5 across core, adapters, and framework bindings.
- Reuse packed-consumer checks for v4, v5.0.0, and current v5; enforce strict peers with legacy overrides disabled and verify transaction type interoperability and offline signing/codec behavior.
- Close Ledger XRPL clients when connection-time network discovery fails.
- Document upstream migration considerations and the fact that already-published RC2 metadata is unchanged.

## Verification
- Full existing build and unit suite passed on the workspace v4 graph.
- All 51 Ledger tests passed, including two new connection-failure cleanup regressions.
- Packed consumers passed with xrpl 4.6.0, 5.0.0, and 5.1.0: React 18/19, Vue, ESM/CommonJS, SSR, transaction types, signing/codec checks, and Nuxt production builds.
- Formatting/lint, docs build, frozen lockfile validation, and git diff checks passed.

## Release notes
Requires a new coordinated SDK release; no npm artifacts were published. Live wallet testing remains separate from these automated checks. xrpl 5.1.0 adds a WebAssembly asset to the tested Nuxt build.