### PR TITLE
fix(xaman): correct account-refresh network semantics

### DIFF
--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -112,12 +112,16 @@ calling an adapter that explicitly declares the operation unsupported.
 async fetchAccount(): Promise<AccountInfo | null>
 ```
 
-Ask the connected adapter for fresh wallet account and network data, update the
+Query the connected adapter for account information, update the
 manager cache and persisted session, and emit `accountChanged` and/or
 `networkChanged` for differences. The `account` property remains the cached,
 synchronous counterpart.
 
-Crossmark, GemWallet, Ledger, Otsu, and Xaman support live refresh.
+Crossmark, GemWallet, Ledger, Otsu, and Xaman support account refresh, but its
+freshness is adapter-specific. Xaman queries the authenticated OAuth subject and
+retains its session network context; it does not query the mobile app's current
+account or network selection. A successful refresh is not proof of the current
+wallet network. See [Xaman network evidence](/guide/production#xaman-session-refresh-and-network-evidence).
 WalletConnect, Xyra, and custom adapters without `SupportsFetchAccount` reject
 with `UNSUPPORTED_METHOD`; the manager does not silently substitute cached
 `getAccount()` data. Calling without a connection rejects with `NOT_CONNECTED`.

--- a/docs/guide/migration-v1.md
+++ b/docs/guide/migration-v1.md
@@ -108,7 +108,7 @@ if (manager.supports('signMessage')) {
 }
 ```
 
