### PR TITLE
fix(xaman): bound sign-only expiry extensions

### DIFF
--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -106,6 +106,13 @@ flags use `CAPABILITY_DEFAULTS`, where each signing operation defaults to
 `true`. A manager signing method rejects with `UNSUPPORTED_METHOD` before
 calling an adapter that explicitly declares the operation unsupported.
 
+#### Xaman signing expiry
+
+For Xaman `sign()`, the adapter option `maxLastLedgerSequenceExtension` defaults to
+50 additional ledgers beyond a supplied absolute expiry (`0` for strict matching).
+This is unreleased after RC2 and does not apply to wallet-owned `signAndSubmit()`;
+see [expiry policy and limits](/guide/transactions#xaman-expiry-policy).
+
 #### fetchAccount()
 
 ```typescript

--- a/docs/guide/transactions.md
+++ b/docs/guide/transactions.md
@@ -61,6 +61,59 @@ Submit a multisigned artifact only after the adapter-specific flow has combined
 all required contributions. The generic result does not contain the account's
 signer-list quorum, so it cannot determine submission readiness by itself.
 
+### Xaman expiry policy
+
+::: warning Release availability
+This policy is an unreleased change after `1.0.0-rc.2`. RC2 requires exact matching
+of supplied expiry values even when Xaman adjusts them.
+:::
+
+For `sign()` only, Xaman may increase a supplied absolute `LastLedgerSequence` by
+**up to 50 ledgers by default**. This is an extension beyond the requested expiry,
+not a 50-ledger deadline measured from signing time. Configure it on the adapter:
+
+```ts
+const xaman = new XamanAdapter({
+  apiKey: 'YOUR_KEY',
+  maxLastLedgerSequenceExtension: 50, // Default; use 0 for exact expiry matching
+});
+```
+
+For a requested expiry of `10_000_020`, the default accepts an actual signed expiry
+from `10_000_020` through `10_000_070`, inclusive. A decrease, missing expiry, or a
+larger extension fails with `SIGN_FAILED`. The limit must be an integer from `0`
+through `4_294_967_295`; invalid configuration throws `RangeError` at construction.
+
+The adapter checks the expiry in both the resolved request and the decoded,
+cryptographically verified signed blob. Other supplied transaction fields remain
+strictly compared. The original caller object is not modified. Use the returned
+`signed.tx_json.LastLedgerSequence` (or decode `signed.tx_blob`) when recording
+the actual deadline; do not record the originally requested expiry as the signed one.
+
+Supply an **absolute** expiry to get this bound, for example by preparing the
+transaction with your XRPL client's `autofill()` before calling `sign()`:
+
+```ts
+const prepared = await xrplClient.autofill(transaction);
+const signed = await manager.sign(prepared);
+```
+
+Supplied values must be integers between `32570` and `4_294_967_295`.
+Xaman treats smaller values as relative offsets; `sign()` rejects those before
+opening a signing request because their absolute deadline cannot be bounded from
+the request alone. If you **omit** expiry, wallet autofill remains supported, but
+there is no requested absolute deadline to enforce this extension limit against.
+The setting does not introduce an RPC lookup or guarantee that a deadline is still
+in the future. Multisigning and Batch require exact matching of supplied expiry
+even when the configured allowance is nonzero.
+
+`signAndSubmit()` remains wallet-owned: Xaman signs and broadcasts. It does not
+apply this allowance or compare the result with the original request after
+submission. Signature, signer, hash, network, and dispatch-result checks remain.
+Use `sign()` followed by application submission when you need the expiry policy
+enforced before broadcasting. A `signAndSubmit()` error is not proof that nothing
+was submitted; reconcile the outcome before asking the user to sign again.
+
 ### Ledger multisign contributions
 
 Ledger supports parallel multisigning through `sign()`. Prepare the transaction

--- a/docs/guide/wallets.md
+++ b/docs/guide/wallets.md
@@ -54,7 +54,7 @@ Xaman API keys and WalletConnect project IDs are browser identifiers, not server
 
 ## Adapter options
 
-- `XamanAdapter`: `apiKey`, QR callback, deep-link transformation, and post-signing return URLs.
+- `XamanAdapter`: `apiKey`, QR callback, deep-link transformation, post-signing return URLs, and `maxLastLedgerSequenceExtension` (unreleased after RC2; default 50, sign-only). See [expiry policy](/guide/transactions#xaman-expiry-policy).
 - `WalletConnectAdapter`: `projectId`, metadata, QR/deep-link callbacks, modal mode, and theme.
 - `LedgerAdapter`: derivation path, operation timeout, and WebHID preference. Ledger requires HTTPS outside localhost.
 - `MetaMaskSnapAdapter`: optional `snapId`; use the default published Snap unless developing a local Snap.

--- a/packages/adapters/xaman/src/xaman-adapter.ts
+++ b/packages/adapters/xaman/src/xaman-adapter.ts
@@ -38,6 +38,8 @@ const SIGNING_TIMEOUT_MS = 5 * 60 * 1000;
 const RESOLVED_PAYLOAD_RETRY_MAX_MS = 5_000;
 const RESOLVED_PAYLOAD_RETRY_TIMEOUT_MS = 30_000;
 const SIGNING_OUTPUT_FIELDS = new Set(['TxnSignature']);
+const MAX_LEDGER_SEQUENCE = 0xffffffff;
+const MIN_ABSOLUTE_LEDGER_SEQUENCE = 32570;
 
 const XAMAN_NETWORKS_BY_ID = new Map<number, XamanNetwork>([
   [0, { forceNetwork: 'MAINNET', networkId: 0, id: 'mainnet', name: 'Mainnet' }],
@@ -146,6 +148,12 @@ export interface XamanAdapterOptions {
   onDeepLink?: (uri: string) => string; // Transform URI for deep linking
   /** Optional navigation destinations offered after a signing request is resolved */
   returnUrl?: XamanReturnUrl;
+  /**
+   * Maximum increase to a supplied absolute LastLedgerSequence in sign() results.
+   * Defaults to 50 ledgers; 0 requires exact matching. Does not apply to
+   * signAndSubmit(), multisigning, Batch, or wallet-chosen (omitted) expiry.
+   */
+  maxLastLedgerSequenceExtension?: number;
 }
 
 export type XamanConnectOptions = WalletConnectionOptionsById['xaman'];
@@ -167,6 +175,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
   private sdkApiKey: string | null = null;
   private currentAccount: AccountInfo | null = null;
   private options: XamanAdapterOptions;
+  private readonly maxLastLedgerSequenceExtension: number;
   private activePayloadOperations = new Set<ActivePayloadOperation>();
   private connectionGeneration = 0;
   private supersededRestorationGeneration: number | null = null;
@@ -185,6 +194,16 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
   } = {};
 
   constructor(options: XamanAdapterOptions = {}) {
+    const extension =
+      options.maxLastLedgerSequenceExtension === undefined
+        ? 50
+        : options.maxLastLedgerSequenceExtension;
+    if (!Number.isSafeInteger(extension) || extension < 0 || extension > MAX_LEDGER_SEQUENCE) {
+      throw new RangeError(
+        'maxLastLedgerSequenceExtension must be an integer between 0 and 4294967295'
+      );
+    }
+    this.maxLastLedgerSequenceExtension = extension;
     this.options = options;
   }
 
@@ -613,7 +632,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
    * actual signed data and dispatch result come from `payload.get()`.
    */
   private async createAndWaitForPayload(
-    transaction: Transaction,
+    inputTransaction: Transaction,
     submit: boolean
   ): Promise<{
     txid: string;
@@ -623,6 +642,22 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
   }> {
     if (!this.client || !this.currentAccount) {
       throw createWalletError.notConnected();
+    }
+
+    // Compare against a snapshot of the serialized request, independent of both
+    // caller mutations during approval and mutations by the wallet SDK.
+    const transaction = JSON.parse(JSON.stringify(inputTransaction)) as Transaction;
+    if (!submit && transaction.LastLedgerSequence !== undefined) {
+      const expiry = transaction.LastLedgerSequence;
+      if (
+        !Number.isSafeInteger(expiry) ||
+        expiry < MIN_ABSOLUTE_LEDGER_SEQUENCE ||
+        expiry > MAX_LEDGER_SEQUENCE
+      ) {
+        throw new Error(
+          'Xaman sign() requires an absolute LastLedgerSequence between 32570 and 4294967295; relative expiry offsets are not supported'
+        );
+      }
     }
 
     const client = this.client;
@@ -639,7 +674,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
 
     // oxlint-disable-next-line typescript/no-explicit-any
     const payloadBody: any = {
-      txjson: transaction,
+      txjson: JSON.parse(JSON.stringify(transaction)) as Transaction,
       options: {
         submit,
         force_network: xamanNetwork.forceNetwork,
@@ -742,7 +777,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
         throw new Error('Xaman payload signer did not match the connected account');
       }
 
-      this.validateRequestedTransaction(transaction, resolved.payload?.request_json);
+      if (!submit) this.validateRequestedTransaction(transaction, resolved.payload?.request_json);
 
       const { response } = resolved;
       if (typeof response.hex !== 'string' || response.hex.length === 0) {
@@ -788,7 +823,7 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
           response.multisign_account,
           xamanNetwork
         );
-        this.validateRequestedTransaction(transaction, tx_json);
+        if (!submit) this.validateRequestedTransaction(transaction, tx_json);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         throw new Error(`Xaman returned an invalid signed transaction blob: ${message}`);
@@ -1128,7 +1163,31 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
     requested: Transaction,
     actual: Record<string, unknown> | undefined
   ): void {
-    if (!actual || !this.containsRequestedValue(requested, actual)) {
+    if (!actual) {
+      throw new Error('Xaman returned a transaction that did not match the signing request');
+    }
+    let expected = requested;
+    const requestedExpiry = requested.LastLedgerSequence;
+    if (requestedExpiry !== undefined) {
+      const actualExpiry = actual.LastLedgerSequence;
+      const maxExtension =
+        requested.SigningPubKey === '' || requested.TransactionType === 'Batch'
+          ? 0
+          : this.maxLastLedgerSequenceExtension;
+      if (
+        typeof actualExpiry !== 'number' ||
+        !Number.isSafeInteger(actualExpiry) ||
+        actualExpiry > MAX_LEDGER_SEQUENCE ||
+        actualExpiry < requestedExpiry ||
+        actualExpiry - requestedExpiry > maxExtension
+      ) {
+        throw new Error(
+          'Xaman returned LastLedgerSequence outside the permitted signing expiry range'
+        );
+      }
+      expected = { ...requested, LastLedgerSequence: actualExpiry };
+    }
+    if (!this.containsRequestedValue(expected, actual)) {
       throw new Error('Xaman returned a transaction that did not match the signing request');
     }
   }

--- a/packages/adapters/xaman/tests/xaman-adapter.test.ts
+++ b/packages/adapters/xaman/tests/xaman-adapter.test.ts
@@ -26,7 +26,7 @@ vi.mock('xumm', () => ({
   }),
 }));
 
-import { XamanAdapter } from '../src/xaman-adapter';
+import { XamanAdapter, type XamanAdapterOptions } from '../src/xaman-adapter';
 
 const SIGNING_WALLET = Wallet.fromSeed('snoPBrXtMeMyMHUVTgbuqAfg1SUTb');
 const CONNECTED_ACCOUNT = SIGNING_WALLET.address;
@@ -51,6 +51,23 @@ const REQUESTED_TRANSACTION = {
   Sequence: 1,
   Flags: 0,
 } as Transaction;
+const MIN_ABSOLUTE_LEDGER_SEQUENCE = 32570;
+const MAX_LEDGER_SEQUENCE = 0xffffffff;
+
+function signedExpiryFixture(lastLedgerSequence: number, overrides: Record<string, unknown> = {}) {
+  const input = {
+    ...REQUESTED_TRANSACTION,
+    ...overrides,
+    LastLedgerSequence: lastLedgerSequence,
+  } as Transaction;
+  const signed = SIGNING_WALLET.sign(input);
+  return {
+    input,
+    blob: signed.tx_blob,
+    hash: hashes.hashSignedTx(signed.tx_blob),
+    tx_json: decode(signed.tx_blob) as Transaction,
+  };
+}
 const MULTISIGN_SOURCE = Wallet.generate();
 const MULTISIGN_INPUT = {
   TransactionType: 'Payment',
@@ -68,6 +85,37 @@ const EXISTING_MULTISIGNER = Wallet.generate();
 const PARTIALLY_SIGNED_INPUT = decode(
   EXISTING_MULTISIGNER.sign(MULTISIGN_INPUT, true).tx_blob
 ) as Transaction;
+
+function multisignedExpiryFixture(lastLedgerSequence: number) {
+  const input = { ...MULTISIGN_INPUT, LastLedgerSequence: lastLedgerSequence } as Transaction;
+  const signed = SIGNING_WALLET.sign(input, true);
+  return {
+    input,
+    blob: signed.tx_blob,
+    hash: hashes.hashSignedTx(signed.tx_blob),
+    tx_json: decode(signed.tx_blob) as Transaction,
+  };
+}
+
+function batchExpiryFixture(lastLedgerSequence: number) {
+  return signedExpiryFixture(lastLedgerSequence, {
+    TransactionType: 'Batch',
+    RawTransactions: [
+      {
+        RawTransaction: {
+          TransactionType: 'Payment',
+          Account: CONNECTED_ACCOUNT,
+          Destination: 'rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe',
+          Amount: '1',
+          Fee: '0',
+          Sequence: 2,
+          Flags: 0x40000000,
+          SigningPubKey: '',
+        },
+      },
+    ],
+  });
+}
 
 function signedFixture(networkId = 0) {
   const input = {
@@ -93,7 +141,9 @@ type PayloadEventCallback = (event: {
   payload: { meta: { app_opened: boolean } };
 }) => unknown | Promise<unknown>;
 
-function createSubscriptionHarness() {
+type PayloadBody = { txjson: Transaction; options: Record<string, unknown> };
+
+function createSubscriptionHarness(onCreate?: (body: PayloadBody) => void) {
   let callback: PayloadEventCallback | undefined;
   let resolveOutcome: ((outcome: unknown) => void) | undefined;
   let markReady: (() => void) | undefined;
@@ -107,6 +157,7 @@ function createSubscriptionHarness() {
   const close = vi.fn(() => resolveOutcome?.(undefined));
 
   mockXummInstance.payload.createAndSubscribe.mockImplementation(async (_body, onEvent) => {
+    onCreate?.(_body as PayloadBody);
     callback = onEvent as PayloadEventCallback;
     markReady?.();
     return {
@@ -135,7 +186,7 @@ function resolvedPayload(
   submit: boolean,
   responseOverrides: Record<string, unknown> = {},
   metaOverrides: Record<string, unknown> = {},
-  requestJson: Transaction = REQUESTED_TRANSACTION
+  requestJson: Record<string, unknown> = REQUESTED_TRANSACTION
 ) {
   return {
     meta: {
@@ -211,16 +262,20 @@ beforeEach(() => {
   mockXummInstance.user.networkType = Promise.resolve(undefined);
 });
 
-async function signedAdapter(network: NetworkConfig = 'mainnet') {
+async function signedAdapter(
+  network: NetworkConfig = 'mainnet',
+  options: Omit<XamanAdapterOptions, 'apiKey'> = {},
+  onCreate?: (body: PayloadBody) => void
+) {
   setLiveXamanNetwork(network);
   mockXummInstance.authorize.mockResolvedValue({ me: { account: CONNECTED_ACCOUNT } });
-  const adapter = new XamanAdapter({ apiKey: 'test-key' });
+  const adapter = new XamanAdapter({ apiKey: 'test-key', ...options });
   // Without an onQRCode callback, openSignWindow() falls back to window.open(),
   // which doesn't exist in this (Node) test environment — supply a no-op so
   // signing proceeds straight to the subscription wait, same as a headless caller.
   await adapter.connect({ network, onQRCode: () => {} });
 
-  return { adapter, subscription: createSubscriptionHarness() };
+  return { adapter, subscription: createSubscriptionHarness(onCreate) };
 }
 
 const INVALID_NETWORK_IDS = [
@@ -328,6 +383,23 @@ describe('XamanAdapter configuration', () => {
   it('accepts constructor or deferred API keys', () => {
     expect(new XamanAdapter({ apiKey: 'constructor-key' }).getMissingConfiguration()).toEqual([]);
     expect(new XamanAdapter().getMissingConfiguration({ apiKey: 'deferred-key' })).toEqual([]);
+  });
+
+  it.each([NaN, Infinity, -Infinity, -1, 0.5, MAX_LEDGER_SEQUENCE + 1, null])(
+    'rejects invalid maxLastLedgerSequenceExtension %p',
+    (maxLastLedgerSequenceExtension) => {
+      expect(
+        () =>
+          new XamanAdapter({
+            maxLastLedgerSequenceExtension: maxLastLedgerSequenceExtension as never,
+          })
+      ).toThrow(RangeError);
+    }
+  );
+
+  it('accepts zero and a custom maxLastLedgerSequenceExtension', () => {
+    expect(() => new XamanAdapter({ maxLastLedgerSequenceExtension: 0 })).not.toThrow();
+    expect(() => new XamanAdapter({ maxLastLedgerSequenceExtension: 7 })).not.toThrow();
   });
 
   it('identifies a missing API key before connection work begins', async () => {
@@ -837,6 +909,303 @@ describe('XamanAdapter.sign', () => {
     expectTypeOf(result.tx_json).toEqualTypeOf<Transaction | undefined>();
   });
 
+  it('accepts the default 50-ledger expiry extension in request JSON and the signed blob', async () => {
+    const requested = signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 10);
+    const resolved = signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 60);
+    const { adapter, subscription } = await signedAdapter();
+    mockXummInstance.payload.get.mockResolvedValue(
+      resolvedPayload(false, { hex: resolved.blob, txid: resolved.hash }, {}, resolved.input)
+    );
+
+    const signPromise = adapter.sign(requested.input);
+    await subscription.emit({ signed: true });
+
+    await expect(signPromise).resolves.toMatchObject({
+      hash: resolved.hash,
+      tx_json: { LastLedgerSequence: MIN_ABSOLUTE_LEDGER_SEQUENCE + 60 },
+    });
+  });
+
+  it('rejects a request JSON expiry extended beyond the default limit', async () => {
+    const requested = signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 10);
+    const resolved = signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 61);
+    const { adapter, subscription } = await signedAdapter();
+    mockXummInstance.payload.get.mockResolvedValue(
+      resolvedPayload(false, { hex: resolved.blob, txid: resolved.hash }, {}, resolved.input)
+    );
+
+    const signPromise = adapter.sign(requested.input);
+    const rejection = expect(signPromise).rejects.toMatchObject({
+      code: WalletErrorCode.SIGN_FAILED,
+    });
+    await subscription.emit({ signed: true });
+
+    await rejection;
+  });
+
+  it('rejects a signed blob expiry extended beyond the default limit', async () => {
+    const requested = signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 10);
+    const resolved = signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 61);
+    const { adapter, subscription } = await signedAdapter();
+    mockXummInstance.payload.get.mockResolvedValue(
+      resolvedPayload(false, { hex: resolved.blob, txid: resolved.hash }, {}, requested.input)
+    );
+
+    const signPromise = adapter.sign(requested.input);
+    const rejection = expect(signPromise).rejects.toMatchObject({
+      code: WalletErrorCode.SIGN_FAILED,
+    });
+    await subscription.emit({ signed: true });
+
+    await rejection;
+  });
+
+  it('clamps the expiry extension at the uint32 maximum', async () => {
+    const requested = signedExpiryFixture(MAX_LEDGER_SEQUENCE - 10);
+    const resolved = signedExpiryFixture(MAX_LEDGER_SEQUENCE);
+    const { adapter, subscription } = await signedAdapter();
+    mockXummInstance.payload.get.mockResolvedValue(
+      resolvedPayload(false, { hex: resolved.blob, txid: resolved.hash }, {}, resolved.input)
+    );
+
+    const signPromise = adapter.sign(requested.input);
+    await subscription.emit({ signed: true });
+
+    await expect(signPromise).resolves.toMatchObject({ hash: resolved.hash });
+  });
+
+  it.each([0, 7])('accepts expiry at the configured limit %s', async (limit) => {
+    const requested = signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 10);
+    const resolved = signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 10 + limit);
+    const { adapter, subscription } = await signedAdapter('mainnet', {
+      maxLastLedgerSequenceExtension: limit,
+    });
+    mockXummInstance.payload.get.mockResolvedValue(
+      resolvedPayload(false, { hex: resolved.blob, txid: resolved.hash }, {}, resolved.input)
+    );
+
+    const signPromise = adapter.sign(requested.input);
+    await subscription.emit({ signed: true });
+
+    await expect(signPromise).resolves.toMatchObject({ hash: resolved.hash });
+  });
+
+  it.each([0, 7])('rejects expiry above the configured limit %s', async (limit) => {
+    const requested = signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 10);
+    const resolved = signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 11 + limit);
+    const { adapter, subscription } = await signedAdapter('mainnet', {
+      maxLastLedgerSequenceExtension: limit,
+    });
+    mockXummInstance.payload.get.mockResolvedValue(
+      resolvedPayload(false, { hex: resolved.blob, txid: resolved.hash }, {}, resolved.input)
+    );
+
+    const signPromise = adapter.sign(requested.input);
+    const rejection = expect(signPromise).rejects.toMatchObject({
+      code: WalletErrorCode.SIGN_FAILED,
+    });
+    await subscription.emit({ signed: true });
+
+    await rejection;
+  });
+
+  it.each([
+    [
+      'missing',
+      {
+        ...signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 10).input,
+        LastLedgerSequence: undefined,
+      },
+    ],
+    [
+      'null',
+      { ...signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 10).input, LastLedgerSequence: null },
+    ],
+    [
+      'string',
+      {
+        ...signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 10).input,
+        LastLedgerSequence: '32580',
+      },
+    ],
+    [
+      'fractional',
+      {
+        ...signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 10).input,
+        LastLedgerSequence: 32580.5,
+      },
+    ],
+    [
+      'too early',
+      {
+        ...signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 10).input,
+        LastLedgerSequence: MIN_ABSOLUTE_LEDGER_SEQUENCE - 1,
+      },
+    ],
+    [
+      'too late',
+      {
+        ...signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 10).input,
+        LastLedgerSequence: MAX_LEDGER_SEQUENCE + 1,
+      },
+    ],
+  ])('rejects a malformed %s response expiry', async (_description, responseRequest) => {
+    const requested = signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 10);
+    const resolved = signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 10);
+    const { adapter, subscription } = await signedAdapter();
+    mockXummInstance.payload.get.mockResolvedValue(
+      resolvedPayload(false, { hex: resolved.blob, txid: resolved.hash }, {}, responseRequest)
+    );
+
+    const signPromise = adapter.sign(requested.input);
+    const rejection = expect(signPromise).rejects.toMatchObject({
+      code: WalletErrorCode.SIGN_FAILED,
+    });
+    await subscription.emit({ signed: true });
+
+    await rejection;
+  });
+
+  it.each([
+    ['omitted', signedFixture().blob, signedFixture().hash],
+    [
+      'earlier',
+      signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 9).blob,
+      signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 9).hash,
+    ],
+    [
+      'too late',
+      signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 61).blob,
+      signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 61).hash,
+    ],
+  ])(
+    'rejects a signed blob whose expiry is %s or outside the limit',
+    async (_description, hex, txid) => {
+      const requested = signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 10);
+      const { adapter, subscription } = await signedAdapter();
+      mockXummInstance.payload.get.mockResolvedValue(
+        resolvedPayload(false, { hex, txid }, {}, requested.input)
+      );
+
+      const signPromise = adapter.sign(requested.input);
+      const rejection = expect(signPromise).rejects.toMatchObject({
+        code: WalletErrorCode.SIGN_FAILED,
+      });
+      await subscription.emit({ signed: true });
+
+      await rejection;
+    }
+  );
+
+  it.each([
+    MIN_ABSOLUTE_LEDGER_SEQUENCE - 1,
+    0,
+    -1,
+    MIN_ABSOLUTE_LEDGER_SEQUENCE + 0.5,
+    MAX_LEDGER_SEQUENCE + 1,
+    NaN,
+    Infinity,
+    null,
+    '32580',
+  ])('rejects invalid supplied LastLedgerSequence %p before creating a payload', async (expiry) => {
+    const { adapter } = await signedAdapter();
+    const transaction = {
+      ...REQUESTED_TRANSACTION,
+      LastLedgerSequence: expiry,
+    } as unknown as Transaction;
+
+    await expect(adapter.sign(transaction)).rejects.toMatchObject({
+      code: WalletErrorCode.SIGN_FAILED,
+    });
+    expect(mockXummInstance.payload.createAndSubscribe).not.toHaveBeenCalled();
+  });
+
+  it('keeps other supplied fields strict while allowing only the expiry extension', async () => {
+    const requested = signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 10);
+    const resolved = signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 11, {
+      Amount: '5000000',
+    });
+    const { adapter, subscription } = await signedAdapter();
+    mockXummInstance.payload.get.mockResolvedValue(
+      resolvedPayload(false, { hex: resolved.blob, txid: resolved.hash }, {}, resolved.input)
+    );
+
+    const signPromise = adapter.sign(requested.input);
+    const rejection = expect(signPromise).rejects.toMatchObject({
+      code: WalletErrorCode.SIGN_FAILED,
+    });
+    await subscription.emit({ signed: true });
+
+    await rejection;
+  });
+
+  it('does not apply an expiry bound when the wallet chooses LastLedgerSequence', async () => {
+    const resolved = signedExpiryFixture(MAX_LEDGER_SEQUENCE);
+    const { adapter, subscription } = await signedAdapter();
+    mockXummInstance.payload.get.mockResolvedValue(
+      resolvedPayload(false, { hex: resolved.blob, txid: resolved.hash }, {}, resolved.input)
+    );
+
+    const signPromise = adapter.sign(REQUESTED_TRANSACTION);
+    await subscription.emit({ signed: true });
+
+    await expect(signPromise).resolves.toMatchObject({ hash: resolved.hash });
+  });
+
+  it('snapshots the caller transaction and SDK payload before approval-time mutation', async () => {
+    const requested = signedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 10);
+    const responseRequest = { ...requested.input };
+    const { adapter, subscription } = await signedAdapter('mainnet', {}, (body) => {
+      body.txjson.LastLedgerSequence = MIN_ABSOLUTE_LEDGER_SEQUENCE + 61;
+    });
+    mockXummInstance.payload.get.mockResolvedValue(
+      resolvedPayload(false, { hex: requested.blob, txid: requested.hash }, {}, responseRequest)
+    );
+
+    const signPromise = adapter.sign(requested.input);
+    requested.input.LastLedgerSequence = MIN_ABSOLUTE_LEDGER_SEQUENCE + 61;
+    await subscription.emit({ signed: true });
+
+    await expect(signPromise).resolves.toMatchObject({ hash: requested.hash });
+  });
+
+  it('requires exact expiry for multisigning and Batch transactions', async () => {
+    const cases = [
+      {
+        requested: multisignedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 10),
+        resolved: multisignedExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 11),
+        response: { account: MULTISIGN_SOURCE.address, multisign_account: CONNECTED_ACCOUNT },
+        meta: { multisign: true },
+      },
+      {
+        requested: batchExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 10),
+        resolved: batchExpiryFixture(MIN_ABSOLUTE_LEDGER_SEQUENCE + 11),
+        response: { account: CONNECTED_ACCOUNT, multisign_account: null },
+        meta: { multisign: false },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const { adapter, subscription } = await signedAdapter();
+      mockXummInstance.payload.get.mockResolvedValue(
+        resolvedPayload(
+          false,
+          { hex: testCase.resolved.blob, txid: testCase.resolved.hash, ...testCase.response },
+          testCase.meta,
+          testCase.resolved.input
+        )
+      );
+
+      const signPromise = adapter.sign(testCase.requested.input);
+      const rejection = expect(signPromise).rejects.toMatchObject({
+        code: WalletErrorCode.SIGN_FAILED,
+      });
+      await subscription.emit({ signed: true });
+
+      await rejection;
+    }
+  });
+
   it('rejects a resolved payload from a different network', async () => {
     const { adapter, subscription } = await signedAdapter();
     mockXummInstance.payload.get.mockResolvedValue(
@@ -1297,6 +1666,54 @@ describe('XamanAdapter.signMessage', () => {
 });
 
 describe('XamanAdapter.signAndSubmit', () => {
+  it.each([undefined, 0])(
+    'does not compare submitted fields or apply expiry allowance %s',
+    async (limit) => {
+      const requested = signedExpiryFixture(100_000);
+      const resolved = signedExpiryFixture(100_150, { Amount: '5000000' });
+      const { adapter, subscription } = await signedAdapter('mainnet', {
+        maxLastLedgerSequenceExtension: limit,
+      });
+      mockXummInstance.payload.get.mockResolvedValue(
+        resolvedPayload(true, { hex: resolved.blob, txid: resolved.hash }, {}, resolved.input)
+      );
+      const submitted = adapter.signAndSubmit(requested.input);
+      await subscription.emit({ signed: true });
+      await expect(submitted).resolves.toMatchObject({
+        hash: resolved.hash,
+        tx_json: { Amount: '5000000', LastLedgerSequence: 100_150 },
+      });
+      expect(mockXummInstance.payload.createAndSubscribe).toHaveBeenCalledWith(
+        expect.objectContaining({ options: expect.objectContaining({ submit: true }) }),
+        expect.any(Function)
+      );
+    }
+  );
+
+  it('still rejects an invalid signature after wallet-owned submission', async () => {
+    const requested = signedExpiryFixture(100_000);
+    const changed = signedExpiryFixture(100_150);
+    const invalidBlob = encode({ ...changed.tx_json, Amount: '2' } as Transaction);
+    const { adapter, subscription } = await signedAdapter();
+    mockXummInstance.payload.get.mockResolvedValue(
+      resolvedPayload(
+        true,
+        {
+          hex: invalidBlob,
+          txid: hashes.hashSignedTx(invalidBlob),
+        },
+        {},
+        changed.input
+      )
+    );
+    const submitted = adapter.signAndSubmit(requested.input);
+    const rejection = expect(submitted).rejects.toMatchObject({
+      code: WalletErrorCode.SIGN_FAILED,
+    });
+    await subscription.emit({ signed: true });
+    await rejection;
+  });
+
   it('returns signed data only after Xaman reports a successful node dispatch', async () => {
     const { adapter, subscription } = await signedAdapter();
     mockXummInstance.payload.get.mockResolvedValue(resolvedPayload(true));

--- a/packages/xrpl-connect/README.md
+++ b/packages/xrpl-connect/README.md
@@ -596,6 +596,19 @@ export { useWallet, useWalletConnect } from './hooks.js';
 
 ## Troubleshooting
 
+### Xaman signing expiry
+
+Unreleased after RC2: Xaman `sign()` accepts up to 50 additional ledgers beyond a
+supplied absolute `LastLedgerSequence`. Configure
+`new XamanAdapter({ apiKey, maxLastLedgerSequenceExtension: 50 })`; use `0` for
+strict matching. Omitted expiry remains wallet-chosen and has no extension bound;
+relative offsets are rejected in sign-only requests. Other supplied fields remain
+strictly compared. Record the actual expiry returned in `tx_json` or the decoded blob.
+
+Xaman `signAndSubmit()` remains wallet-owned and does not perform original-request
+comparison after submission. Signature, signer, hash, network, and dispatch checks
+remain. See the [full policy and multisign limitations](https://github.com/XRPL-Commons/xrpl-connect/blob/develop/docs/guide/transactions.md#xaman-expiry-policy).
+
 ### Issue: Large Bundle Size
 
 **Problem**: The meta-package includes all adapters, but your app only needs one.

--- a/packages/xrpl-connect/tests/publish/types-cjs.cts
+++ b/packages/xrpl-connect/tests/publish/types-cjs.cts
@@ -50,11 +50,13 @@ const invalidCssVars: WalletConnectorCssVars = {
 const invalidStandardWalletId: WalletId = 'custom-wallet';
 const descriptorWalletId: WalletId = ADAPTER_DESCRIPTORS[0].id;
 const packagedAdapters = createAdapters({
-  xaman: { apiKey: 'api-key' },
+  xaman: { apiKey: 'api-key', maxLastLedgerSequenceExtension: 50 },
   walletconnect: { projectId: 'project-id' },
 });
 const manager = new WalletManager({ adapters: packagedAdapters });
-const configuredXaman = new XamanAdapter({ apiKey: 'api-key' });
+const configuredXaman = new XamanAdapter({ apiKey: 'api-key', maxLastLedgerSequenceExtension: 0 });
+// @ts-expect-error The expiry extension is a numeric ledger count.
+new XamanAdapter({ maxLastLedgerSequenceExtension: '50' });
 const deferredXaman = new XamanAdapter();
 const configuredWalletConnect = new WalletConnectAdapter({ projectId: 'project-id' });
 const deferredWalletConnect = new WalletConnectAdapter();

--- a/packages/xrpl-connect/tests/publish/types-esm.mts
+++ b/packages/xrpl-connect/tests/publish/types-esm.mts
@@ -54,12 +54,14 @@ const invalidCssVars: WalletConnectorCssVars = {
 const invalidStandardWalletId: WalletId = 'custom-wallet';
 const descriptorWalletId: WalletId = ADAPTER_DESCRIPTORS[0].id;
 const packagedAdapters = createAdapters({
-  xaman: { apiKey: 'api-key' },
+  xaman: { apiKey: 'api-key', maxLastLedgerSequenceExtension: 50 },
   walletconnect: { projectId: 'project-id' },
   ledger: { accountIndex: 1 },
 });
 const manager = new WalletManager({ adapters: packagedAdapters });
-const configuredXaman = new XamanAdapter({ apiKey: 'api-key' });
+const configuredXaman = new XamanAdapter({ apiKey: 'api-key', maxLastLedgerSequenceExtension: 0 });
+// @ts-expect-error The expiry extension is a numeric ledger count.
+new XamanAdapter({ maxLastLedgerSequenceExtension: '50' });
 const deferredXaman = new XamanAdapter();
 const configuredWalletConnect = new WalletConnectAdapter({ projectId: 'project-id' });
 const deferredWalletConnect = new WalletConnectAdapter();

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,7 @@
 # Lessons
 
+- Keep wallet-owned submission separate from sign-only validation. Do not expand a wallet-specific expiry policy into centralized broadcasting without explicit agreement; post-submission request comparison cannot prevent submission.
+
 - A lifecycle-readiness review must exercise ownership boundaries under adversarial interleavings: late teardown after replacement, concurrent teardown callers, explicit disconnect during probes, externally shared managers, connector-owned versus pre-existing sessions, and framework deactivate/reactivate cycles. Passing isolated adapter and wrapper suites is not sufficient evidence without those cross-boundary regressions.
 - Cancellation intent must remain observable even when there is no committed session, and ownership must distinguish an accepted connector-started operation from a rejected attempt against external committed or in-flight state before any teardown is authorized.
 - When a branch already has a dedicated local worktree, locate and use that branch-attached worktree for fixes, verification, commits, and pushes instead of creating a detached review worktree.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,15 @@
+# Xaman sign-only expiry policy
+
+- [x] Add a constructor-configurable maximum LastLedgerSequence extension, default 50; 0 preserves strict matching.
+- [x] Bound only supplied absolute expiry values in sign-only results; snapshot the request and keep all other supplied-field comparisons strict.
+- [x] Keep wallet-owned signAndSubmit, removing post-submit request equality checks while retaining integrity/network/submission validation.
+- [x] Add real-signature regressions for limits, malformed input, mutation, and submission semantics.
+- [x] Document absolute-expiry requirements, omitted/relative expiry behavior, multisigning, and release availability; verify builds/types/tests.
+
+## Review
+
+Separate from PR #197; no network-refresh changes or package publication. The Xaman suite passes all 246 tests and its TypeScript check. Packed-candidate consumer checks (including constructor/factory option types, React/Vue, SSR, and Nuxt builds), the documentation build, formatting, lint, and diff whitespace checks pass. Fixtures use real local signatures and mocked Xaman responses; no live wallet signing or submission was exercised. Prepared for review on `fix/xaman-sign-expiry`.
+
 # Issue #180
 
 ## Issue summary


### PR DESCRIPTION
## Summary

- Add maxLastLedgerSequenceExtension to Xaman adapter options: default 50 extra ledgers beyond a supplied absolute LastLedgerSequence; 0 requires exact preservation.
- Apply the allowance only to sign(), validating both returned request metadata and the decoded signed blob while preserving comparisons for all other supplied fields.
- Snapshot requests independently of caller and SDK mutations. Reject relative or malformed supplied expiry values before opening a signing request; preserve exact expiry for multisign and Batch.
- Keep signAndSubmit() wallet-owned and remove original-request comparisons after submission, retaining signature, signer, hash, network, and submission-result validation.
- Document configuration and limitations: omitted expiry remains wallet-controlled, and this policy does not establish that an expiry is still in the future.

## Verification

- Xaman: 246 tests and TypeScript checks passed, using real local signatures with mocked wallet responses.
- Packed candidate checks passed, including public constructor/factory types, strict peers, React/Vue consumers, SSR, and Nuxt production build.
- Documentation build, formatting, lint, and git diff --check passed.
- No live wallet signing or submission exercised; no npm publication.

Separate from the network-refresh changes in #197.