### PR TITLE
fix(ui): emit connected before closing the wallet modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- UI: emit the public `connected` event before closing the connector after a successful wallet, WalletConnect, or Ledger connection.
 - Ledger: close the XRPL client when connection-time network discovery fails, including the stricter `server_info` validation introduced in xrpl.js v5.
 
 ## [1.0.0-rc.2] - 2026-09-08

--- a/docs/guide/api-reference.md
+++ b/docs/guide/api-reference.md
@@ -288,6 +288,7 @@ connector.addEventListener('connecting', (e) => {
 #### connected
 
 Emitted when successfully connected.
+For UI-owned connections, this event is dispatched before the connector closes the modal.
 
 ```javascript
 connector.addEventListener('connected', (e) => {

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -251,6 +251,7 @@ connector.addEventListener('connecting', (e) => {
 ### `connected` Event
 
 Emitted when the user successfully connects to a wallet.
+For UI-owned connections, this event is dispatched before the connector closes the modal.
 
 ```typescript
 connector.addEventListener('connected', (e) => {

--- a/packages/ui/src/services/WalletService.ts
+++ b/packages/ui/src/services/WalletService.ts
@@ -71,9 +71,19 @@ export interface CancelledConnectionAttempt {
   managerConnectionStarted: boolean;
 }
 
+export interface SuccessfulConnectionAttempt {
+  connectionAttemptId: number;
+  walletId: string;
+  detail: Record<string, unknown>;
+}
+
+interface ActiveConnectionAttempt extends CancelledConnectionAttempt {
+  detail: Record<string, unknown>;
+}
+
 export class WalletService {
   private nextConnectionAttemptId = 0;
-  private activeConnectionAttempt: CancelledConnectionAttempt | null = null;
+  private activeConnectionAttempt: ActiveConnectionAttempt | null = null;
 
   constructor(
     private walletManager: WalletManager,
@@ -93,22 +103,49 @@ export class WalletService {
   }
 
   cancelPendingWork(): CancelledConnectionAttempt | null {
-    const cancelledAttempt = this.activeConnectionAttempt;
+    const activeAttempt = this.activeConnectionAttempt;
     this.activeConnectionAttempt = null;
     this.nextConnectionAttemptId += 1;
-    return cancelledAttempt;
+    return activeAttempt
+      ? {
+          connectionAttemptId: activeAttempt.connectionAttemptId,
+          walletId: activeAttempt.walletId,
+          managerConnectionStarted: activeAttempt.managerConnectionStarted,
+        }
+      : null;
+  }
+
+  settleManagerConnection(walletId: string): SuccessfulConnectionAttempt | null {
+    const activeAttempt = this.activeConnectionAttempt;
+    if (
+      !activeAttempt ||
+      !activeAttempt.managerConnectionStarted ||
+      activeAttempt.walletId !== walletId ||
+      !this.isCurrentAttempt(activeAttempt.connectionAttemptId)
+    ) {
+      return null;
+    }
+
+    this.activeConnectionAttempt = null;
+    this.nextConnectionAttemptId += 1;
+    return {
+      connectionAttemptId: activeAttempt.connectionAttemptId,
+      walletId: activeAttempt.walletId,
+      detail: activeAttempt.detail,
+    };
   }
 
   private isCurrentAttempt(connectionAttemptId: number): boolean {
     return connectionAttemptId === this.nextConnectionAttemptId;
   }
 
-  private beginConnectionAttempt(walletId: string): number {
+  private beginConnectionAttempt(walletId: string, detail: Record<string, unknown> = {}): number {
     const connectionAttemptId = ++this.nextConnectionAttemptId;
     this.activeConnectionAttempt = {
       connectionAttemptId,
       walletId,
       managerConnectionStarted: false,
+      detail,
     };
     return connectionAttemptId;
   }
@@ -334,7 +371,7 @@ export class WalletService {
     if (!this.walletManager || !this.component.accountSelectionData) return;
 
     const { walletId, walletName, walletIcon } = this.component.accountSelectionData;
-    const uiAttempt = this.beginConnectionAttempt(walletId);
+    const uiAttempt = this.beginConnectionAttempt(walletId, { accountIndex });
     const connectionAttemptId = uiAttempt;
 
     try {
@@ -392,7 +429,7 @@ export class WalletService {
     if (!this.walletManager || !this.component.accountSelectionData) return;
 
     const { walletId, walletName, walletIcon } = this.component.accountSelectionData;
-    const uiAttempt = this.beginConnectionAttempt(walletId);
+    const uiAttempt = this.beginConnectionAttempt(walletId, { derivationPath });
     const connectionAttemptId = uiAttempt;
 
     try {

--- a/packages/ui/src/wallet-connector.ts
+++ b/packages/ui/src/wallet-connector.ts
@@ -378,10 +378,28 @@ if (typeof window !== 'undefined' && typeof HTMLElement !== 'undefined') {
           this.invalidateWalletConnectPreInitialization(
             manager.wallet !== this.preInitializationAdapter
           );
-          this.resolveConnectionWaiters(account);
+          const connectedOpenGeneration = this.openGeneration;
           const connectedId = manager.wallet?.id;
+          const settledAttempt = connectedId
+            ? this.walletService?.settleManagerConnection(connectedId)
+            : null;
+          this.resolveConnectionWaiters(account);
           if (connectedId) this.recordMruId(connectedId);
-          this.close();
+          if (settledAttempt) {
+            this.dispatchEvent(
+              new CustomEvent('connected', {
+                detail: {
+                  walletId: settledAttempt.walletId,
+                  ...settledAttempt.detail,
+                  connectionAttemptId: settledAttempt.connectionAttemptId,
+                },
+              })
+            );
+          }
+          if (this.openGeneration === connectedOpenGeneration && manager === this.walletManager) {
+            if (this.isOpen) this.close();
+            else this.render();
+          }
         },
         disconnecting: () => {
           if (manager !== this.walletManager) return;

--- a/packages/ui/tests/WalletConnector.test.ts
+++ b/packages/ui/tests/WalletConnector.test.ts
@@ -698,6 +698,299 @@ describe('WalletConnector wallet availability', () => {
     await connection;
   });
 
+  it('emits connected before closing a real UI-owned manager connection', async () => {
+    const adapter = createAdapter(
+      'wallet',
+      'Wallet',
+      vi.fn(async () => true)
+    );
+    adapter.connect = vi.fn(async () => ({ address: 'rConnected', network: NETWORK }));
+    const manager = new WalletManager({
+      adapters: [adapter],
+      storage: new MemoryStorageAdapter(),
+    });
+    element = createElement(manager);
+    document.body.appendChild(element);
+
+    const events: string[] = [];
+    let connectedDetail: Record<string, unknown> | undefined;
+    element.addEventListener('connecting', () => events.push('connecting'));
+    element.addEventListener('connected', (event) => {
+      events.push('connected');
+      connectedDetail = (event as CustomEvent<Record<string, unknown>>).detail;
+    });
+    element.addEventListener('close', () => events.push('close'));
+
+    await element.open();
+    const walletButton = element
+      .getOverlayRoot()
+      ?.querySelector<HTMLButtonElement>('[data-wallet-id="wallet"]');
+    expect(walletButton).not.toBeNull();
+    walletButton!.click();
+
+    await vi.advanceTimersByTimeAsync(TIMINGS.NON_SAFARI_CONNECT_DELAY);
+    await vi.waitFor(() => expect(manager.connected).toBe(true));
+
+    expect(events.filter((event) => event === 'connected')).toHaveLength(1);
+    expect(events.indexOf('connected')).toBeLessThan(events.indexOf('close'));
+    expect(connectedDetail).toEqual({
+      walletId: 'wallet',
+      connectionAttemptId: expect.any(Number),
+    });
+  });
+
+  it('resolves openAndWait before a connected listener closes the connector', async () => {
+    const adapter = createAdapter(
+      'wallet',
+      'Wallet',
+      vi.fn(async () => true)
+    );
+    adapter.connect = vi.fn(async () => ({ address: 'rConnected', network: NETWORK }));
+    const manager = new WalletManager({ adapters: [adapter] });
+    element = createElement(manager);
+
+    const events: string[] = [];
+    element.addEventListener('connected', () => {
+      events.push('connected');
+      element!.close();
+    });
+    element.addEventListener('close', () => events.push('close'));
+
+    await element.open();
+    const connection = (
+      element as unknown as {
+        openAndWait(): Promise<{ address: string; network: NetworkInfo }>;
+      }
+    ).openAndWait();
+    await vi.waitFor(() =>
+      expect(
+        element.getOverlayRoot()?.querySelector<HTMLButtonElement>('[data-wallet-id="wallet"]')
+      ).not.toBeNull()
+    );
+    element
+      .getOverlayRoot()
+      ?.querySelector<HTMLButtonElement>('[data-wallet-id="wallet"]')
+      ?.click();
+
+    await vi.advanceTimersByTimeAsync(TIMINGS.NON_SAFARI_CONNECT_DELAY);
+    await vi.waitFor(() => expect(manager.connected).toBe(true));
+    await expect(connection).resolves.toMatchObject({ address: 'rConnected' });
+    expect(events).toEqual(['connected', 'close']);
+  });
+
+  it('does not close a replacement manager after a connected listener rebinds it', async () => {
+    const adapter = createAdapter(
+      'wallet',
+      'Wallet',
+      vi.fn(async () => true)
+    );
+    adapter.connect = vi.fn(async () => ({ address: 'rConnected', network: NETWORK }));
+    const manager = new WalletManager({ adapters: [adapter] });
+    const replacementManager = new WalletManager({ adapters: [] });
+    element = createElement(manager);
+
+    const onClose = vi.fn();
+    element.addEventListener('connected', () => element!.setWalletManager(replacementManager));
+    element.addEventListener('close', onClose);
+
+    await element.open();
+    element
+      .getOverlayRoot()
+      ?.querySelector<HTMLButtonElement>('[data-wallet-id="wallet"]')
+      ?.click();
+    await vi.waitFor(() => expect(manager.connected).toBe(true));
+
+    expect(element.walletManager).toBe(replacementManager);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('refreshes the closed connector after an external manager connection', async () => {
+    const adapter = createAdapter(
+      'wallet',
+      'Wallet',
+      vi.fn(async () => true)
+    );
+    adapter.connect = vi.fn(async () => ({ address: 'rExternal', network: NETWORK }));
+    const manager = new WalletManager({ adapters: [adapter] });
+    element = createElement(manager);
+
+    const onConnected = vi.fn();
+    const onClose = vi.fn();
+    element.addEventListener('connected', onConnected);
+    element.addEventListener('close', onClose);
+    const getConnectButton = () =>
+      element.shadowRoot?.querySelector<HTMLButtonElement>('#connect-wallet-button');
+    expect(getConnectButton()?.textContent).toBe('Connect Wallet');
+
+    await manager.connect('wallet');
+
+    expect(onConnected).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(getConnectButton()?.textContent).toBe('rExt...rnal');
+  });
+
+  it('emits connected before closing a WalletConnect desktop connection', async () => {
+    const walletConnect = {
+      ...createAdapter(
+        'walletconnect',
+        'WalletConnect',
+        vi.fn(async () => true)
+      ),
+      options: { useModal: false, modalMode: 'never' as const },
+      connect: vi.fn(async () => ({ address: 'rWalletConnectDesktop', network: NETWORK })),
+    };
+    const manager = new WalletManager({ adapters: [walletConnect] });
+    element = createElement(manager);
+
+    const events: string[] = [];
+    let connectedDetail: Record<string, unknown> | undefined;
+    element.addEventListener('connected', (event) => {
+      events.push('connected');
+      connectedDetail = (event as CustomEvent<Record<string, unknown>>).detail;
+    });
+    element.addEventListener('close', () => events.push('close'));
+
+    await element.open();
+    element
+      .getOverlayRoot()
+      ?.querySelector<HTMLButtonElement>('[data-wallet-id="walletconnect"]')
+      ?.click();
+    await vi.waitFor(() => expect(manager.connected).toBe(true));
+
+    expect(events).toEqual(['connected', 'close']);
+    expect(connectedDetail).toEqual({
+      walletId: 'walletconnect',
+      connectionAttemptId: expect.any(Number),
+    });
+  });
+
+  it('emits connected before closing a WalletConnect mobile modal connection', async () => {
+    const walletConnect = {
+      ...createAdapter(
+        'walletconnect',
+        'WalletConnect',
+        vi.fn(async () => true)
+      ),
+      options: { useModal: true, modalMode: 'always' as const },
+      connect: vi.fn(async () => ({ address: 'rWalletConnectMobile', network: NETWORK })),
+    };
+    const manager = new WalletManager({ adapters: [walletConnect] });
+    element = createElement(manager);
+
+    const events: string[] = [];
+    let connectedDetail: Record<string, unknown> | undefined;
+    element.addEventListener('connected', (event) => {
+      events.push('connected');
+      connectedDetail = (event as CustomEvent<Record<string, unknown>>).detail;
+    });
+    element.addEventListener('close', () => events.push('close'));
+
+    await element.open();
+    element
+      .getOverlayRoot()
+      ?.querySelector<HTMLButtonElement>('[data-wallet-id="walletconnect"]')
+      ?.click();
+    await vi.advanceTimersByTimeAsync(TIMINGS.NON_SAFARI_CONNECT_DELAY);
+    await vi.waitFor(() => expect(manager.connected).toBe(true));
+
+    expect(events).toEqual(['connected', 'close']);
+    expect(connectedDetail).toEqual({
+      walletId: 'walletconnect',
+      connectionAttemptId: expect.any(Number),
+    });
+  });
+
+  it('emits the account index when a Ledger account connection settles', async () => {
+    const ledger = {
+      ...createAdapter(
+        'ledger',
+        'Ledger',
+        vi.fn(async () => true)
+      ),
+      getAccounts: vi.fn(async () => [
+        { address: 'rLedger0', publicKey: 'ED0', path: "44'/144'/0'/0/0", index: 0 },
+      ]),
+      connect: vi.fn(async () => ({ address: 'rLedger0', network: NETWORK })),
+    };
+    const manager = new WalletManager({ adapters: [ledger] });
+    element = createElement(manager);
+
+    const events: string[] = [];
+    let connectedDetail: Record<string, unknown> | undefined;
+    element.addEventListener('connected', (event) => {
+      events.push('connected');
+      connectedDetail = (event as CustomEvent<Record<string, unknown>>).detail;
+    });
+    element.addEventListener('close', () => events.push('close'));
+
+    await element.open();
+    element
+      .getOverlayRoot()
+      ?.querySelector<HTMLButtonElement>('[data-wallet-id="ledger"]')
+      ?.click();
+    await vi.advanceTimersByTimeAsync(TIMINGS.NON_SAFARI_CONNECT_DELAY);
+    await vi.waitFor(() => expect(ledger.getAccounts).toHaveBeenCalledOnce());
+    element.getOverlayRoot()?.querySelector<HTMLButtonElement>('.account-button')?.click();
+    await vi.advanceTimersByTimeAsync(TIMINGS.NON_SAFARI_CONNECT_DELAY);
+    await vi.waitFor(() => expect(manager.connected).toBe(true));
+
+    expect(events).toEqual(['connected', 'close']);
+    expect(connectedDetail).toEqual({
+      walletId: 'ledger',
+      accountIndex: 0,
+      connectionAttemptId: expect.any(Number),
+    });
+  });
+
+  it('emits the derivation path when a custom Ledger connection settles', async () => {
+    const ledger = {
+      ...createAdapter(
+        'ledger',
+        'Ledger',
+        vi.fn(async () => true)
+      ),
+      getAccounts: vi.fn(async () => []),
+      connect: vi.fn(async () => ({ address: 'rLedgerCustom', network: NETWORK })),
+    };
+    const manager = new WalletManager({ adapters: [ledger] });
+    element = createElement(manager);
+
+    const events: string[] = [];
+    let connectedDetail: Record<string, unknown> | undefined;
+    element.addEventListener('connected', (event) => {
+      events.push('connected');
+      connectedDetail = (event as CustomEvent<Record<string, unknown>>).detail;
+    });
+    element.addEventListener('close', () => events.push('close'));
+
+    await element.open();
+    element
+      .getOverlayRoot()
+      ?.querySelector<HTMLButtonElement>('[data-wallet-id="ledger"]')
+      ?.click();
+    await vi.advanceTimersByTimeAsync(TIMINGS.NON_SAFARI_CONNECT_DELAY);
+    await vi.waitFor(() => expect(ledger.getAccounts).toHaveBeenCalledOnce());
+    const derivationPath = "44'/144'/7'/0/3";
+    const input = element
+      .getOverlayRoot()
+      ?.querySelector<HTMLInputElement>('#custom-derivation-path');
+    expect(input).not.toBeNull();
+    input!.value = derivationPath;
+    element
+      .getOverlayRoot()
+      ?.querySelector<HTMLButtonElement>('#custom-path-connect-button')
+      ?.click();
+    await vi.advanceTimersByTimeAsync(TIMINGS.NON_SAFARI_CONNECT_DELAY);
+    await vi.waitFor(() => expect(manager.connected).toBe(true));
+
+    expect(events).toEqual(['connected', 'close']);
+    expect(connectedDetail).toEqual({
+      walletId: 'ledger',
+      derivationPath,
+      connectionAttemptId: expect.any(Number),
+    });
+  });
+
   it('does not emit cancelled when returning from an already-settled error', async () => {
     const adapter = createAdapter(
       'wallet',


### PR DESCRIPTION
Successful UI connections emitted `connecting` and `close` but omitted `connected`: the manager's synchronous success handler closed the modal and invalidated the awaiting UI attempt. Settle the current attempt and emit `connected` exactly once before closing, preserving WalletConnect and Ledger event details.

Resolve `openAndWait()` before invoking public listeners, preserve modals reopened or rebound by those listeners, and refresh the closed connector for connections started directly through the manager. Regression tests exercise the real manager and web component; the missing-event case fails before the fix.

Validation on Node 24.11.0 / pnpm 10.18.3:

- Uncached workspace build, including documentation and examples.
- 864 unit tests and 20 release-tooling tests passed.
- 20 Chromium browser tests passed.
- Formatting/lint and UI, React, and Vue TypeScript checks passed.