-Use `manager.fetchAccount()` when the application needs current wallet-owned account or network data rather than the cached `manager.account`. Adapters without a reliable live query reject with `UNSUPPORTED_METHOD`; `null` means a supported query found no active account and the manager cleared the session. Account and network events remain the preferred way to keep reactive UI synchronized.
+Use `manager.fetchAccount()` to query account information through the adapter rather than merely reading cached `manager.account`. Freshness depends on the adapter: Xaman refreshes its OAuth subject and retains the session network context, not the mobile app's current selection. Successful refresh does not prove the wallet's current network. Adapters without a supported query reject with `UNSUPPORTED_METHOD`; `null` means the query found no active account and the manager cleared the session. Account and network events remain the preferred way to keep reactive UI synchronized. See [Xaman network evidence](/guide/production#xaman-session-refresh-and-network-evidence).
 
 ## Persistence and reconnection
 

--- a/docs/guide/production.md
+++ b/docs/guide/production.md
@@ -73,6 +73,35 @@ directives. WalletConnect's built-in inline QR logo does not require adding `dat
 CSP warning does not block a request, but a separate enforced policy can. Never log or share
 WalletConnect pairing URIs: they contain a pairing secret.
 
+## Xaman session refresh and network evidence
+
+`XamanAdapter.fetchAccount()` checks the OAuth session with `ping()` and refreshes its
+authenticated subject. It is not a live query of the mobile app's selected account/network.
+The returned `account.network` and `getNetwork()` retain the network context established
+from OAuth user information at connection or restoration. That information may itself
+come from a saved session. Reconnecting is therefore not proof of the current selection.
+
+The OAuth ping schema does not declare `network_endpoint` or `network_id`. The adapter
+ignores these extensions rather than changing its signing target or failing on partial
+metadata. **This behavior is unreleased after RC2**: RC2 attempted to parse those fields,
+which could cause spurious refresh failures or misleading network updates.
+
+- A valid session subject refreshes the account while retaining the session network.
+- No authenticated subject returns `null`; the manager clears the session.
+- A transport failure rejects and keeps the cached state. It is not a successful refresh.
+- Late responses cannot overwrite a disconnected or replaced session.
+
+Do not treat `fetchAccount()` success, the application's profile, or an RPC query as proof
+of the mobile wallet's current network. Application/RPC checks establish the **target**
+network. For Xaman signing, XRPL Connect sends `force_network` and validates the resolved
+payload's `environment_networkid` and node type against that target. Missing IDs or
+contradictory signing network information remain errors, even after successful refresh.
+These are transaction-specific checks, not a general network-verification flag.
+
+Display the session/target network accurately, handle signing-network mismatches, and verify
+the actual signed transaction before application submission. Do not disable signing checks
+to work around refresh metadata. Test with a real Xaman session as well as mocked responses.
+
 ## Error UX
 
 Branch on `WalletError.category` for broad UX and `WalletError.code` for specific recovery. Render wallet/provider messages as text, never unsanitized HTML.

--- a/docs/guide/wallets.md
+++ b/docs/guide/wallets.md
@@ -8,7 +8,7 @@ XRPL Connect v1.0 ships eight adapters behind one `WalletManager` API. Register 
 
 | Adapter ID      | Wallet        | Requirement                     | Sign | Submit | Messages | Live account refresh |
 | --------------- | ------------- | ------------------------------- | :--: | :----: | :------: | :------------------: |
-| `xaman`         | Xaman         | Browser API key                 | Yes  |  Yes   |    No    |         Yes          |
+| `xaman`         | Xaman         | Browser API key                 | Yes  |  Yes   |    No    |  OAuth session only  |
 | `crossmark`     | Crossmark     | Browser extension               | Yes  |  Yes   |    No    |         Yes          |
 | `gemwallet`     | GemWallet     | Browser extension               | Yes  |  Yes   |   Yes    |         Yes          |
 | `walletconnect` | WalletConnect | Project ID                      | Yes  |  Yes   |    No    |          No          |
@@ -63,6 +63,11 @@ Xaman API keys and WalletConnect project IDs are browser identifiers, not server
 Xaman and WalletConnect need constructor credentials to appear in wallet discovery and to support automatic reconnection. Direct calls can defer a credential for one session with `manager.connect('xaman', { apiKey })` or `manager.connect('walletconnect', { projectId })`; these options are selected from the wallet ID at compile time and are not persisted. Missing credentials fail early with `CONFIGURATION_REQUIRED`. Other connect-time options can override supported adapter settings. Configure Xaman return URLs on the adapter constructor when connecting through `WalletManager`; direct `XamanAdapter.connect()` calls can override them for one session. Return navigation may open another browser tab, so restore application state and use the signing result—not navigation—as confirmation. Keep the Xaman API key stable for the lifetime of the page because its browser SDK owns page-global OAuth state.
 
 ## Networks
+
+Xaman's network is OAuth session context, which may be restored from saved user information.
+Neither reconnecting nor `fetchAccount()` guarantees the mobile app's current selection.
+Signing forces the session target network and validates the resolved payload's network;
+see [Xaman network evidence](/guide/production#xaman-session-refresh-and-network-evidence).
 
 Pass `mainnet`, `testnet`, `devnet`, or a supported `NetworkConfig` to `WalletManager`. Adapters validate the selected network and reject contradictory wallet responses. In particular, WalletConnect accepts only a well-formed CAIP-10 account with a valid XRPL classic address on the requested chain; malformed responses or sessions without a matching chain are disconnected and rejected. Start development on testnet and display the active network beside every signing action.
 

--- a/packages/adapters/xaman/src/xaman-adapter.ts
+++ b/packages/adapters/xaman/src/xaman-adapter.ts
@@ -266,7 +266,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
         return null;
       }
 
-      const resolvedNetwork = await this.getAuthoritativeNetwork(client);
+      const resolvedNetwork = await this.getSessionNetwork(client);
       const resolvedXamanNetwork = this.resolveXamanNetwork(resolvedNetwork);
       if (requestedXamanNetwork) {
         this.validateXamanNetwork(
@@ -439,7 +439,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
       logger.info('Connection phase: authorization successful');
 
       const account = authResult.me.account;
-      const network = await this.getAuthoritativeNetwork(client, authResult.me);
+      const network = await this.getSessionNetwork(client, authResult.me);
       if (generation !== this.connectionGeneration || this.client !== client) {
         throw new Error('Xaman connection attempt was superseded or disconnected');
       }
@@ -540,7 +540,8 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
   }
 
   /**
-   * Refresh the authenticated account and network from Xaman's live ping endpoint.
+   * Refresh the OAuth session subject, retaining its established network context.
+   * Ping does not report the mobile app's current account/network selection.
    */
   async fetchAccount(): Promise<AccountInfo | null> {
     const client = this.client;
@@ -556,32 +557,19 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
       if (refreshRevision !== this.accountRefreshRevision) return this.currentAccount;
       if (!this.currentAccount) return null;
 
-      const jwtData = pong?.jwtData as
-        | {
-            sub?: unknown;
-            network_endpoint?: unknown;
-            network_id?: unknown;
-          }
-        | undefined;
+      const jwtData = pong?.jwtData as { sub?: unknown } | undefined;
       const address = typeof jwtData?.sub === 'string' ? jwtData.sub : '';
       if (!address) {
         this.currentAccount = null;
         return null;
       }
 
-      const endpoint = jwtData?.network_endpoint;
-      const networkId = normalizeNetworkId(jwtData?.network_id);
-      let network = this.currentAccount.network;
-      if (typeof endpoint === 'string' && endpoint.length > 0 && networkId !== undefined) {
-        network = this.parseNetwork(endpoint, networkId);
-      } else if (endpoint !== undefined || jwtData?.network_id !== undefined) {
-        throw new Error('Xaman ping returned missing or invalid network metadata');
-      }
-
+      // OAuth ping has no supported network fields. Signing independently forces
+      // this session's target network and validates the resolved payload network.
       this.currentAccount = {
         address,
         publicKey: undefined,
-        network,
+        network: this.currentAccount.network,
       };
       return this.currentAccount;
     } catch (error) {
@@ -591,7 +579,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
   }
 
   /**
-   * Get current network
+   * Get the session network context, not the mobile app's current selection.
    */
   async getNetwork(): Promise<NetworkInfo> {
     if (!this.currentAccount) {
@@ -895,7 +883,9 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
     }
   }
 
-  private async getAuthoritativeNetwork(
+  // OAuth user information can be restored from a saved session. It establishes
+  // signing context, not a live observation of the mobile app's network.
+  private async getSessionNetwork(
     client: Xumm,
     authorizedMe?: {
       networkEndpoint?: unknown;

--- a/packages/adapters/xaman/tests/xaman-adapter.test.ts
+++ b/packages/adapters/xaman/tests/xaman-adapter.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, expectTypeOf, vi, beforeEach } from 'vite-plus/test';
-import { WalletErrorCode, type NetworkConfig, type Transaction } from '@xrpl-connect/core';
+import {
+  MemoryStorageAdapter,
+  WalletManager,
+  WalletErrorCode,
+  type NetworkConfig,
+  type Transaction,
+} from '@xrpl-connect/core';
 import { decode, encode, hashes, Wallet } from 'xrpl';
 
 const mockXummInstance = {
@@ -1668,81 +1674,41 @@ describe('XamanAdapter.fetchAccount', () => {
     return adapter;
   }
 
-  it('uses a fresh ping to replace changed account and network data', async () => {
-    const adapter = await connected();
-    const changedAccount = Wallet.generate().address;
-    mockXummInstance.ping.mockResolvedValue({
-      jwtData: {
-        sub: changedAccount,
-        network_endpoint: 'wss://s.altnet.rippletest.net:51233',
-        network_id: 1,
-      },
-    });
-
-    await expect(adapter.fetchAccount()).resolves.toMatchObject({
-      address: changedAccount,
-      network: {
-        id: 'testnet',
-        wss: 'wss://s.altnet.rippletest.net:51233',
-      },
-    });
-    expect(mockXummInstance.ping).toHaveBeenCalledTimes(1);
-    await expect(adapter.getAccount()).resolves.toMatchObject({ address: changedAccount });
-  });
-
-  it.each([0, '0', 1, '1'])('refreshes network ID %s', async (networkId) => {
-    const adapter = await connected();
-    mockXummInstance.ping.mockResolvedValue({
-      jwtData: {
-        sub: CONNECTED_ACCOUNT,
-        network_endpoint: 'wss://testnet.xrpl-labs.com',
-        network_id: networkId,
-      },
-    });
-    await expect(adapter.fetchAccount()).resolves.toMatchObject({
-      network: {
-        id: Number(networkId) === 0 ? 'mainnet' : 'testnet',
-        walletConnectId: `xrpl:${networkId}`,
-      },
-    });
-  });
-
-  it.each(INVALID_NETWORK_IDS)(
-    'rejects invalid ping network ID %j without changing the account',
-    async (networkId) => {
+  it.each([
+    {},
+    { network_endpoint: 'wss://testnet.xrpl-labs.com' },
+    { network_id: 1 },
+    { network_endpoint: 'wss://testnet.xrpl-labs.com', network_id: 1 },
+    { network_endpoint: null, network_id: 'invalid' },
+    { network_endpoint: '', network_id: 999 },
+    ...INVALID_NETWORK_IDS.map((network_id) => ({
+      network_endpoint: 'wss://testnet.xrpl-labs.com',
+      network_id,
+    })),
+  ])(
+    'refreshes the session subject without trusting undocumented network fields %j',
+    async (metadata) => {
       const adapter = await connected();
+      const network = await adapter.getNetwork();
+      const changedAccount = Wallet.generate().address;
       mockXummInstance.ping.mockResolvedValue({
-        jwtData: {
-          sub: 'changed-account',
-          network_endpoint: 'wss://testnet.xrpl-labs.com',
-          network_id: networkId,
-        },
+        jwtData: { sub: changedAccount, ...metadata },
       });
-      await expect(adapter.fetchAccount()).rejects.toMatchObject({
-        code: WalletErrorCode.CONNECTION_FAILED,
-        message: expect.stringContaining('missing or invalid network metadata'),
-      });
+
+      for (let attempt = 0; attempt < 2; attempt++) {
+        await expect(adapter.fetchAccount()).resolves.toMatchObject({
+          address: changedAccount,
+          network,
+        });
+      }
+      expect(mockXummInstance.ping).toHaveBeenCalledTimes(2);
       await expect(adapter.getAccount()).resolves.toMatchObject({
-        address: CONNECTED_ACCOUNT,
-        network: { id: 'mainnet' },
+        address: changedAccount,
+        network,
       });
+      await expect(adapter.getNetwork()).resolves.toEqual(network);
     }
   );
-
-  it.each([999, '999'])('rejects unsupported ping network ID %s', async (networkId) => {
-    const adapter = await connected();
-    mockXummInstance.ping.mockResolvedValue({
-      jwtData: {
-        sub: CONNECTED_ACCOUNT,
-        network_endpoint: 'wss://testnet.xrpl-labs.com',
-        network_id: networkId,
-      },
-    });
-    await expect(adapter.fetchAccount()).rejects.toMatchObject({
-      code: WalletErrorCode.NETWORK_NOT_SUPPORTED,
-    });
-    await expect(adapter.getNetwork()).resolves.toMatchObject({ id: 'mainnet' });
-  });
 
   it('clears stale account state when ping has no authenticated subject', async () => {
     const adapter = await connected();
@@ -1751,6 +1717,104 @@ describe('XamanAdapter.fetchAccount', () => {
     await expect(adapter.fetchAccount()).resolves.toBeNull();
     await expect(adapter.getAccount()).resolves.toBeNull();
   });
+
+  it('does not emit a manager network change from OAuth ping extensions', async () => {
+    mockXummInstance.authorize.mockResolvedValue({ me: { account: CONNECTED_ACCOUNT } });
+    const adapter = new XamanAdapter({ apiKey: 'test-key' });
+    const manager = new WalletManager({ adapters: [adapter], storage: new MemoryStorageAdapter() });
+    const networkChanged = vi.fn();
+    manager.on('networkChanged', networkChanged);
+    await manager.connect('xaman', { network: 'mainnet' });
+    mockXummInstance.ping.mockResolvedValue({
+      jwtData: {
+        sub: CONNECTED_ACCOUNT,
+        network_endpoint: 'wss://testnet.xrpl-labs.com',
+        network_id: 1,
+      },
+    });
+    await manager.fetchAccount();
+    await manager.fetchAccount();
+    expect(manager.account?.network.id).toBe('mainnet');
+    expect(networkChanged).not.toHaveBeenCalled();
+    await manager.disconnect();
+  });
+
+  it('does not retarget signing from undocumented ping network fields', async () => {
+    const { adapter, subscription } = await signedAdapter();
+    mockXummInstance.ping.mockResolvedValue({
+      jwtData: {
+        sub: CONNECTED_ACCOUNT,
+        network_endpoint: 'wss://testnet.xrpl-labs.com',
+        network_id: 1,
+      },
+    });
+    await adapter.fetchAccount();
+    mockXummInstance.payload.get.mockResolvedValue(resolvedPayload(false));
+    const signing = adapter.sign(REQUESTED_TRANSACTION);
+    const result = expect(signing).resolves.toMatchObject({ tx_blob: SIGNED_TX_HEX });
+    await subscription.emit({ signed: true });
+    await result;
+    expect(mockXummInstance.payload.createAndSubscribe).toHaveBeenCalledWith(
+      expect.objectContaining({ options: expect.objectContaining({ force_network: 'MAINNET' }) }),
+      expect.any(Function)
+    );
+    await adapter.disconnect();
+  });
+
+  it('does not apply a pending refresh to a replacement session', async () => {
+    const adapter = await connected();
+    let resolvePing!: (value: unknown) => void;
+    mockXummInstance.ping.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolvePing = resolve;
+        })
+    );
+    const refresh = adapter.fetchAccount();
+    const rejection = expect(refresh).rejects.toMatchObject({
+      code: WalletErrorCode.NOT_CONNECTED,
+    });
+    await adapter.disconnect();
+    await adapter.connect({ network: 'mainnet' });
+    resolvePing({ jwtData: { sub: Wallet.generate().address } });
+    await rejection;
+    await expect(adapter.getAccount()).resolves.toMatchObject({
+      address: CONNECTED_ACCOUNT,
+      network: { id: 'mainnet' },
+    });
+    await adapter.disconnect();
+  });
+
+  it.each([
+    { id: 0, type: 'MAINNET', accepted: true },
+    { id: 1, type: 'TESTNET', accepted: false },
+    { id: null, type: null, accepted: false },
+    { id: 0, type: 'TESTNET', accepted: false },
+  ])(
+    'still forces and verifies signing network after a metadata-free refresh: %j',
+    async ({ id, type, accepted }) => {
+      const { adapter, subscription } = await signedAdapter();
+      mockXummInstance.ping.mockResolvedValue({ jwtData: { sub: CONNECTED_ACCOUNT } });
+      await adapter.fetchAccount();
+      mockXummInstance.payload.get.mockResolvedValue(
+        resolvedPayload(false, {
+          environment_networkid: id,
+          environment_nodetype: type,
+        })
+      );
+      const signing = adapter.sign(REQUESTED_TRANSACTION);
+      const result = accepted
+        ? expect(signing).resolves.toMatchObject({ tx_blob: SIGNED_TX_HEX })
+        : expect(signing).rejects.toMatchObject({ code: WalletErrorCode.NETWORK_MISMATCH });
+      await subscription.emit({ signed: true });
+      await result;
+      expect(mockXummInstance.payload.createAndSubscribe).toHaveBeenCalledWith(
+        expect.objectContaining({ options: expect.objectContaining({ force_network: 'MAINNET' }) }),
+        expect.any(Function)
+      );
+      await adapter.disconnect();
+    }
+  );
 
   it('returns null without pinging when disconnected', async () => {
     const adapter = new XamanAdapter({ apiKey: 'test-key' });

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -289,13 +289,16 @@ if (walletManager.supports('signMessage')) {
 
 #### `fetchAccount(): Promise<AccountInfo | null>`
 
-Requests fresh account and network data from the connected wallet, updates the
+Queries account information through the connected adapter, updates the
 manager cache and persisted session, and emits `accountChanged` and/or
 `networkChanged` when those values differ. This is distinct from the `account`
 getter, which only returns cached state.
 
-Live refresh is currently implemented by the Crossmark, GemWallet, Ledger,
-Otsu, and Xaman adapters. WalletConnect, Xyra, and custom adapters without
+Account refresh is currently implemented by the Crossmark, GemWallet, Ledger,
+Otsu, and Xaman adapters. Freshness is adapter-specific: Xaman checks its OAuth
+session subject and retains the session network, not the mobile app's current
+account or network selection. A successful refresh is not proof of the wallet's
+current network. WalletConnect, Xyra, and custom adapters without
 `SupportsFetchAccount` reject with `WalletErrorCode.UNSUPPORTED_METHOD`; an
 unsupported adapter is never queried through its cached `getAccount()` method.
 Calling `fetchAccount()` without an active connection rejects with
@@ -303,9 +306,9 @@ Calling `fetchAccount()` without an active connection rejects with
 manager clears the session, emits `disconnect`, and returns `null`.
 
 ```typescript
-const freshAccount = await walletManager.fetchAccount();
-if (freshAccount) {
-  console.log('Current wallet account:', freshAccount.address);
+const account = await walletManager.fetchAccount();
+if (account) {
+  console.log('Authorized account:', account.address);
 }
 ```
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -77,7 +77,7 @@ export function isStandardNetworkId(networkId: string): networkId is StandardNet
 export interface AccountInfo {
   address: string; // XRPL address (r...)
   publicKey?: string; // Public key (optional)
-  network: NetworkInfo; // Network the account is connected to
+  network: NetworkInfo; // Adapter's network context; may come from a saved session
 }
 
 /**
@@ -306,8 +306,10 @@ export interface SupportsDeepLink {
 }
 
 /**
- * Capability: adapter can query its wallet, provider, or device for the current
- * authorized account without opening a new connection flow.
+ * Capability: adapter can query its wallet, provider, device, or authenticated
+ * session for account information without opening a new connection flow.
+ * This does not guarantee a live network query. Xaman refreshes its OAuth subject
+ * and retains session network context, not the mobile app's current selection.
  */
 export interface SupportsFetchAccount {
   fetchAccount(): Promise<AccountInfo | null>;

--- a/packages/core/src/wallet-manager.ts
+++ b/packages/core/src/wallet-manager.ts
@@ -689,10 +689,10 @@ export class WalletManager extends EventEmitter<WalletEvent> {
   }
 
   /**
-   * Re-fetch the account live from the connected wallet and refresh the cached
-   * value, emitting `accountChanged` if it changed. Use this when you need the
-   * current on-wallet account rather than the cached `account` getter (e.g. the
-   * user may have switched accounts in the wallet).
+   * Query the connected adapter and refresh cached account information, emitting
+   * account/network change events for differences. Freshness is adapter-specific:
+   * Xaman queries its OAuth subject and retains the session network context.
+   * Success does not universally verify the wallet's current network selection.
    */
   async fetchAccount(): Promise<AccountInfo | null> {
     if (!this.currentAdapter || !this.currentAccount) {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,27 @@
+# Xaman session refresh contract
+
+- [x] Verify the upstream expiry adjustment and explain its rationale without changing signing policy.
+- [x] Reproduce refresh failures and false network updates from unsupported ping metadata.
+- [x] Restrict Xaman refresh to documented authenticated-session fields; retain network context and lifecycle guards.
+- [x] Verify signing still forces and validates the target network after refresh.
+- [x] Correct API documentation, run focused tests/build/types, and review the diff.
+
+## Refresh review
+
+The old implementation failed 32 targeted refresh regressions before the fix. Xaman now
+refreshes the OAuth subject without treating undocumented ping network fields as current
+mobile selection. Session network context is retained; signing still enforces and validates
+the target. Documentation no longer promises universal live account/network freshness.
+
+Verified Xaman app commit `01e2538b08efa2c960233911fad02633f31ce6cd`: expiry is populated
+near signing and clamped to a minimum window (normally 20 ledgers, 150 for Tangem).
+Upstream commit `716ebf5` explains increasing the default window because signing takes time.
+No expiry-policy change, publication, or live-wallet verification is included.
+
+Verification: core tests (97), Xaman type check and regressions, full workspace/docs build,
+workspace formatting/lint, and diff whitespace checks passed. Changes remain local in
+`fix/xaman-network-refresh` for review.
+
 # Issue #180
 
 ## Issue summary


### PR DESCRIPTION
## Summary

Addresses point 2 from the integration feedback: OAuth session refresh does not establish the current network selection in the Xaman mobile app.

- Stop interpreting undocumented ping network_endpoint/network_id fields as authoritative network information.
- Refresh the authenticated session subject while retaining the network context established during OAuth connection/restoration.
- Preserve refresh cancellation, stale-response guards, missing-subject cleanup, and transport-failure behavior.
- Clarify the adapter, core API, and migration/production documentation: successful refresh is not proof of the current mobile wallet network.
- Keep transaction-specific force_network enforcement and resolved-payload network validation unchanged.

## Verification

- Reproduced 32 failing refresh regressions against the old implementation before applying the fix.
- All 211 Xaman tests and the adapter TypeScript check passed.
- All 97 core tests passed.
- Added coverage for repeated refreshes, incomplete/malformed/contradictory ping extensions, manager network events, replacement-session races, and signing network enforcement after refresh.
- Full workspace and documentation builds, formatting/lint, and diff checks passed.

## Scope

Point 2 only: no LastLedgerSequence policy or transaction expiry validation changes. No package versions changed and nothing was published. Live Xaman sessions were not exercised; verification uses mocked SDK responses and locally signed transaction fixtures. The documentation identifies the behavior change as unreleased after RC2.