### PR TITLE
fix(ui): honor the manager auto-connect policy for Xaman

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ledger: close the XRPL client when connection-time network discovery fails, including the stricter `server_info` validation introduced in xrpl.js v5.
 - UI: honor the `WalletManager` auto-connect policy by leaving Xaman session restoration to the manager and framework lifecycle; mounting or replacing the connector no longer reconnects when `autoConnect` is omitted or `false`.
+- Xaman: complete mobile OAuth returns through manager reconnection even before the first session is persisted, while keeping automatic recovery opt-in.
 
 ## [1.0.0-rc.2] - 2026-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Ledger: close the XRPL client when connection-time network discovery fails, including the stricter `server_info` validation introduced in xrpl.js v5.
+- UI: honor the `WalletManager` auto-connect policy by leaving Xaman session restoration to the manager and framework lifecycle; mounting or replacing the connector no longer reconnects when `autoConnect` is omitted or `false`.
 
 ## [1.0.0-rc.2] - 2026-09-08
 

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -59,7 +59,9 @@ whose provider APIs do not support silent access may ignore it.
 async reconnect(): Promise<AccountInfo | null>
 ```
 
-Reconnect to the previously connected wallet using stored state. Returns `null` when no valid stored session is found.
+Reconnect to the previously connected wallet using stored state. When storage is empty,
+configured adapters can also complete an authorization returned to this page, such as
+Xaman's first mobile OAuth login. Returns `null` when neither can be restored.
 
 #### sign()
 
@@ -631,6 +633,25 @@ function supportsFetchAccount(
 Use this type guard before calling an adapter's live-refresh method directly.
 Crossmark, GemWallet, Ledger, Otsu, and Xaman implement it. WalletConnect and
 Xyra do not.
+
+### SupportsPendingConnection
+
+```typescript
+interface SupportsPendingConnection {
+  hasPendingConnection(): boolean;
+}
+
+function supportsPendingConnection(
+  adapter: WalletAdapter
+): adapter is WalletAdapter & SupportsPendingConnection;
+```
+
+Detection must be synchronous and side-effect free. It identifies a returned wallet
+authorization that `connect()` can complete without starting a new authorization.
+Xaman implements it for successful OAuth callback parameters; rejected-return URLs
+are ignored. With empty storage, `reconnect()` attempts the first configured candidate
+in registration order through the normal connection validation and persistence path.
+Automatic recovery requires `autoConnect: true`; callers may also reconnect explicitly.
 
 ### ConnectOptions
 

--- a/docs/guide/wallets.md
+++ b/docs/guide/wallets.md
@@ -52,6 +52,11 @@ export const manager = new WalletManager({
 
 Xaman API keys and WalletConnect project IDs are browser identifiers, not server secrets. Restrict them to your production origins in the provider dashboard. Never place private keys, seeds, API secrets, or signing credentials in client code.
 
+On a Xaman mobile OAuth return, `autoConnect: true` completes sign-in even if the
+manager has not saved its first session yet. With auto-connect omitted or disabled,
+call `manager.reconnect()` explicitly on the returned page. Mounting the connector
+does not initiate recovery.
+
 ## Adapter options
 
 - `XamanAdapter`: `apiKey`, QR callback, deep-link transformation, post-signing return URLs, and `maxLastLedgerSequenceExtension` (unreleased after RC2; default 50, sign-only). See [expiry policy](/guide/transactions#xaman-expiry-policy).

--- a/packages/adapters/xaman/src/xaman-adapter.ts
+++ b/packages/adapters/xaman/src/xaman-adapter.ts
@@ -21,6 +21,7 @@ import {
   SubmittedTransaction,
   SupportsDeepLink,
   SupportsFetchAccount,
+  SupportsPendingConnection,
   WalletCapabilities,
   WalletConnectionOptionsById,
 } from '@xrpl-connect/core';
@@ -161,7 +162,9 @@ export type XamanConnectOptions = WalletConnectionOptionsById['xaman'];
 /**
  * Xaman wallet adapter implementation
  */
-export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFetchAccount {
+export class XamanAdapter
+  implements WalletAdapter, SupportsDeepLink, SupportsFetchAccount, SupportsPendingConnection
+{
   readonly id = 'xaman';
   readonly name = 'Xaman';
   readonly icon = ICON_DATA_URL;
@@ -216,6 +219,13 @@ export class XamanAdapter implements WalletAdapter, SupportsDeepLink, SupportsFe
    */
   async isAvailable(): Promise<boolean> {
     return true;
+  }
+
+  hasPendingConnection(): boolean {
+    if (typeof document === 'undefined' || !document.location?.search) return false;
+    // Successful OAuth return parameters consumed by the Xumm PKCE SDK.
+    const params = new URLSearchParams(document.location.search);
+    return Boolean(params.get('authorization_code') || params.get('access_token'));
   }
 
   async checkXamanState(

--- a/packages/adapters/xaman/tests/xaman-adapter.test.ts
+++ b/packages/adapters/xaman/tests/xaman-adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, expectTypeOf, vi, beforeEach } from 'vite-plus/test';
+import { describe, it, expect, expectTypeOf, vi, beforeEach, afterEach } from 'vite-plus/test';
 import {
   MemoryStorageAdapter,
   WalletManager,
@@ -283,6 +283,45 @@ async function signedAdapter(
 
   return { adapter, subscription: createSubscriptionHarness(onCreate) };
 }
+
+describe('Xaman OAuth return recovery', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it.each(['access_token', 'authorization_code'])(
+    'completes a returned %s through reconnect without a stored manager session',
+    async (parameter) => {
+      vi.stubGlobal('document', { location: { search: `?${parameter}=oauth-return` } });
+      mockXummInstance.authorize.mockResolvedValue({ me: { account: CONNECTED_ACCOUNT } });
+      const adapter = new XamanAdapter({ apiKey: 'test-key' });
+      const manager = new WalletManager({
+        adapters: [adapter],
+        storage: new MemoryStorageAdapter(),
+      });
+
+      await expect(manager.reconnect()).resolves.toMatchObject({ address: CONNECTED_ACCOUNT });
+
+      expect(mockXummInstance.authorize).toHaveBeenCalledOnce();
+      expect(manager.wallet).toBe(adapter);
+    }
+  );
+
+  it.each([
+    undefined,
+    '',
+    '?state=ordinary-page',
+    '?access_token=',
+    '?error_description=Cancelled',
+  ])('leaves a page without an OAuth result idle (%s)', async (search) => {
+    if (search !== undefined) vi.stubGlobal('document', { location: { search } });
+    const adapter = new XamanAdapter({ apiKey: 'test-key' });
+    const manager = new WalletManager({ adapters: [adapter], storage: new MemoryStorageAdapter() });
+
+    await expect(manager.reconnect()).resolves.toBeNull();
+
+    expect(mockXummInstance.authorize).not.toHaveBeenCalled();
+    expect(manager.connected).toBe(false);
+  });
+});
 
 const INVALID_NETWORK_IDS = [
   undefined,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -145,10 +145,17 @@ console.log('Disconnected');
 
 #### `reconnect(): Promise<AccountInfo | null>`
 
-Reconnects to the previously connected wallet using stored state.
+Reconnects to the previously connected wallet using stored state. When there is no
+stored session, configured adapters implementing `SupportsPendingConnection` can
+complete an authorization returned to the current page, such as Xaman's first
+mobile OAuth login. This uses the normal connection validation and persistence
+path. It does not start a new authorization on pages without a returned result.
+If several adapters report a pending authorization, only the first configured
+candidate in registration order is attempted. Expired stored state is cleared
+without falling back to pending authorization recovery in that attempt.
 
 **Returns**: `AccountInfo` of the reconnected account, or `null` when no valid
-stored session can be restored
+stored session or pending authorization can be restored.
 
 Failed reconnection attempts clear invalid stored state and resolve to `null`.
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,6 +38,7 @@ export type {
   SupportsFetchAccount,
   WalletCapabilities,
   SupportsReconnectOptions,
+  SupportsPendingConnection,
 } from './types';
 
 export {
@@ -52,6 +53,7 @@ export {
   adapterSupports,
   CAPABILITY_DEFAULTS,
   supportsReconnectOptions,
+  supportsPendingConnection,
   getMissingAdapterConfiguration,
   isAdapterConfigured,
 } from './types';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -323,6 +323,15 @@ export interface SupportsReconnectOptions {
   serializeReconnectOptions(options: ConnectOptions): ReconnectOptions | undefined;
 }
 
+/**
+ * Capability: a wallet authorization has returned to this page before the manager
+ * could persist its session. Detection must be synchronous and side-effect free;
+ * connect() must complete the returned authorization without starting a new one.
+ */
+export interface SupportsPendingConnection {
+  hasPendingConnection(): boolean;
+}
+
 export function supportsPreInitialize(
   adapter: WalletAdapter
 ): adapter is WalletAdapter & SupportsPreInitialize {
@@ -347,6 +356,12 @@ export function supportsReconnectOptions(
   return (
     typeof (adapter as Partial<SupportsReconnectOptions>).serializeReconnectOptions === 'function'
   );
+}
+
+export function supportsPendingConnection(
+  adapter: WalletAdapter
+): adapter is WalletAdapter & SupportsPendingConnection {
+  return typeof (adapter as Partial<SupportsPendingConnection>).hasPendingConnection === 'function';
 }
 
 /**

--- a/packages/core/src/wallet-manager.ts
+++ b/packages/core/src/wallet-manager.ts
@@ -26,7 +26,9 @@ import {
   adapterSupports,
   supportsFetchAccount,
   supportsReconnectOptions,
+  supportsPendingConnection,
   getMissingAdapterConfiguration,
+  isAdapterConfigured,
   isStandardNetworkId,
   STANDARD_NETWORKS,
   WalletErrorCode,
@@ -89,7 +91,7 @@ export class WalletManager extends EventEmitter<WalletEvent> {
   }
 
   /**
-   * Attempt to auto-connect from stored state
+   * Restore stored state or complete a returned wallet authorization
    */
   private async autoConnect(): Promise<void> {
     try {
@@ -479,7 +481,7 @@ export class WalletManager extends EventEmitter<WalletEvent> {
   }
 
   /**
-   * Reconnect to previously connected wallet
+   * Restore a previous session or complete a returned wallet authorization
    */
   async reconnect(): Promise<AccountInfo | null> {
     if (this.currentAdapter && this.currentAccount) {
@@ -496,7 +498,19 @@ export class WalletManager extends EventEmitter<WalletEvent> {
       const stored = await this.storage.loadState();
       if (reconnectGeneration !== this.reconnectGeneration) return null;
       if (!stored) {
-        this.logger.debug('No stored state found for reconnection');
+        for (const adapter of this.adapters.values()) {
+          let pending = false;
+          try {
+            pending =
+              supportsPendingConnection(adapter) &&
+              isAdapterConfigured(adapter) &&
+              adapter.hasPendingConnection();
+          } catch (error) {
+            this.logger.warn(`Failed to check pending authorization for ${adapter.name}:`, error);
+          }
+          if (reconnectGeneration !== this.reconnectGeneration) return null;
+          if (pending) return await this.connectInternal(adapter.id);
+        }
         return null;
       }
       if (!this.isStateValid(stored)) {

--- a/packages/core/tests/wallet-manager.test.ts
+++ b/packages/core/tests/wallet-manager.test.ts
@@ -1199,6 +1199,174 @@ describe('WalletManager.reconnect()', () => {
     };
   }
 
+  it('completes and persists a pending connection without a stored session', async () => {
+    const storage = new MemoryStorageAdapter();
+    const adapter = { ...createFakeAdapter(), hasPendingConnection: () => true };
+    const manager = new WalletManager({ adapters: [adapter], storage, network: NETWORK });
+    const onConnect = vi.fn();
+    manager.on('connect', onConnect);
+
+    await expect(manager.reconnect()).resolves.toEqual(ACCOUNT);
+
+    expect(adapter.connect).toHaveBeenCalledExactlyOnceWith({ network: NETWORK });
+    expect(onConnect).toHaveBeenCalledExactlyOnceWith(ACCOUNT);
+    expect(await new Storage(storage).loadState()).toMatchObject({
+      walletId: adapter.id,
+      account: ACCOUNT,
+      network: NETWORK,
+    });
+  });
+
+  it('does not start a new authorization flow when no connection is pending', async () => {
+    const adapter = { ...createFakeAdapter(), hasPendingConnection: () => false };
+    const manager = new WalletManager({ adapters: [adapter], storage: new MemoryStorageAdapter() });
+
+    await expect(manager.reconnect()).resolves.toBeNull();
+
+    expect(adapter.connect).not.toHaveBeenCalled();
+    await manager.connect(adapter.id);
+    expect(manager.account).toEqual(ACCOUNT);
+  });
+
+  it('skips unconfigured pending adapters and restores the configured one', async () => {
+    const unconfigured = {
+      ...createFakeAdapter(),
+      id: 'unconfigured',
+      getMissingConfiguration: () => ['credential'],
+      hasPendingConnection: vi.fn(() => true),
+    };
+    const pending = { ...createFakeAdapter(), hasPendingConnection: () => true };
+    const manager = new WalletManager({
+      adapters: [unconfigured, pending],
+      storage: new MemoryStorageAdapter(),
+    });
+
+    await expect(manager.reconnect()).resolves.toEqual(ACCOUNT);
+
+    expect(unconfigured.hasPendingConnection).not.toHaveBeenCalled();
+    expect(unconfigured.connect).not.toHaveBeenCalled();
+    expect(manager.wallet).toBe(pending);
+  });
+
+  it('keeps stored sessions authoritative over another pending authorization', async () => {
+    const storage = new MemoryStorageAdapter();
+    const stored = createFakeAdapter();
+    await new WalletManager({ adapters: [stored], storage }).connect(stored.id);
+    const pending = {
+      ...createFakeAdapter(),
+      id: 'pending',
+      hasPendingConnection: vi.fn(() => true),
+    };
+    const manager = new WalletManager({ adapters: [pending, stored], storage });
+
+    await expect(manager.reconnect()).resolves.toEqual(ACCOUNT);
+
+    expect(pending.hasPendingConnection).not.toHaveBeenCalled();
+    expect(pending.connect).not.toHaveBeenCalled();
+    expect(manager.wallet).toBe(stored);
+  });
+
+  it('continues after a failed pending-connection check', async () => {
+    const broken = {
+      ...createFakeAdapter(),
+      id: 'broken',
+      hasPendingConnection: () => {
+        throw new Error('Provider is unavailable');
+      },
+    };
+    const pending = { ...createFakeAdapter(), hasPendingConnection: () => true };
+    const manager = new WalletManager({
+      adapters: [broken, pending],
+      storage: new MemoryStorageAdapter(),
+    });
+
+    await expect(manager.reconnect()).resolves.toEqual(ACCOUNT);
+
+    expect(broken.connect).not.toHaveBeenCalled();
+    expect(manager.wallet).toBe(pending);
+  });
+
+  it('attempts only the first pending authorization even when it fails', async () => {
+    const first = {
+      ...createFakeAdapter(),
+      id: 'first',
+      hasPendingConnection: () => true,
+      connect: vi.fn(async () => {
+        throw new Error('Authorization expired');
+      }),
+    };
+    const second = { ...createFakeAdapter(), hasPendingConnection: vi.fn(() => true) };
+    const manager = new WalletManager({
+      adapters: [first, second],
+      storage: new MemoryStorageAdapter(),
+    });
+
+    await expect(manager.reconnect()).resolves.toBeNull();
+
+    expect(first.connect).toHaveBeenCalledOnce();
+    expect(second.hasPendingConnection).not.toHaveBeenCalled();
+    expect(second.connect).not.toHaveBeenCalled();
+  });
+
+  it('does not inspect a returned authorization after disconnect during storage loading', async () => {
+    const storage = new MemoryStorageAdapter();
+    let releaseStorage!: () => void;
+    const loading = new Promise<void>((resolve) => {
+      releaseStorage = resolve;
+    });
+    vi.spyOn(storage, 'get').mockImplementationOnce(async () => {
+      await loading;
+      return null;
+    });
+    const adapter = { ...createFakeAdapter(), hasPendingConnection: vi.fn(() => true) };
+    const manager = new WalletManager({ adapters: [adapter], storage });
+
+    const reconnecting = manager.reconnect();
+    await manager.disconnect();
+    releaseStorage();
+
+    await expect(reconnecting).resolves.toBeNull();
+    expect(adapter.hasPendingConnection).not.toHaveBeenCalled();
+    expect(adapter.connect).not.toHaveBeenCalled();
+  });
+
+  it('validates the requested network before committing a pending authorization', async () => {
+    const storage = new MemoryStorageAdapter();
+    const adapter = { ...createFakeAdapter(), hasPendingConnection: () => true };
+    const manager = new WalletManager({ adapters: [adapter], storage, network: MAINNET });
+
+    await expect(manager.reconnect()).resolves.toBeNull();
+
+    expect(adapter.disconnect).toHaveBeenCalledOnce();
+    expect(manager.connected).toBe(false);
+    expect(await new Storage(storage).loadState()).toBeNull();
+  });
+
+  it('does not commit a cancelled pending authorization over a newer manual session', async () => {
+    const storage = new MemoryStorageAdapter();
+    let resolveAuthorization!: (account: AccountInfo) => void;
+    const pending = {
+      ...createFakeAdapter(),
+      hasPendingConnection: () => true,
+      connect: vi.fn(() => new Promise<AccountInfo>((resolve) => (resolveAuthorization = resolve))),
+    };
+    const manual = { ...createFakeAdapter(), id: 'manual' };
+    const manager = new WalletManager({ adapters: [pending, manual], storage });
+    const onConnect = vi.fn();
+    manager.on('connect', onConnect);
+    const reconnecting = manager.reconnect();
+    await vi.waitFor(() => expect(pending.connect).toHaveBeenCalledOnce());
+
+    await manager.disconnect();
+    await manager.connect(manual.id);
+    resolveAuthorization(ACCOUNT);
+
+    await expect(reconnecting).resolves.toBeNull();
+    expect(manager.wallet).toBe(manual);
+    expect(onConnect).toHaveBeenCalledOnce();
+    expect(await new Storage(storage).loadState()).toMatchObject({ walletId: manual.id });
+  });
+
   it('clears expired state instead of reconnecting it', async () => {
     const storage = new MemoryStorageAdapter();
     await new Storage(storage).saveState({

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -96,6 +96,8 @@ subtree. The manager is created once on mount; pass a React `key` to rebuild it.
 The provider owns persisted-session restoration and calls `reconnect()` only when
 `config.autoConnect` is `true`; mounting `<WalletConnector />` does not restore a session by
 itself. Use `manager.reconnect()` for an explicit restore when automatic restoration is disabled.
+Reconnection also completes a returned Xaman OAuth login before the first manager
+session has been saved.
 
 ### Hooks
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -93,6 +93,9 @@ See the [CSP policy, nonce lifecycle, and wallet-specific limits](https://github
 Builds **one** `WalletManager` from `config` (the core `WalletManagerOptions`:
 `adapters`, `network`, `autoConnect`, `storage`, `logger`) and shares it with the
 subtree. The manager is created once on mount; pass a React `key` to rebuild it.
+The provider owns persisted-session restoration and calls `reconnect()` only when
+`config.autoConnect` is `true`; mounting `<WalletConnector />` does not restore a session by
+itself. Use `manager.reconnect()` for an explicit restore when automatic restoration is disabled.
 
 ### Hooks
 

--- a/packages/react/tests/react.test.tsx
+++ b/packages/react/tests/react.test.tsx
@@ -4,6 +4,7 @@ import { createRef, StrictMode, useRef } from 'react';
 import { renderToString } from 'react-dom/server';
 import {
   WalletManager,
+  MemoryStorageAdapter,
   STANDARD_NETWORKS,
   createWalletError,
   type WalletAdapter,
@@ -122,6 +123,42 @@ describe('XrplConnectProvider + hooks', () => {
 
     await waitFor(() => expect(storage.get).toHaveBeenCalledTimes(1));
   });
+
+  it.each([false, true])(
+    'recovers returned authorization only with autoConnect=%s or an explicit call',
+    async (autoConnect) => {
+      const adapter = {
+        ...makeAdapter(),
+        hasPendingConnection: vi.fn(() => true),
+        connect: vi.fn(async () => ACCOUNT),
+      };
+      const { result, unmount } = renderHook(() => useWallet(), {
+        wrapper: ({ children }) => (
+          <StrictMode>
+            <XrplConnectProvider
+              config={{ adapters: [adapter], autoConnect, storage: new MemoryStorageAdapter() }}
+            >
+              {children}
+            </XrplConnectProvider>
+          </StrictMode>
+        ),
+      });
+
+      if (!autoConnect) {
+        await act(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+        expect(result.current.connected).toBe(false);
+        expect(adapter.hasPendingConnection).not.toHaveBeenCalled();
+        await act(async () => {
+          await result.current.manager.reconnect();
+        });
+      }
+      await waitFor(() => expect(result.current.connected).toBe(true));
+      expect(adapter.connect).toHaveBeenCalledOnce();
+      unmount();
+    }
+  );
 
   it('tracks auto-connect without surfacing an expected manual overlap error', async () => {
     const storedState = deferred<string | null>();

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -913,7 +913,10 @@ Benefits of CSS variables:
 
 5. **Close Modal on Success**: Use the `close()` method or auto-close on successful connection
 
-6. **Persist Connection**: Use `autoConnect: true` in WalletManager to remember the user's wallet
+6. **Persist Connection**: Use `autoConnect: true` in `WalletManager` to remember the user's wallet.
+   The connector follows the manager's policy: with `autoConnect` omitted or `false`, mounting or
+   replacing the element does not restore a session. Call `walletManager.reconnect()` when an
+   explicit restore is needed.
 
 7. **Show Network Info**: Display the connected network to the user from `walletManager.account.network`
 

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -4,12 +4,12 @@
  * Defines a typed surface for the host web component (`WalletConnectorContext`)
  * so services can depend on a stable interface instead of casting through `any`,
  * plus UI-specific capability interfaces for optional adapter methods
- * (`checkXamanState`, `getAccounts`) that aren't part of the base
- * `WalletAdapter` contract. Generic capabilities (`SupportsPreInitialize`,
+ * (`getAccounts`) that aren't part of the base `WalletAdapter` contract.
+ * Generic capabilities (`SupportsPreInitialize`,
  * `SupportsDeepLink`) live in `@xrpl-connect/core`.
  */
 
-import type { AccountInfo, WalletAdapter, WalletManager } from '@xrpl-connect/core';
+import type { WalletAdapter, WalletManager } from '@xrpl-connect/core';
 
 /**
  * A single derived account returned by Ledger's `getAccounts`.
@@ -115,13 +115,6 @@ export interface WalletConnectAdapterLikeOptions {
 }
 
 /**
- * Adapter capability: Xaman-style session state probe used for silent reconnect.
- */
-export interface XamanStateAdapter {
-  checkXamanState(): Promise<AccountInfo | null>;
-}
-
-/**
  * Adapter capability: Ledger-style multi-account enumeration.
  */
 export interface MultiAccountAdapter {
@@ -134,12 +127,6 @@ export interface MultiAccountAdapter {
  */
 export interface ModalConfigurableAdapter {
   options?: WalletConnectAdapterLikeOptions;
-}
-
-export function isXamanStateAdapter(
-  adapter: WalletAdapter
-): adapter is WalletAdapter & XamanStateAdapter {
-  return typeof (adapter as Partial<XamanStateAdapter>).checkXamanState === 'function';
 }
 
 export function isMultiAccountAdapter(

--- a/packages/ui/src/wallet-connector.ts
+++ b/packages/ui/src/wallet-connector.ts
@@ -39,7 +39,6 @@ import {
 import { replaceViewChildren } from './views/dom';
 import { WalletService, EventHandler, type CancelledConnectionAttempt } from './services';
 import {
-  isXamanStateAdapter,
   type AccountSelectionData,
   type ErrorData,
   type LedgerAccount,
@@ -113,7 +112,6 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
     private isOpen = false;
     private openGeneration = 0;
     private managerGeneration = 0;
-    private xamanProbeGeneration = 0;
     private preInitializationGeneration = 0;
     private isFirstOpen = true;
     private primaryWalletId: string | null = null;
@@ -147,7 +145,6 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
     private bodyScrollLocked = false;
     private walletManagerHandlers: {
       connect: (account: AccountInfo) => void;
-      disconnecting: () => void;
       disconnect: () => void;
       accountChanged: () => void;
     } | null = null;
@@ -170,7 +167,6 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
     connectedCallback() {
       this.attachWalletManagerHandlers();
       this.render();
-      void this.checkXamanStateOnInit();
 
       // Update derived colors on initial load
       requestAnimationFrame(() => this.updateDerivedColors());
@@ -191,7 +187,6 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
       const cancelledAttempt = this.cancelPendingConnection();
       this.openGeneration += 1;
       this.managerGeneration += 1;
-      this.xamanProbeGeneration += 1;
       this.isOpen = false;
       this.accountModalOpen = false;
       this.invalidateWalletConnectPreInitialization(
@@ -324,14 +319,12 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
       if (manager === this.walletManager) {
         this.attachWalletManagerHandlers();
         this.render();
-        void this.checkXamanStateOnInit();
         return;
       }
 
       const previousManager = this.walletManager;
       const cancelledAttempt = this.walletService?.cancelPendingWork() ?? null;
       this.managerGeneration += 1;
-      this.xamanProbeGeneration += 1;
       this.invalidateWalletConnectPreInitialization(
         !this.managerOwnsPreInitializationTeardown(cancelledAttempt)
       );
@@ -361,8 +354,6 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
       } else {
         this.render();
       }
-
-      void this.checkXamanStateOnInit();
     }
 
     private attachWalletManagerHandlers(): void {
@@ -383,18 +374,8 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
           if (connectedId) this.recordMruId(connectedId);
           this.close();
         },
-        disconnecting: () => {
-          if (manager !== this.walletManager) return;
-          // Explicit disconnect cancels silent restoration even when there is
-          // no committed session and no later disconnect event to observe.
-          this.xamanProbeGeneration += 1;
-        },
         disconnect: () => {
           if (manager !== this.walletManager) return;
-          // A manager disconnect can complete while the silent Xaman probe is
-          // awaiting the adapter. Invalidate that probe before it can restore
-          // the session that the caller explicitly disconnected.
-          this.xamanProbeGeneration += 1;
           if (this.accountModalOpen) this.closeAccountModal();
           else this.render();
         },
@@ -404,7 +385,6 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
       };
 
       manager.on('connect', this.walletManagerHandlers.connect);
-      manager.on('disconnecting', this.walletManagerHandlers.disconnecting);
       manager.on('disconnect', this.walletManagerHandlers.disconnect);
       manager.on('accountChanged', this.walletManagerHandlers.accountChanged);
     }
@@ -412,7 +392,6 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
     private detachWalletManagerHandlers(): void {
       if (!this.walletManager || !this.walletManagerHandlers) return;
       this.walletManager.off('connect', this.walletManagerHandlers.connect);
-      this.walletManager.off('disconnecting', this.walletManagerHandlers.disconnecting);
       this.walletManager.off('disconnect', this.walletManagerHandlers.disconnect);
       this.walletManager.off('accountChanged', this.walletManagerHandlers.accountChanged);
       this.walletManagerHandlers = null;
@@ -428,51 +407,6 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
       const waiters = Array.from(this.connectionWaiters);
       this.connectionWaiters.clear();
       for (const waiter of waiters) waiter.reject(error);
-    }
-
-    /**
-     * Check for existing Xaman authentication on page load
-     */
-    private async checkXamanStateOnInit() {
-      const manager = this.walletManager;
-      if (!manager) return;
-      // There is no session to restore while this manager is already connected.
-      // More importantly, this prevents a probe started during an existing
-      // session from racing an explicit disconnect before its event arrives.
-      if (manager.connected) return;
-      const managerGeneration = this.managerGeneration;
-      const probeGeneration = ++this.xamanProbeGeneration;
-      try {
-        const xamanAdapter = manager.adapters.get('xaman');
-        if (
-          !xamanAdapter ||
-          !isXamanStateAdapter(xamanAdapter) ||
-          !isAdapterConfigured(xamanAdapter)
-        ) {
-          return;
-        }
-
-        const account = await xamanAdapter.checkXamanState();
-        if (
-          account &&
-          this.isConnected &&
-          probeGeneration === this.xamanProbeGeneration &&
-          managerGeneration === this.managerGeneration &&
-          manager === this.walletManager &&
-          manager.adapters.get('xaman') === xamanAdapter &&
-          !manager.connected
-        ) {
-          await manager.connect('xaman');
-        }
-      } catch (err) {
-        if (
-          probeGeneration === this.xamanProbeGeneration &&
-          managerGeneration === this.managerGeneration &&
-          manager === this.walletManager
-        ) {
-          console.error('Failed to check Xaman state:', err);
-        }
-      }
     }
 
     /**

--- a/packages/ui/tests/WalletConnector.test.ts
+++ b/packages/ui/tests/WalletConnector.test.ts
@@ -130,6 +130,34 @@ describe('WalletConnector wallet availability', () => {
     expect(xaman.connect).toHaveBeenCalledOnce();
   });
 
+  it.each([undefined, false, true])(
+    'honors autoConnect=%s for an OAuth return without manager storage',
+    async (autoConnect) => {
+      const xaman = {
+        ...createConfiguredXamanAdapter(),
+        hasPendingConnection: vi.fn(() => true),
+      };
+      const manager = new WalletManager({
+        adapters: [xaman],
+        autoConnect,
+        storage: new MemoryStorageAdapter(),
+      });
+      element = createElement(manager);
+      document.body.appendChild(element);
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(manager.connected).toBe(autoConnect === true);
+      expect(xaman.connect).toHaveBeenCalledTimes(autoConnect ? 1 : 0);
+      expect(xaman.checkXamanState).not.toHaveBeenCalled();
+      if (!autoConnect) {
+        expect(xaman.hasPendingConnection).not.toHaveBeenCalled();
+        await expect(manager.reconnect()).resolves.toMatchObject({ address: 'rXamanSession' });
+        expect(xaman.connect).toHaveBeenCalledOnce();
+      }
+    }
+  );
+
   it('cancels a pending wallet selection before returning to the wallet list', async () => {
     const walletConnect = createAdapter(
       'walletconnect',

--- a/packages/ui/tests/WalletConnector.test.ts
+++ b/packages/ui/tests/WalletConnector.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
-import { MemoryStorageAdapter, TIME, WalletManager } from '@xrpl-connect/core';
+import { MemoryStorageAdapter, Storage, TIME, WalletManager } from '@xrpl-connect/core';
 import type { NetworkInfo, WalletAdapter } from '@xrpl-connect/core';
 import '../src/wallet-connector';
 import { COLOR_ADJUSTMENT, TIMINGS } from '../src/constants';
@@ -54,6 +54,20 @@ function createAdapter(
   };
 }
 
+function createConfiguredXamanAdapter(address = 'rXamanSession') {
+  const account = { address, network: NETWORK };
+  return {
+    ...createAdapter(
+      'xaman',
+      'Xaman',
+      vi.fn(async () => true)
+    ),
+    getMissingConfiguration: vi.fn(() => []),
+    checkXamanState: vi.fn(async () => account),
+    connect: vi.fn(async () => account),
+  };
+}
+
 function createElement(manager: WalletManager) {
   const element = document.createElement('xrpl-wallet-connector') as HTMLElement & {
     setWalletManager(manager: WalletManager): void;
@@ -87,22 +101,33 @@ describe('WalletConnector wallet availability', () => {
     vi.useRealTimers();
   });
 
-  it('does not probe Xaman session state without constructor configuration', async () => {
-    const xaman = {
-      ...createAdapter(
-        'xaman',
-        'Xaman',
-        vi.fn(async () => true)
-      ),
-      getMissingConfiguration: vi.fn(() => ['apiKey']),
-      checkXamanState: vi.fn(async () => null),
-    };
+  it.each([
+    ['omitted', {}],
+    ['false', { autoConnect: false }],
+  ] as const)('does not restore Xaman on mount when autoConnect is %s', async (_label, options) => {
+    const xaman = createConfiguredXamanAdapter();
+    const manager = new WalletManager({ adapters: [xaman], ...options });
+    element = createElement(manager);
+    document.body.appendChild(element);
 
-    element = createElement(new WalletManager({ adapters: [xaman] }));
+    await vi.advanceTimersByTimeAsync(0);
     await Promise.resolve();
 
-    expect(xaman.getMissingConfiguration).toHaveBeenCalledWith(undefined);
     expect(xaman.checkXamanState).not.toHaveBeenCalled();
+    expect(xaman.connect).not.toHaveBeenCalled();
+    expect(manager.connected).toBe(false);
+  });
+
+  it('keeps explicit Xaman connect functional when autoConnect is disabled', async () => {
+    const xaman = createConfiguredXamanAdapter();
+    const manager = new WalletManager({ adapters: [xaman], autoConnect: false });
+    element = createElement(manager);
+    document.body.appendChild(element);
+
+    await expect(manager.connect('xaman')).resolves.toMatchObject({ address: 'rXamanSession' });
+
+    expect(xaman.checkXamanState).not.toHaveBeenCalled();
+    expect(xaman.connect).toHaveBeenCalledOnce();
   });
 
   it('cancels a pending wallet selection before returning to the wallet list', async () => {
@@ -410,84 +435,61 @@ describe('WalletConnector wallet availability', () => {
     }
   });
 
-  it('ignores a Xaman state probe after the wallet manager is replaced', async () => {
-    let resolveState!: (account: { address: string; network: NetworkInfo }) => void;
-    const state = new Promise<{ address: string; network: NetworkInfo }>((resolve) => {
-      resolveState = resolve;
-    });
-    const xaman = {
-      ...createAdapter(
-        'xaman',
-        'Xaman',
-        vi.fn(async () => true)
-      ),
-      getMissingConfiguration: vi.fn(() => []),
-      checkXamanState: vi.fn(() => state),
-    };
-    const firstManager = new WalletManager({ adapters: [xaman] });
-    const replacementManager = new WalletManager({ adapters: [] });
+  it('does not restore Xaman when the wallet manager is replaced', async () => {
+    const firstXaman = createConfiguredXamanAdapter('rFirstXaman');
+    const secondXaman = createConfiguredXamanAdapter('rSecondXaman');
+    const firstManager = new WalletManager({ adapters: [firstXaman], autoConnect: false });
+    const replacementManager = new WalletManager({ adapters: [secondXaman], autoConnect: false });
     element = createElement(firstManager);
     document.body.appendChild(element);
-    element.setWalletManager(firstManager);
-    await vi.waitFor(() => expect(xaman.checkXamanState).toHaveBeenCalled());
-
     element.setWalletManager(replacementManager);
-    resolveState({ address: 'rStaleXaman', network: NETWORK });
-    await vi.advanceTimersByTimeAsync(0);
 
-    expect(xaman.connect).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(0);
+    await Promise.resolve();
+
+    expect(firstXaman.checkXamanState).not.toHaveBeenCalled();
+    expect(secondXaman.checkXamanState).not.toHaveBeenCalled();
+    expect(firstXaman.connect).not.toHaveBeenCalled();
+    expect(secondXaman.connect).not.toHaveBeenCalled();
     expect(replacementManager.connected).toBe(false);
   });
 
-  it('retries a detached Xaman state probe when the element is connected', async () => {
-    const xaman = {
-      ...createAdapter(
-        'xaman',
-        'Xaman',
-        vi.fn(async () => true)
-      ),
-      connect: vi.fn(async () => ({ address: 'rXamanSession', network: NETWORK })),
-      getMissingConfiguration: vi.fn(() => []),
-      checkXamanState: vi.fn(async () => ({ address: 'rXamanSession', network: NETWORK })),
-    };
-    const manager = new WalletManager({ adapters: [xaman] });
+  it('restores a persisted Xaman session only through explicit manager.reconnect', async () => {
+    const storage = new MemoryStorageAdapter();
+    await new Storage(storage).saveState({
+      walletId: 'xaman',
+      account: { address: 'rStoredXaman', network: NETWORK },
+      network: NETWORK,
+      timestamp: Date.now(),
+    });
+    const xaman = createConfiguredXamanAdapter('rStoredXaman');
+    const manager = new WalletManager({ adapters: [xaman], autoConnect: false, storage });
     element = createElement(manager);
-
-    await vi.advanceTimersByTimeAsync(0);
-    expect(manager.connected).toBe(false);
     document.body.appendChild(element);
-    await vi.waitFor(() => expect(manager.connected).toBe(true));
 
-    expect(xaman.checkXamanState).toHaveBeenCalledTimes(2);
+    await expect(manager.reconnect()).resolves.toMatchObject({ address: 'rStoredXaman' });
+
+    expect(xaman.checkXamanState).not.toHaveBeenCalled();
     expect(xaman.connect).toHaveBeenCalledOnce();
   });
 
-  it('does not reconnect Xaman after the manager is explicitly disconnected', async () => {
-    let resolveState!: (account: { address: string; network: NetworkInfo }) => void;
-    const state = new Promise<{ address: string; network: NetworkInfo }>((resolve) => {
-      resolveState = resolve;
+  it('preserves manager autoConnect restoration for Xaman without a UI probe', async () => {
+    const storage = new MemoryStorageAdapter();
+    await new Storage(storage).saveState({
+      walletId: 'xaman',
+      account: { address: 'rAutoXaman', network: NETWORK },
+      network: NETWORK,
+      timestamp: Date.now(),
     });
-    const xaman = {
-      ...createAdapter(
-        'xaman',
-        'Xaman',
-        vi.fn(async () => true)
-      ),
-      getMissingConfiguration: vi.fn(() => []),
-      checkXamanState: vi.fn(() => state),
-    };
-    const manager = new WalletManager({ adapters: [xaman] });
+    const xaman = createConfiguredXamanAdapter('rAutoXaman');
+    const manager = new WalletManager({ adapters: [xaman], autoConnect: true, storage });
     element = createElement(manager);
     document.body.appendChild(element);
 
-    await vi.waitFor(() => expect(xaman.checkXamanState).toHaveBeenCalled());
-    await manager.disconnect();
+    await vi.waitFor(() => expect(manager.connected).toBe(true));
 
-    resolveState({ address: 'rStaleXaman', network: NETWORK });
-    await vi.advanceTimersByTimeAsync(0);
-
-    expect(xaman.connect).not.toHaveBeenCalled();
-    expect(manager.connected).toBe(false);
+    expect(xaman.checkXamanState).not.toHaveBeenCalled();
+    expect(xaman.connect).toHaveBeenCalledOnce();
   });
 
   it('does not disconnect a manager-owned WalletConnect session when closing the modal', async () => {

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -62,6 +62,10 @@ See the [CSP policy, nonce lifecycle, and wallet-specific limits](https://github
 ## API
 
 - `createXrplConnect(config)` creates the app plugin and one isolated manager per installation.
+- The plugin owns persisted-session restoration and calls `reconnect()` only when
+  `config.autoConnect` is `true`; mounting `<WalletConnector>` does not restore a session by
+  itself. Use `useWallet().manager.reconnect()` for an explicit restore when automatic restoration
+  is disabled.
 - `useWallet()` exposes `manager`, readonly `connected`, `account`, `network`, `connecting`,
   and `error` refs, plus `connect` and `disconnect`.
 - `useSigner()` exposes `sign`, `signAndSubmit`, and `signMessage`.

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -65,7 +65,8 @@ See the [CSP policy, nonce lifecycle, and wallet-specific limits](https://github
 - The plugin owns persisted-session restoration and calls `reconnect()` only when
   `config.autoConnect` is `true`; mounting `<WalletConnector>` does not restore a session by
   itself. Use `useWallet().manager.reconnect()` for an explicit restore when automatic restoration
-  is disabled.
+  is disabled. Reconnection also completes a returned Xaman OAuth login before the first manager
+  session has been saved.
 - `useWallet()` exposes `manager`, readonly `connected`, `account`, `network`, `connecting`,
   and `error` refs, plus `connect` and `disconnect`.
 - `useSigner()` exposes `sign`, `signAndSubmit`, and `signMessage`.

--- a/packages/vue/tests/vue.test.ts
+++ b/packages/vue/tests/vue.test.ts
@@ -181,6 +181,40 @@ describe('Vue plugin and composables', () => {
     expect(wallet!.manager.listenerCount('connect')).toBe(0);
   });
 
+  it.each([false, true])(
+    'recovers returned authorization only with autoConnect=%s or an explicit call',
+    async (autoConnect) => {
+      const adapter = {
+        ...makeAdapter(),
+        hasPendingConnection: vi.fn(() => true),
+        connect: vi.fn(async () => ACCOUNT),
+      };
+      let wallet!: ReturnType<typeof useWallet>;
+      const app = createApp(
+        defineComponent({
+          setup() {
+            wallet = useWallet();
+            return () => null;
+          },
+        })
+      );
+      app.use(
+        createXrplConnect({ adapters: [adapter], autoConnect, storage: new MemoryStorageAdapter() })
+      );
+      app.mount(document.createElement('div'));
+
+      if (!autoConnect) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(wallet.connected.value).toBe(false);
+        expect(adapter.hasPendingConnection).not.toHaveBeenCalled();
+        await wallet.manager.reconnect();
+      }
+      await vi.waitFor(() => expect(wallet.connected.value).toBe(true));
+      expect(adapter.connect).toHaveBeenCalledOnce();
+      app.unmount();
+    }
+  );
+
   it('disconnects its owned manager when the app unmounts', async () => {
     const disconnect = vi.fn(async () => undefined);
     const mounted = mountWithPlugin(() => useWallet(), [makeAdapter({ disconnect })]);

--- a/packages/xrpl-connect/README.md
+++ b/packages/xrpl-connect/README.md
@@ -137,6 +137,7 @@ export {
   ManagedSignedMessage,
   WalletCapabilities,
   SupportsFetchAccount,
+  SupportsPendingConnection,
   WalletEvent,
   WalletAdapterEvent,
   ConnectOptions,
@@ -154,6 +155,7 @@ export {
   // Capability helpers
   adapterSupports,
   supportsFetchAccount,
+  supportsPendingConnection,
 };
 ```
 


### PR DESCRIPTION
Mounting or replacing `<xrpl-wallet-connector>` could restore a Xaman session even with `autoConnect: false`. Remove the component's separate Xaman restoration path so `WalletManager` and the React/Vue lifecycle own reconnection. Explicit `connect()` and `reconnect()`, and `autoConnect: true`, keep working.

Preserve first-time mobile OAuth completion when the returned page has no manager session stored yet. A passive `SupportsPendingConnection` adapter capability lets `reconnect()` recognize a successful Xaman callback and use the existing connection pipeline for validation, persistence, events, and cancellation. Ordinary page loads and rejected-return URLs stay idle; stored sessions retain priority.

Regression coverage exercises omitted/false/enabled auto-connect, manager replacement, explicit recovery, empty storage, configuration and network checks, cancellation, competing adapters, and React/Vue lifecycle behavior. The new recovery tests failed before the fix. Documentation explains reconnection ownership and OAuth return recovery.

Validation on Node 24.11.0 / pnpm 10.18.3:

- Uncached workspace build, including documentation and examples.
- 890 unit tests and 20 release-tooling tests passed.
- 20 Chromium browser tests passed.
- Formatting/lint and UI, React, and Vue TypeScript checks passed.
- Real installed Xumm SDK callback smoke test with only the userinfo HTTP response stubbed: connected, session persisted, callback URL consumed, and no popup opened. No live wallet interaction was performed.
